### PR TITLE
feat: Rich Dataset Input (M5)

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,28 +1,49 @@
 # Datasets
 
-Place benchmark datasets here.
+Sample dataset files for `xpyd-bench`.
 
-## Supported formats
+## Supported Formats
 
-- **JSON**: Array of objects with `prompt` field
-- **JSONL**: One object per line with `prompt` field
+### JSONL (`.jsonl`)
+One JSON object per line. Required field: `prompt` (or `text`, `input`, `question`).
+Optional: `output_len` / `max_tokens`.
 
-## Schema
+```jsonl
+{"prompt": "What is the capital of France?", "output_len": 32}
+{"prompt": "Explain relativity.", "output_len": 128}
+```
 
-### Completion endpoint
+### JSON (`.json`)
+A JSON array of objects with the same fields as JSONL.
 
 ```json
 [
-  {"prompt": "Once upon a time"},
-  {"prompt": "The quick brown fox"}
+  {"prompt": "Summarize open-source benefits.", "output_len": 100},
+  {"prompt": "Compare Python and Rust.", "output_len": 150}
 ]
 ```
 
-### Chat endpoint
+### CSV (`.csv`)
+Header row with `prompt` column (or `text`, `input`, `question`).
+Optional `output_len` / `max_tokens` column.
 
-```json
-[
-  {"messages": [{"role": "user", "content": "Hello, how are you?"}]},
-  {"messages": [{"role": "user", "content": "Explain quantum computing"}]}
-]
+```csv
+prompt,output_len
+"Describe the water cycle.",128
+"What is quantum computing?",64
 ```
+
+## Synthetic Generation
+
+Use `--dataset-name synthetic` with distribution options:
+
+```bash
+xpyd-bench --dataset-name synthetic \
+  --num-prompts 500 \
+  --input-len 256 \
+  --output-len 128 \
+  --synthetic-input-len-dist uniform \
+  --synthetic-output-len-dist normal
+```
+
+Supported distributions: `fixed`, `uniform`, `normal`, `zipf`.

--- a/datasets/sample.csv
+++ b/datasets/sample.csv
@@ -1,0 +1,4 @@
+prompt,output_len
+"Describe the water cycle in detail.",128
+"What is quantum computing?",64
+"List three benefits of exercise.",48

--- a/datasets/sample.json
+++ b/datasets/sample.json
@@ -1,0 +1,4 @@
+[
+  {"prompt": "Summarize the benefits of open-source software.", "output_len": 100},
+  {"prompt": "What are the main differences between Python and Rust?", "output_len": 150}
+]

--- a/datasets/sample.jsonl
+++ b/datasets/sample.jsonl
@@ -1,0 +1,3 @@
+{"prompt": "What is the capital of France?", "output_len": 32}
+{"prompt": "Explain the theory of relativity in simple terms.", "output_len": 128}
+{"prompt": "Write a haiku about machine learning.", "output_len": 64}

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -303,8 +303,26 @@ async def run_benchmark(args: Namespace, base_url: str) -> dict:
     is_streaming = is_chat  # streaming by default for chat endpoint
     url = f"{base_url}{args.endpoint}"
 
-    # Generate prompts
-    prompts = _generate_random_prompts(args.num_prompts, args.input_len, args.seed)
+    # Generate or load prompts
+    dataset_path = getattr(args, "dataset_path", None)
+    if dataset_path:
+        from xpyd_bench.datasets.loader import load_dataset, validate_and_report
+
+        entries = load_dataset(
+            path=dataset_path,
+            num_prompts=args.num_prompts,
+            input_len=args.input_len,
+            output_len=args.output_len,
+            input_len_dist=getattr(args, "synthetic_input_len_dist", "fixed"),
+            output_len_dist=getattr(args, "synthetic_output_len_dist", "fixed"),
+            seed=args.seed,
+        )
+        validate_and_report(entries, dataset_path)
+        prompts = [e.prompt for e in entries]
+        # Override num_prompts to match actual dataset size
+        args.num_prompts = len(prompts)
+    else:
+        prompts = _generate_random_prompts(args.num_prompts, args.input_len, args.seed)
 
     # Generate inter-arrival intervals
     rate_pattern = getattr(args, "rate_pattern", None)

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -83,16 +83,30 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         "--dataset-name",
         type=str,
         default="random",
-        choices=["random"],
-        help="Dataset name (default: random).",
+        choices=["random", "synthetic"],
+        help="Dataset name (default: random). 'synthetic' enables distribution control.",
     )
     parser.add_argument(
         "--dataset-path",
         type=str,
         default=None,
-        help="Path to dataset file (JSONL/JSON).",
+        help="Path to dataset file (.jsonl, .json, or .csv).",
     )
     parser.add_argument("--seed", type=int, default=0, help="Random seed (default: 0).")
+    parser.add_argument(
+        "--synthetic-input-len-dist",
+        type=str,
+        default="fixed",
+        choices=["fixed", "uniform", "normal", "zipf"],
+        help="Input length distribution for synthetic datasets (default: fixed).",
+    )
+    parser.add_argument(
+        "--synthetic-output-len-dist",
+        type=str,
+        default="fixed",
+        choices=["fixed", "uniform", "normal", "zipf"],
+        help="Output length distribution for synthetic datasets (default: fixed).",
+    )
 
     # Sampling parameters
     sampling = parser.add_argument_group("sampling parameters")

--- a/src/xpyd_bench/datasets/__init__.py
+++ b/src/xpyd_bench/datasets/__init__.py
@@ -1,0 +1,5 @@
+"""Dataset loading and generation for xpyd-bench."""
+
+from xpyd_bench.datasets.loader import DatasetStats, load_dataset, validate_and_report
+
+__all__ = ["DatasetStats", "load_dataset", "validate_and_report"]

--- a/src/xpyd_bench/datasets/loader.py
+++ b/src/xpyd_bench/datasets/loader.py
@@ -1,0 +1,274 @@
+"""Dataset loader: JSONL, JSON, CSV, and synthetic generation."""
+
+from __future__ import annotations
+
+import csv
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class DatasetStats:
+    """Summary statistics for a loaded dataset."""
+
+    count: int
+    avg_prompt_len: float  # estimated tokens (words)
+    min_prompt_len: int
+    max_prompt_len: int
+    avg_output_len: float | None = None
+    min_output_len: int | None = None
+    max_output_len: int | None = None
+
+
+@dataclass
+class DatasetEntry:
+    """A single dataset entry with prompt and optional expected output length."""
+
+    prompt: str
+    output_len: int | None = None
+
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count from text (word-based approximation)."""
+    return len(text.split())
+
+
+def _validate_entries(entries: list[DatasetEntry], source: str) -> None:
+    """Validate dataset entries, raise on problems."""
+    if not entries:
+        raise ValueError(f"Dataset is empty: {source}")
+    for i, entry in enumerate(entries):
+        if not entry.prompt or not entry.prompt.strip():
+            raise ValueError(f"Empty prompt at index {i} in {source}")
+
+
+def compute_stats(entries: list[DatasetEntry]) -> DatasetStats:
+    """Compute summary statistics for dataset entries."""
+    prompt_lens = [_estimate_tokens(e.prompt) for e in entries]
+    output_lens = [e.output_len for e in entries if e.output_len is not None]
+
+    stats = DatasetStats(
+        count=len(entries),
+        avg_prompt_len=sum(prompt_lens) / len(prompt_lens),
+        min_prompt_len=min(prompt_lens),
+        max_prompt_len=max(prompt_lens),
+    )
+    if output_lens:
+        stats.avg_output_len = sum(output_lens) / len(output_lens)
+        stats.min_output_len = min(output_lens)
+        stats.max_output_len = max(output_lens)
+    return stats
+
+
+def _parse_record(record: dict[str, Any], index: int, source: str) -> DatasetEntry:
+    """Parse a single record dict into a DatasetEntry."""
+    prompt = record.get("prompt")
+    if prompt is None:
+        # Try alternate field names
+        prompt = record.get("text") or record.get("input") or record.get("question")
+    if prompt is None:
+        raise ValueError(
+            f"Record at index {index} in {source} has no 'prompt', 'text', "
+            f"'input', or 'question' field"
+        )
+    output_len = record.get("output_len") or record.get("max_tokens")
+    if output_len is not None:
+        output_len = int(output_len)
+    return DatasetEntry(prompt=str(prompt), output_len=output_len)
+
+
+def load_jsonl(path: Path) -> list[DatasetEntry]:
+    """Load dataset from a JSONL file (one JSON object per line)."""
+    entries: list[DatasetEntry] = []
+    with open(path) as f:
+        for i, line in enumerate(f):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON at line {i + 1} in {path}: {exc}") from exc
+            entries.append(_parse_record(record, i, str(path)))
+    return entries
+
+
+def load_json(path: Path) -> list[DatasetEntry]:
+    """Load dataset from a JSON file (array of objects)."""
+    with open(path) as f:
+        try:
+            data = json.load(f)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, list):
+        raise ValueError(f"Expected JSON array in {path}, got {type(data).__name__}")
+    return [_parse_record(record, i, str(path)) for i, record in enumerate(data)]
+
+
+def load_csv(path: Path) -> list[DatasetEntry]:
+    """Load dataset from a CSV file with 'prompt' column."""
+    entries: list[DatasetEntry] = []
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None:
+            raise ValueError(f"CSV file {path} has no header row")
+        # Find prompt column (case-insensitive)
+        prompt_col = None
+        for col in reader.fieldnames:
+            if col.lower() in ("prompt", "text", "input", "question"):
+                prompt_col = col
+                break
+        if prompt_col is None:
+            raise ValueError(
+                f"CSV file {path} has no 'prompt', 'text', 'input', or 'question' column. "
+                f"Found columns: {reader.fieldnames}"
+            )
+        output_col = None
+        for col in reader.fieldnames:
+            if col.lower() in ("output_len", "max_tokens"):
+                output_col = col
+                break
+        for i, row in enumerate(reader):
+            prompt = row[prompt_col]
+            if not prompt or not prompt.strip():
+                raise ValueError(f"Empty prompt at row {i + 1} in {path}")
+            output_len = None
+            if output_col and row.get(output_col):
+                output_len = int(row[output_col])
+            entries.append(DatasetEntry(prompt=prompt, output_len=output_len))
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Synthetic generation
+# ---------------------------------------------------------------------------
+
+_VOCAB = [
+    "the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog",
+    "a", "an", "is", "was", "hello", "world", "benchmark", "test",
+    "data", "model", "request", "response", "token", "stream",
+    "latency", "throughput", "server", "client", "batch", "queue",
+    "memory", "compute", "inference", "training", "weight", "layer",
+    "attention", "transformer", "embedding", "gradient", "optimizer", "loss",
+]
+
+
+def generate_synthetic(
+    num: int,
+    input_len: int = 256,
+    output_len: int = 128,
+    input_len_dist: str = "fixed",
+    output_len_dist: str = "fixed",
+    seed: int = 0,
+) -> list[DatasetEntry]:
+    """Generate synthetic dataset with configurable length distributions.
+
+    Supported distributions: fixed, uniform, normal, zipf.
+    For uniform/normal/zipf, the given length is used as the mean/center.
+    """
+    rng = random.Random(seed)
+    entries: list[DatasetEntry] = []
+
+    input_lens = _sample_lengths(num, input_len, input_len_dist, seed)
+    output_lens = _sample_lengths(num, output_len, output_len_dist, seed + 1)
+
+    for i in range(num):
+        prompt_words = [rng.choice(_VOCAB) for _ in range(input_lens[i])]
+        entries.append(DatasetEntry(prompt=" ".join(prompt_words), output_len=output_lens[i]))
+
+    return entries
+
+
+def _sample_lengths(num: int, center: int, dist: str, seed: int) -> list[int]:
+    """Sample lengths from a distribution centered around *center*."""
+    rng = random.Random(seed)
+
+    if dist == "fixed":
+        return [center] * num
+
+    if dist == "uniform":
+        lo = max(1, center // 2)
+        hi = center * 2
+        return [rng.randint(lo, hi) for _ in range(num)]
+
+    if dist == "normal":
+        std = max(1, center // 4)
+        return [max(1, int(rng.gauss(center, std))) for _ in range(num)]
+
+    if dist == "zipf":
+        # Approximate Zipf-like: sample from a power-law around center
+        results = []
+        for _ in range(num):
+            # Zipf(a=1.5) mapped to center
+            x = rng.paretovariate(1.5)
+            length = max(1, int(center / x))
+            results.append(length)
+        return results
+
+    raise ValueError(f"Unknown distribution: {dist!r}. Use: fixed, uniform, normal, zipf.")
+
+
+# ---------------------------------------------------------------------------
+# Main API
+# ---------------------------------------------------------------------------
+
+
+def load_dataset(
+    path: str | None = None,
+    name: str = "random",
+    num_prompts: int = 1000,
+    input_len: int = 256,
+    output_len: int = 128,
+    input_len_dist: str = "fixed",
+    output_len_dist: str = "fixed",
+    seed: int = 0,
+) -> list[DatasetEntry]:
+    """Load or generate a dataset.
+
+    If *path* is given, detect format by extension (.jsonl, .json, .csv).
+    Otherwise generate a synthetic dataset named *name*.
+    """
+    if path:
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"Dataset file not found: {path}")
+        ext = p.suffix.lower()
+        if ext == ".jsonl":
+            entries = load_jsonl(p)
+        elif ext == ".json":
+            entries = load_json(p)
+        elif ext == ".csv":
+            entries = load_csv(p)
+        else:
+            raise ValueError(f"Unsupported dataset format: {ext}. Use .jsonl, .json, or .csv.")
+        _validate_entries(entries, str(p))
+        return entries
+
+    # Synthetic
+    return generate_synthetic(
+        num=num_prompts,
+        input_len=input_len,
+        output_len=output_len,
+        input_len_dist=input_len_dist,
+        output_len_dist=output_len_dist,
+        seed=seed,
+    )
+
+
+def validate_and_report(entries: list[DatasetEntry], source: str = "dataset") -> DatasetStats:
+    """Validate entries and print summary stats. Returns stats."""
+    _validate_entries(entries, source)
+    stats = compute_stats(entries)
+    print(f"Dataset: {source}")
+    print(f"  Entries:          {stats.count}")
+    print(f"  Avg prompt len:   {stats.avg_prompt_len:.1f} tokens (est.)")
+    print(f"  Min prompt len:   {stats.min_prompt_len}")
+    print(f"  Max prompt len:   {stats.max_prompt_len}")
+    if stats.avg_output_len is not None:
+        print(f"  Avg output len:   {stats.avg_output_len:.1f}")
+        print(f"  Min output len:   {stats.min_output_len}")
+        print(f"  Max output len:   {stats.max_output_len}")
+    return stats

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,238 @@
+"""Tests for dataset loading and generation (M5)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_bench.datasets.loader import (
+    DatasetEntry,
+    compute_stats,
+    generate_synthetic,
+    load_csv,
+    load_dataset,
+    load_json,
+    load_jsonl,
+    validate_and_report,
+)
+
+# ---------------------------------------------------------------------------
+# JSONL
+# ---------------------------------------------------------------------------
+
+
+class TestLoadJsonl:
+    def test_basic(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.jsonl"
+        p.write_text(
+            '{"prompt": "hello world"}\n'
+            '{"prompt": "foo bar", "output_len": 64}\n'
+        )
+        entries = load_jsonl(p)
+        assert len(entries) == 2
+        assert entries[0].prompt == "hello world"
+        assert entries[0].output_len is None
+        assert entries[1].output_len == 64
+
+    def test_alternate_fields(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.jsonl"
+        p.write_text('{"text": "alt field"}\n')
+        entries = load_jsonl(p)
+        assert entries[0].prompt == "alt field"
+
+    def test_invalid_json(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.jsonl"
+        p.write_text("not json\n")
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            load_jsonl(p)
+
+    def test_missing_prompt(self, tmp_path: Path) -> None:
+        p = tmp_path / "noprompt.jsonl"
+        p.write_text('{"other": "value"}\n')
+        with pytest.raises(ValueError, match="no 'prompt'"):
+            load_jsonl(p)
+
+    def test_blank_lines_skipped(self, tmp_path: Path) -> None:
+        p = tmp_path / "blanks.jsonl"
+        p.write_text('{"prompt": "a"}\n\n{"prompt": "b"}\n')
+        assert len(load_jsonl(p)) == 2
+
+
+# ---------------------------------------------------------------------------
+# JSON array
+# ---------------------------------------------------------------------------
+
+
+class TestLoadJson:
+    def test_basic(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.json"
+        p.write_text(json.dumps([{"prompt": "p1"}, {"prompt": "p2"}]))
+        entries = load_json(p)
+        assert len(entries) == 2
+
+    def test_not_array(self, tmp_path: Path) -> None:
+        p = tmp_path / "obj.json"
+        p.write_text('{"prompt": "single"}')
+        with pytest.raises(ValueError, match="Expected JSON array"):
+            load_json(p)
+
+    def test_invalid_json(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.json"
+        p.write_text("{broken")
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            load_json(p)
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCsv:
+    def test_basic(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.csv"
+        p.write_text("prompt,output_len\nhello world,64\nfoo bar,128\n")
+        entries = load_csv(p)
+        assert len(entries) == 2
+        assert entries[0].prompt == "hello world"
+        assert entries[0].output_len == 64
+
+    def test_alternate_column(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.csv"
+        p.write_text("text\nsome prompt\n")
+        entries = load_csv(p)
+        assert entries[0].prompt == "some prompt"
+
+    def test_no_prompt_column(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.csv"
+        p.write_text("id,value\n1,abc\n")
+        with pytest.raises(ValueError, match="no 'prompt'"):
+            load_csv(p)
+
+    def test_empty_prompt_row(self, tmp_path: Path) -> None:
+        p = tmp_path / "empty.csv"
+        # A row with an explicitly empty prompt value
+        p.write_text('prompt\nhello\n""\n')
+        with pytest.raises(ValueError, match="Empty prompt"):
+            load_csv(p)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic generation
+# ---------------------------------------------------------------------------
+
+
+class TestSynthetic:
+    def test_fixed(self) -> None:
+        entries = generate_synthetic(10, input_len=50, output_len=25, seed=42)
+        assert len(entries) == 10
+        for e in entries:
+            assert len(e.prompt.split()) == 50
+            assert e.output_len == 25
+
+    def test_uniform(self) -> None:
+        entries = generate_synthetic(
+            100, input_len=100, input_len_dist="uniform", seed=42
+        )
+        lens = [len(e.prompt.split()) for e in entries]
+        assert min(lens) >= 1
+        # Should have variety
+        assert max(lens) > min(lens)
+
+    def test_normal(self) -> None:
+        entries = generate_synthetic(
+            100, input_len=100, input_len_dist="normal", seed=42
+        )
+        lens = [len(e.prompt.split()) for e in entries]
+        assert max(lens) > min(lens)
+
+    def test_zipf(self) -> None:
+        entries = generate_synthetic(
+            100, input_len=100, input_len_dist="zipf", seed=42
+        )
+        lens = [len(e.prompt.split()) for e in entries]
+        assert max(lens) > min(lens)
+
+    def test_unknown_dist(self) -> None:
+        with pytest.raises(ValueError, match="Unknown distribution"):
+            generate_synthetic(10, input_len_dist="bogus")
+
+    def test_output_dist(self) -> None:
+        entries = generate_synthetic(
+            50, output_len=100, output_len_dist="uniform", seed=7
+        )
+        out_lens = [e.output_len for e in entries]
+        assert max(out_lens) > min(out_lens)
+
+
+# ---------------------------------------------------------------------------
+# load_dataset (unified API)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDataset:
+    def test_from_jsonl(self, tmp_path: Path) -> None:
+        p = tmp_path / "d.jsonl"
+        p.write_text('{"prompt": "x"}\n')
+        entries = load_dataset(path=str(p))
+        assert len(entries) == 1
+
+    def test_from_json(self, tmp_path: Path) -> None:
+        p = tmp_path / "d.json"
+        p.write_text(json.dumps([{"prompt": "x"}]))
+        entries = load_dataset(path=str(p))
+        assert len(entries) == 1
+
+    def test_from_csv(self, tmp_path: Path) -> None:
+        p = tmp_path / "d.csv"
+        p.write_text("prompt\nx\n")
+        entries = load_dataset(path=str(p))
+        assert len(entries) == 1
+
+    def test_unsupported_ext(self, tmp_path: Path) -> None:
+        p = tmp_path / "d.xml"
+        p.write_text("<data/>")
+        with pytest.raises(ValueError, match="Unsupported"):
+            load_dataset(path=str(p))
+
+    def test_file_not_found(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_dataset(path="/nonexistent/file.jsonl")
+
+    def test_synthetic_default(self) -> None:
+        entries = load_dataset(num_prompts=5, input_len=10, seed=1)
+        assert len(entries) == 5
+
+    def test_empty_dataset(self, tmp_path: Path) -> None:
+        p = tmp_path / "empty.jsonl"
+        p.write_text("")
+        with pytest.raises(ValueError, match="empty"):
+            load_dataset(path=str(p))
+
+
+# ---------------------------------------------------------------------------
+# Stats & validation
+# ---------------------------------------------------------------------------
+
+
+class TestStatsAndValidation:
+    def test_compute_stats(self) -> None:
+        entries = [
+            DatasetEntry(prompt="one two three", output_len=10),
+            DatasetEntry(prompt="a b c d e", output_len=20),
+        ]
+        stats = compute_stats(entries)
+        assert stats.count == 2
+        assert stats.min_prompt_len == 3
+        assert stats.max_prompt_len == 5
+        assert stats.avg_output_len == 15.0
+
+    def test_validate_and_report(self, capsys) -> None:
+        entries = [DatasetEntry(prompt="hello world")]
+        stats = validate_and_report(entries, "test")
+        assert stats.count == 1
+        captured = capsys.readouterr()
+        assert "Dataset: test" in captured.out
+        assert "Entries:" in captured.out


### PR DESCRIPTION
## Summary
Implement M5: Rich Dataset Input — JSONL, JSON, CSV loading and synthetic generation with configurable distributions.

## Changes
- New `src/xpyd_bench/datasets/` module with loader functions
- Supported formats: `.jsonl`, `.json`, `.csv` (auto-detected by extension)
- Flexible field names: `prompt`, `text`, `input`, `question`
- Synthetic generation with 4 distributions: `fixed`, `uniform`, `normal`, `zipf`
- Dataset validation (rejects empty/malformed) and stats reporting
- New CLI args: `--synthetic-input-len-dist`, `--synthetic-output-len-dist`
- Sample dataset files in `datasets/`
- 28 new tests (87 total, all passing)
- Lint clean (ruff + isort)

Closes #9