### PR TITLE
feat: add built-in benchmark scenario presets (M7)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,3 +44,10 @@
 - Time-series metrics (throughput over time)
 - Rich terminal output (progress bars, live stats)
 - JSON and human-readable report formats
+
+## M7: Built-in Benchmark Scenarios 🔄
+- Predefined scenario presets: short, long_context, mixed, stress
+- ScenarioConfig dataclass with CLI-compatible overrides
+- `--scenario` CLI flag to select presets
+- `--list-scenarios` flag to list available presets
+- Tests covering all presets and CLI integration

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -171,6 +171,19 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Path to YAML config file for extended options.",
     )
 
+    # Scenarios (M7)
+    parser.add_argument(
+        "--scenario",
+        type=str,
+        default=None,
+        help="Use a built-in scenario preset (short, long_context, mixed, stress).",
+    )
+    parser.add_argument(
+        "--list-scenarios",
+        action="store_true",
+        help="List available built-in scenarios and exit.",
+    )
+
     # Reporting (M6)
     reporting = parser.add_argument_group("reporting")
     reporting.add_argument(
@@ -234,6 +247,32 @@ def bench_main(argv: list[str] | None = None) -> None:
     )
     _add_vllm_compat_args(parser)
     args = parser.parse_args(argv)
+
+    # List scenarios and exit
+    if args.list_scenarios:
+        from xpyd_bench.scenarios import list_scenarios
+
+        scenarios = list_scenarios()
+        print("Available scenarios:\n")
+        for s in scenarios:
+            print(f"  {s.name:15s} {s.description}")
+            overrides = s.to_overrides()
+            for k, v in overrides.items():
+                print(f"    {k}: {v}")
+            print()
+        return
+
+    # Apply scenario defaults (CLI flags take precedence)
+    if args.scenario:
+        from xpyd_bench.scenarios import get_scenario
+
+        scenario = get_scenario(args.scenario)
+        overrides = scenario.to_overrides()
+        for key, value in overrides.items():
+            # Only apply if the user did not explicitly set the flag
+            current = getattr(args, key, None)
+            if current is None or current == parser.get_default(key):
+                setattr(args, key, value)
 
     # Merge YAML config if provided
     if args.config:

--- a/src/xpyd_bench/scenarios/__init__.py
+++ b/src/xpyd_bench/scenarios/__init__.py
@@ -2,8 +2,24 @@
 
 from __future__ import annotations
 
-# TODO: implement predefined scenarios
-# - short: short prompts, short outputs (chat-like)
-# - long_context: long prompts, moderate outputs (RAG-like)
-# - mixed: realistic mix of short and long
-# - stress: high concurrency burst test
+from xpyd_bench.scenarios.presets import (
+    LONG_CONTEXT,
+    MIXED,
+    SCENARIOS,
+    SHORT,
+    STRESS,
+    ScenarioConfig,
+    get_scenario,
+    list_scenarios,
+)
+
+__all__ = [
+    "LONG_CONTEXT",
+    "MIXED",
+    "SCENARIOS",
+    "SHORT",
+    "STRESS",
+    "ScenarioConfig",
+    "get_scenario",
+    "list_scenarios",
+]

--- a/src/xpyd_bench/scenarios/presets.py
+++ b/src/xpyd_bench/scenarios/presets.py
@@ -1,0 +1,115 @@
+"""Built-in benchmark scenario presets.
+
+Each preset defines a set of CLI-compatible defaults for common workload
+patterns.  Users select a preset via ``--scenario <name>`` and can still
+override individual flags on the command line.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass
+class ScenarioConfig:
+    """A named benchmark scenario preset."""
+
+    name: str
+    description: str
+
+    # Workload
+    num_prompts: int = 1000
+    input_len: int = 256
+    output_len: int = 128
+    request_rate: float = float("inf")
+    max_concurrency: int | None = None
+    burstiness: float = 1.0
+
+    # Dataset
+    dataset_name: str = "random"
+    synthetic_input_len_dist: str = "fixed"
+    synthetic_output_len_dist: str = "fixed"
+
+    # Sampling
+    temperature: float | None = None
+
+    # Rate pattern (YAML-style dict, None = use request_rate)
+    rate_pattern: dict[str, Any] | None = None
+
+    def to_overrides(self) -> dict[str, Any]:
+        """Return a dict of non-None fields suitable for applying to args."""
+        d = asdict(self)
+        d.pop("name")
+        d.pop("description")
+        return {k: v for k, v in d.items() if v is not None}
+
+
+# ---------------------------------------------------------------------------
+# Built-in presets
+# ---------------------------------------------------------------------------
+
+SHORT = ScenarioConfig(
+    name="short",
+    description="Short prompts, short outputs — simulates interactive chat workload",
+    num_prompts=2000,
+    input_len=32,
+    output_len=64,
+    request_rate=50.0,
+    max_concurrency=64,
+    temperature=0.8,
+)
+
+LONG_CONTEXT = ScenarioConfig(
+    name="long_context",
+    description="Long prompts, moderate outputs — simulates RAG / document QA workload",
+    num_prompts=200,
+    input_len=2048,
+    output_len=256,
+    request_rate=5.0,
+    max_concurrency=16,
+    temperature=0.0,
+)
+
+MIXED = ScenarioConfig(
+    name="mixed",
+    description="Realistic mix of short and long prompts with varied output lengths",
+    num_prompts=1000,
+    input_len=256,
+    output_len=128,
+    request_rate=20.0,
+    max_concurrency=32,
+    dataset_name="synthetic",
+    synthetic_input_len_dist="zipf",
+    synthetic_output_len_dist="uniform",
+)
+
+STRESS = ScenarioConfig(
+    name="stress",
+    description="High-concurrency burst test — designed to stress-test the server",
+    num_prompts=5000,
+    input_len=64,
+    output_len=32,
+    request_rate=float("inf"),
+    max_concurrency=256,
+    burstiness=1.0,
+    temperature=0.0,
+)
+
+# Registry
+SCENARIOS: dict[str, ScenarioConfig] = {
+    s.name: s for s in [SHORT, LONG_CONTEXT, MIXED, STRESS]
+}
+
+
+def get_scenario(name: str) -> ScenarioConfig:
+    """Look up a scenario by name. Raises ``KeyError`` if not found."""
+    if name not in SCENARIOS:
+        available = ", ".join(sorted(SCENARIOS.keys()))
+        raise KeyError(f"Unknown scenario '{name}'. Available: {available}")
+    return SCENARIOS[name]
+
+
+def list_scenarios() -> list[ScenarioConfig]:
+    """Return all built-in scenarios."""
+    return list(SCENARIOS.values())

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,0 +1,116 @@
+"""Tests for M7: Built-in benchmark scenarios."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_bench.scenarios import (
+    LONG_CONTEXT,
+    MIXED,
+    SCENARIOS,
+    SHORT,
+    STRESS,
+    ScenarioConfig,
+    get_scenario,
+    list_scenarios,
+)
+
+
+class TestScenarioConfig:
+    """ScenarioConfig dataclass and registry."""
+
+    def test_four_presets_exist(self) -> None:
+        assert len(SCENARIOS) == 4
+        assert set(SCENARIOS.keys()) == {"short", "long_context", "mixed", "stress"}
+
+    def test_get_scenario_valid(self) -> None:
+        for name in ("short", "long_context", "mixed", "stress"):
+            s = get_scenario(name)
+            assert isinstance(s, ScenarioConfig)
+            assert s.name == name
+
+    def test_get_scenario_unknown_raises(self) -> None:
+        with pytest.raises(KeyError, match="Unknown scenario"):
+            get_scenario("nonexistent")
+
+    def test_list_scenarios(self) -> None:
+        scenarios = list_scenarios()
+        assert len(scenarios) == 4
+        assert all(isinstance(s, ScenarioConfig) for s in scenarios)
+
+    def test_to_overrides_excludes_name_and_description(self) -> None:
+        overrides = SHORT.to_overrides()
+        assert "name" not in overrides
+        assert "description" not in overrides
+
+    def test_to_overrides_excludes_none(self) -> None:
+        for s in SCENARIOS.values():
+            overrides = s.to_overrides()
+            for v in overrides.values():
+                assert v is not None
+
+
+class TestShortPreset:
+    """Validate the 'short' scenario."""
+
+    def test_short_prompts(self) -> None:
+        assert SHORT.input_len == 32
+
+    def test_short_outputs(self) -> None:
+        assert SHORT.output_len == 64
+
+    def test_high_concurrency(self) -> None:
+        assert SHORT.max_concurrency is not None
+        assert SHORT.max_concurrency >= 32
+
+
+class TestLongContextPreset:
+    """Validate the 'long_context' scenario."""
+
+    def test_long_input(self) -> None:
+        assert LONG_CONTEXT.input_len >= 1024
+
+    def test_moderate_output(self) -> None:
+        assert LONG_CONTEXT.output_len >= 128
+
+    def test_low_rate(self) -> None:
+        assert LONG_CONTEXT.request_rate <= 20.0
+
+
+class TestMixedPreset:
+    """Validate the 'mixed' scenario."""
+
+    def test_uses_synthetic(self) -> None:
+        assert MIXED.dataset_name == "synthetic"
+
+    def test_varied_distributions(self) -> None:
+        assert MIXED.synthetic_input_len_dist != "fixed"
+        assert MIXED.synthetic_output_len_dist != "fixed"
+
+
+class TestStressPreset:
+    """Validate the 'stress' scenario."""
+
+    def test_high_num_prompts(self) -> None:
+        assert STRESS.num_prompts >= 1000
+
+    def test_inf_rate(self) -> None:
+        assert STRESS.request_rate == float("inf")
+
+    def test_high_concurrency(self) -> None:
+        assert STRESS.max_concurrency is not None
+        assert STRESS.max_concurrency >= 128
+
+
+class TestCLIScenarioFlag:
+    """Test --scenario and --list-scenarios CLI integration."""
+
+    def test_list_scenarios_exits_cleanly(self, capsys: pytest.CaptureFixture) -> None:
+        from xpyd_bench.cli import bench_main
+
+        bench_main(["--list-scenarios"])
+        captured = capsys.readouterr()
+        assert "short" in captured.out
+        assert "long_context" in captured.out
+        assert "mixed" in captured.out
+        assert "stress" in captured.out


### PR DESCRIPTION
## Summary

Implement built-in benchmark scenario presets in the `scenarios/` module, replacing the previous TODO stub.

### Changes
- **`src/xpyd_bench/scenarios/presets.py`**: `ScenarioConfig` dataclass and 4 presets:
  - `short` — chat-like: 32-token prompts, 64-token outputs, 50 req/s
  - `long_context` — RAG-like: 2048-token prompts, 256-token outputs, 5 req/s
  - `mixed` — realistic: zipf input dist, uniform output dist, 20 req/s
  - `stress` — burst: 5000 prompts, inf rate, 256 concurrency
- **`src/xpyd_bench/scenarios/__init__.py`**: proper re-exports
- **`src/xpyd_bench/cli.py`**: `--scenario` and `--list-scenarios` CLI flags
- **`tests/test_scenarios.py`**: 18 tests covering all presets and CLI integration

### Verification
- `ruff check src tests` ✅
- `isort --check src tests` ✅
- 115 tests pass (18 new + 97 existing) ✅

Closes #13