### PR TITLE
feat: full OpenAI API parameter coverage (M3)

### DIFF
--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -235,6 +235,12 @@ def _build_payload(
         payload["logprobs"] = args.logprobs
     if args.ignore_eos:
         payload["ignore_eos"] = True
+    if getattr(args, "stop", None) is not None:
+        payload["stop"] = args.stop
+    if getattr(args, "n", None) is not None:
+        payload["n"] = args.n
+    if getattr(args, "api_seed", None) is not None:
+        payload["seed"] = args.api_seed
 
     return payload
 

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -104,6 +104,25 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
     sampling.add_argument("--best-of", type=int, default=None)
     sampling.add_argument("--use-beam-search", action="store_true")
     sampling.add_argument("--logprobs", type=int, default=None)
+    sampling.add_argument(
+        "--stop",
+        type=str,
+        nargs="*",
+        default=None,
+        help="Stop sequence(s) for generation.",
+    )
+    sampling.add_argument(
+        "--n",
+        type=int,
+        default=None,
+        help="Number of completions to generate per request.",
+    )
+    sampling.add_argument(
+        "--api-seed",
+        type=int,
+        default=None,
+        help="Seed sent in API requests (deterministic generation).",
+    )
 
     # Output
     parser.add_argument(

--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -34,14 +34,41 @@ def set_config(config: ServerConfig) -> None:
     _config = config
 
 
+def _normalize_prompt(prompt: str | list | None) -> str:
+    """Normalize all 4 OpenAI prompt formats to a single string.
+
+    Supported formats:
+      1. string
+      2. array of strings
+      3. array of token integers
+      4. array of mixed strings/token-arrays
+    """
+    if prompt is None:
+        return ""
+    if isinstance(prompt, str):
+        return prompt
+    if isinstance(prompt, list):
+        parts: list[str] = []
+        for item in prompt:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, int):
+                # Token id — represent as placeholder text
+                parts.append(f"<tok:{item}>")
+            elif isinstance(item, list):
+                # Sub-array of token ids
+                parts.append("".join(f"<tok:{t}>" for t in item))
+            else:
+                parts.append(str(item))
+        return " ".join(parts)
+    return str(prompt)
+
+
 def _estimate_prompt_tokens(prompt: str | list | None, messages: list | None) -> int:
     """Rough token count estimation (~4 chars per token)."""
     if prompt is not None:
-        if isinstance(prompt, str):
-            return max(1, len(prompt) // 4)
-        if isinstance(prompt, list):
-            total = sum(len(str(p)) for p in prompt)
-            return max(1, total // 4)
+        text = _normalize_prompt(prompt)
+        return max(1, len(text) // 4)
     if messages is not None:
         total = sum(len(m.get("content", "")) for m in messages)
         return max(1, total // 4)
@@ -67,6 +94,8 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
     max_tokens = body.get("max_tokens", _config.max_tokens_default)
     stream = body.get("stream", False)
     model = body.get("model", _config.model_name)
+    n = body.get("n", 1)
+    seed = body.get("seed", None)
     prompt_tokens = _estimate_prompt_tokens(prompt, None)
 
     if stream:
@@ -80,24 +109,29 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
     await asyncio.sleep(total_ms / 1000.0)
 
     generated_text = " ".join(["token"] * max_tokens)
-    return JSONResponse({
+    choices = [
+        {
+            "index": i,
+            "text": generated_text,
+            "finish_reason": "length",
+        }
+        for i in range(n)
+    ]
+    resp_body: dict = {
         "id": _make_completion_id(),
         "object": "text_completion",
         "created": int(time.time()),
         "model": model,
-        "choices": [
-            {
-                "index": 0,
-                "text": generated_text,
-                "finish_reason": "length",
-            }
-        ],
+        "choices": choices,
         "usage": {
             "prompt_tokens": prompt_tokens,
-            "completion_tokens": max_tokens,
-            "total_tokens": prompt_tokens + max_tokens,
+            "completion_tokens": max_tokens * n,
+            "total_tokens": prompt_tokens + max_tokens * n,
         },
-    })
+    }
+    if seed is not None:
+        resp_body["system_fingerprint"] = f"fp_seed_{seed}"
+    return JSONResponse(resp_body)
 
 
 async def _stream_completions(model: str, prompt_tokens: int, max_tokens: int):
@@ -140,6 +174,8 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
     max_tokens = body.get("max_tokens", _config.max_tokens_default)
     stream = body.get("stream", False)
     model = body.get("model", _config.model_name)
+    n = body.get("n", 1)
+    seed = body.get("seed", None)
     prompt_tokens = _estimate_prompt_tokens(None, messages)
 
     if stream:
@@ -153,24 +189,29 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
     await asyncio.sleep(total_ms / 1000.0)
 
     generated_text = " ".join(["token"] * max_tokens)
-    return JSONResponse({
+    choices = [
+        {
+            "index": i,
+            "message": {"role": "assistant", "content": generated_text},
+            "finish_reason": "length",
+        }
+        for i in range(n)
+    ]
+    resp_body: dict = {
         "id": _make_chat_completion_id(),
         "object": "chat.completion",
         "created": int(time.time()),
         "model": model,
-        "choices": [
-            {
-                "index": 0,
-                "message": {"role": "assistant", "content": generated_text},
-                "finish_reason": "length",
-            }
-        ],
+        "choices": choices,
         "usage": {
             "prompt_tokens": prompt_tokens,
-            "completion_tokens": max_tokens,
-            "total_tokens": prompt_tokens + max_tokens,
+            "completion_tokens": max_tokens * n,
+            "total_tokens": prompt_tokens + max_tokens * n,
         },
-    })
+    }
+    if seed is not None:
+        resp_body["system_fingerprint"] = f"fp_seed_{seed}"
+    return JSONResponse(resp_body)
 
 
 async def _stream_chat_completions(model: str, prompt_tokens: int, max_tokens: int):

--- a/tests/test_m3_params.py
+++ b/tests/test_m3_params.py
@@ -1,0 +1,220 @@
+"""Tests for M3: Full OpenAI API parameter coverage."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from xpyd_bench.dummy.server import ServerConfig, create_app
+
+
+@pytest.fixture()
+def client():
+    app = create_app(ServerConfig(prefill_ms=0, decode_ms=0))
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Prompt format tests (4 formats per OpenAI spec)
+# ---------------------------------------------------------------------------
+
+
+class TestPromptFormats:
+    """Dummy server should accept all 4 prompt input formats."""
+
+    def test_string_prompt(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "Hello world", "max_tokens": 2},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["choices"][0]["text"]
+
+    def test_array_of_strings(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": ["Hello", "world"], "max_tokens": 2},
+        )
+        assert resp.status_code == 200
+
+    def test_array_of_tokens(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": [1234, 5678, 90], "max_tokens": 2},
+        )
+        assert resp.status_code == 200
+
+    def test_array_of_mixed(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": ["Hello", [1234, 5678], "world"], "max_tokens": 2},
+        )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# n parameter (multiple choices)
+# ---------------------------------------------------------------------------
+
+
+class TestNParameter:
+    def test_completions_n_choices(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "test", "max_tokens": 3, "n": 4},
+        )
+        data = resp.json()
+        assert len(data["choices"]) == 4
+        indices = [c["index"] for c in data["choices"]]
+        assert indices == [0, 1, 2, 3]
+        assert data["usage"]["completion_tokens"] == 3 * 4
+
+    def test_chat_n_choices(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 2,
+                "n": 3,
+            },
+        )
+        data = resp.json()
+        assert len(data["choices"]) == 3
+
+    def test_default_n_is_one(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "test", "max_tokens": 1},
+        )
+        assert len(resp.json()["choices"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# seed parameter
+# ---------------------------------------------------------------------------
+
+
+class TestSeedParameter:
+    def test_seed_echoed_completions(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "test", "max_tokens": 1, "seed": 42},
+        )
+        data = resp.json()
+        assert "system_fingerprint" in data
+        assert "42" in data["system_fingerprint"]
+
+    def test_seed_echoed_chat(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 1,
+                "seed": 99,
+            },
+        )
+        data = resp.json()
+        assert "system_fingerprint" in data
+
+    def test_no_seed_no_fingerprint(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "test", "max_tokens": 1},
+        )
+        assert "system_fingerprint" not in resp.json()
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestCLIArgs:
+    def test_stop_args(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--stop", "END", "STOP"])
+        assert args.stop == ["END", "STOP"]
+
+    def test_n_arg(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--n", "5"])
+        assert args.n == 5
+
+    def test_api_seed_arg(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--api-seed", "42"])
+        assert args.api_seed == 42
+
+
+# ---------------------------------------------------------------------------
+# Runner payload building
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadBuild:
+    def test_payload_includes_new_params(self):
+        from argparse import Namespace
+
+        from xpyd_bench.bench.runner import _build_payload
+
+        args = Namespace(
+            model="m",
+            output_len=10,
+            temperature=None,
+            top_p=None,
+            top_k=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            best_of=None,
+            use_beam_search=False,
+            logprobs=None,
+            ignore_eos=False,
+            stop=["END"],
+            n=3,
+            api_seed=42,
+        )
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert payload["stop"] == ["END"]
+        assert payload["n"] == 3
+        assert payload["seed"] == 42
+
+    def test_payload_omits_none_params(self):
+        from argparse import Namespace
+
+        from xpyd_bench.bench.runner import _build_payload
+
+        args = Namespace(
+            model="m",
+            output_len=10,
+            temperature=None,
+            top_p=None,
+            top_k=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            best_of=None,
+            use_beam_search=False,
+            logprobs=None,
+            ignore_eos=False,
+            stop=None,
+            n=None,
+            api_seed=None,
+        )
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert "stop" not in payload
+        assert "n" not in payload
+        assert "seed" not in payload


### PR DESCRIPTION
## Summary
Full OpenAI API parameter coverage for bench CLI and dummy server.

### Changes
- **Prompt formats**: Dummy server now accepts all 4 OpenAI prompt formats (string, array of strings, array of tokens, array of mixed)
- **CLI args**: Added `--stop`, `--n`, `--api-seed` arguments
- **Runner**: Passes stop, n, seed to API request payloads
- **Dummy server**: Returns `n` choices, echoes seed via `system_fingerprint`
- **Tests**: 15 new tests covering all new functionality

Closes #5