### PR TITLE
feat: add benchmark comparison and regression detection (M8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
 
 [project.scripts]
 xpyd-bench = "xpyd_bench.cli:bench_main"
+xpyd-bench-compare = "xpyd_bench.cli:compare_main"
 xpyd-dummy = "xpyd_bench.dummy.cli:dummy_main"
 
 # Reserved for future xpyd CLI subcommand discovery

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -325,6 +325,52 @@ def bench_main(argv: list[str] | None = None) -> None:
         _save_result(args, result)
 
 
+def compare_main(argv: list[str] | None = None) -> None:
+    """Entry point for ``xpyd-bench-compare`` command."""
+    from xpyd_bench.compare import (
+        compare,
+        format_comparison_table,
+        load_result,
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench-compare",
+        description="Compare two benchmark results and detect regressions",
+    )
+    parser.add_argument("baseline", help="Path to baseline result JSON file")
+    parser.add_argument("candidate", help="Path to candidate result JSON file")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=5.0,
+        help="Regression threshold percentage (default: 5.0)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Export JSON diff to a file",
+    )
+    args = parser.parse_args(argv)
+
+    baseline = load_result(args.baseline)
+    candidate = load_result(args.candidate)
+    result = compare(baseline, candidate, threshold_pct=args.threshold)
+
+    print(format_comparison_table(result))
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w") as f:
+            json.dump(result.to_dict(), f, indent=2)
+        print(f"\nJSON diff saved to {out_path}")
+
+    if result.has_regression:
+        raise SystemExit(1)
+
+
 def _save_result(args: argparse.Namespace, result: dict) -> None:
     """Save benchmark result to JSON."""
     from datetime import datetime

--- a/src/xpyd_bench/compare.py
+++ b/src/xpyd_bench/compare.py
@@ -1,0 +1,216 @@
+"""Benchmark comparison and regression detection.
+
+Compares two JSON result files (baseline vs candidate) and reports metric
+deltas with configurable regression thresholds.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# Metrics where lower is better (latencies)
+_LOWER_IS_BETTER = {
+    "mean_ttft_ms",
+    "p50_ttft_ms",
+    "p90_ttft_ms",
+    "p95_ttft_ms",
+    "p99_ttft_ms",
+    "mean_tpot_ms",
+    "p50_tpot_ms",
+    "p90_tpot_ms",
+    "p95_tpot_ms",
+    "p99_tpot_ms",
+    "mean_itl_ms",
+    "p50_itl_ms",
+    "p90_itl_ms",
+    "p95_itl_ms",
+    "p99_itl_ms",
+    "mean_e2el_ms",
+    "p50_e2el_ms",
+    "p90_e2el_ms",
+    "p95_e2el_ms",
+    "p99_e2el_ms",
+}
+
+# Metrics where higher is better (throughput)
+_HIGHER_IS_BETTER = {
+    "request_throughput",
+    "output_throughput",
+    "total_token_throughput",
+}
+
+# All compared metrics
+COMPARED_METRICS = sorted(_LOWER_IS_BETTER | _HIGHER_IS_BETTER)
+
+
+@dataclass
+class MetricDelta:
+    """Comparison result for a single metric."""
+
+    name: str
+    baseline: float
+    candidate: float
+    delta: float  # candidate - baseline
+    pct_change: float  # percentage change
+    direction: str  # "improved", "regressed", "unchanged"
+    regressed: bool  # True if regression exceeds threshold
+
+
+@dataclass
+class ComparisonResult:
+    """Full comparison result."""
+
+    metrics: list[MetricDelta]
+    has_regression: bool
+    threshold_pct: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-friendly dict."""
+        return {
+            "threshold_pct": self.threshold_pct,
+            "has_regression": self.has_regression,
+            "metrics": [
+                {
+                    "name": m.name,
+                    "baseline": m.baseline,
+                    "candidate": m.candidate,
+                    "delta": m.delta,
+                    "pct_change": m.pct_change,
+                    "direction": m.direction,
+                    "regressed": m.regressed,
+                }
+                for m in self.metrics
+            ],
+        }
+
+
+def _extract_metrics(data: dict[str, Any]) -> dict[str, float]:
+    """Extract comparable metrics from a result dict.
+
+    Supports both flat dicts and dicts with a ``summary`` key.
+    """
+    src = data.get("summary", data)
+    result: dict[str, float] = {}
+    for key in COMPARED_METRICS:
+        val = src.get(key)
+        if val is not None:
+            try:
+                result[key] = float(val)
+            except (TypeError, ValueError):
+                pass
+    return result
+
+
+def load_result(path: str | Path) -> dict[str, Any]:
+    """Load a JSON benchmark result file."""
+    with open(path) as f:
+        return json.load(f)
+
+
+def compare(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    threshold_pct: float = 5.0,
+) -> ComparisonResult:
+    """Compare two benchmark results and detect regressions.
+
+    Args:
+        baseline: Parsed JSON result (baseline run).
+        candidate: Parsed JSON result (candidate run).
+        threshold_pct: Percentage threshold for regression detection.
+
+    Returns:
+        ComparisonResult with per-metric deltas and overall regression flag.
+    """
+    base_m = _extract_metrics(baseline)
+    cand_m = _extract_metrics(candidate)
+
+    # Compare only metrics present in both
+    common_keys = sorted(set(base_m) & set(cand_m))
+
+    deltas: list[MetricDelta] = []
+    has_regression = False
+
+    for key in common_keys:
+        bval = base_m[key]
+        cval = cand_m[key]
+        delta = cval - bval
+
+        if bval == 0:
+            pct = 0.0 if cval == 0 else float("inf")
+        else:
+            pct = (delta / abs(bval)) * 100.0
+
+        # Determine direction
+        lower_better = key in _LOWER_IS_BETTER
+        if abs(pct) < 0.01:
+            direction = "unchanged"
+            regressed = False
+        elif lower_better:
+            # Lower is better: positive delta = regression
+            direction = "regressed" if delta > 0 else "improved"
+            regressed = delta > 0 and pct > threshold_pct
+        else:
+            # Higher is better: negative delta = regression
+            direction = "regressed" if delta < 0 else "improved"
+            regressed = delta < 0 and abs(pct) > threshold_pct
+
+        if regressed:
+            has_regression = True
+
+        deltas.append(
+            MetricDelta(
+                name=key,
+                baseline=bval,
+                candidate=cval,
+                delta=round(delta, 4),
+                pct_change=round(pct, 2),
+                direction=direction,
+                regressed=regressed,
+            )
+        )
+
+    return ComparisonResult(
+        metrics=deltas,
+        has_regression=has_regression,
+        threshold_pct=threshold_pct,
+    )
+
+
+def format_comparison_table(result: ComparisonResult) -> str:
+    """Format comparison as a human-readable table."""
+    lines: list[str] = []
+    lines.append("=" * 90)
+    lines.append("  xPyD-bench — Benchmark Comparison")
+    lines.append(f"  Regression threshold: {result.threshold_pct}%")
+    lines.append("=" * 90)
+    lines.append("")
+
+    header = (
+        f"  {'Metric':<28s} {'Baseline':>10s} {'Candidate':>10s} "
+        f"{'Delta':>10s} {'Change':>8s} {'Status':>10s}"
+    )
+    lines.append(header)
+    lines.append("  " + "-" * 86)
+
+    for m in result.metrics:
+        indicator = "↓ REGRESS" if m.regressed else m.direction
+        sign = "+" if m.pct_change > 0 else ""
+        lines.append(
+            f"  {m.name:<28s} {m.baseline:>10.2f} {m.candidate:>10.2f} "
+            f"{m.delta:>+10.2f} {sign}{m.pct_change:>6.1f}% {indicator:>10s}"
+        )
+
+    lines.append("  " + "-" * 86)
+    lines.append("")
+
+    if result.has_regression:
+        lines.append("  ⚠️  REGRESSION DETECTED — one or more metrics exceeded threshold")
+    else:
+        lines.append("  ✅  No regressions detected")
+
+    lines.append("=" * 90)
+    return "\n".join(lines)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,304 @@
+"""Tests for benchmark comparison and regression detection (M8)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from xpyd_bench.compare import (
+    compare,
+    format_comparison_table,
+    load_result,
+)
+
+
+def _make_result(**overrides: float) -> dict:
+    """Create a minimal benchmark result dict with default metrics."""
+    base = {
+        "mean_ttft_ms": 50.0,
+        "p50_ttft_ms": 45.0,
+        "p90_ttft_ms": 80.0,
+        "p95_ttft_ms": 95.0,
+        "p99_ttft_ms": 120.0,
+        "mean_tpot_ms": 10.0,
+        "p50_tpot_ms": 9.0,
+        "p90_tpot_ms": 15.0,
+        "p95_tpot_ms": 18.0,
+        "p99_tpot_ms": 25.0,
+        "mean_itl_ms": 8.0,
+        "p50_itl_ms": 7.0,
+        "p90_itl_ms": 12.0,
+        "p95_itl_ms": 14.0,
+        "p99_itl_ms": 20.0,
+        "mean_e2el_ms": 500.0,
+        "p50_e2el_ms": 480.0,
+        "p90_e2el_ms": 700.0,
+        "p95_e2el_ms": 800.0,
+        "p99_e2el_ms": 1000.0,
+        "request_throughput": 100.0,
+        "output_throughput": 5000.0,
+        "total_token_throughput": 8000.0,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCompareIdentical:
+    """Compare identical results — all unchanged, exit 0."""
+
+    def test_all_unchanged(self) -> None:
+        data = _make_result()
+        result = compare(data, data)
+        assert not result.has_regression
+        for m in result.metrics:
+            assert m.direction == "unchanged"
+            assert m.delta == 0.0
+            assert not m.regressed
+
+
+class TestCompareRegression:
+    """Compare with regressions — correct detection."""
+
+    def test_latency_regression(self) -> None:
+        baseline = _make_result()
+        # 20% worse TTFT
+        candidate = _make_result(mean_ttft_ms=60.0)
+        result = compare(baseline, candidate, threshold_pct=5.0)
+        assert result.has_regression
+
+        ttft = next(m for m in result.metrics if m.name == "mean_ttft_ms")
+        assert ttft.direction == "regressed"
+        assert ttft.regressed
+        assert ttft.pct_change == 20.0
+
+    def test_throughput_regression(self) -> None:
+        baseline = _make_result()
+        # 10% worse throughput
+        candidate = _make_result(request_throughput=90.0)
+        result = compare(baseline, candidate, threshold_pct=5.0)
+        assert result.has_regression
+
+        rtp = next(m for m in result.metrics if m.name == "request_throughput")
+        assert rtp.direction == "regressed"
+        assert rtp.regressed
+
+    def test_regression_exit_code(self) -> None:
+        """CLI exits with code 1 on regression."""
+        from xpyd_bench.cli import compare_main
+
+        baseline = _make_result()
+        candidate = _make_result(mean_ttft_ms=100.0)
+
+        with tempfile.TemporaryDirectory() as td:
+            bp = Path(td) / "base.json"
+            cp = Path(td) / "cand.json"
+            bp.write_text(json.dumps(baseline))
+            cp.write_text(json.dumps(candidate))
+
+            with pytest.raises(SystemExit) as exc_info:
+                compare_main([str(bp), str(cp)])
+            assert exc_info.value.code == 1
+
+
+class TestCompareImprovement:
+    """Compare with improvements — correct detection, exit 0."""
+
+    def test_latency_improvement(self) -> None:
+        baseline = _make_result()
+        # 20% better TTFT (lower)
+        candidate = _make_result(mean_ttft_ms=40.0)
+        result = compare(baseline, candidate, threshold_pct=5.0)
+        assert not result.has_regression
+
+        ttft = next(m for m in result.metrics if m.name == "mean_ttft_ms")
+        assert ttft.direction == "improved"
+        assert not ttft.regressed
+
+    def test_throughput_improvement(self) -> None:
+        baseline = _make_result()
+        candidate = _make_result(request_throughput=120.0)
+        result = compare(baseline, candidate, threshold_pct=5.0)
+        assert not result.has_regression
+
+        rtp = next(m for m in result.metrics if m.name == "request_throughput")
+        assert rtp.direction == "improved"
+
+
+class TestCustomThreshold:
+    """Custom threshold works."""
+
+    def test_below_threshold_no_regression(self) -> None:
+        baseline = _make_result()
+        # 3% regression — below 5% threshold
+        candidate = _make_result(mean_ttft_ms=51.5)
+        result = compare(baseline, candidate, threshold_pct=5.0)
+        assert not result.has_regression
+
+    def test_above_threshold_triggers_regression(self) -> None:
+        baseline = _make_result()
+        # 3% regression — above 2% threshold
+        candidate = _make_result(mean_ttft_ms=51.5)
+        result = compare(baseline, candidate, threshold_pct=2.0)
+        assert result.has_regression
+
+    def test_zero_threshold(self) -> None:
+        baseline = _make_result()
+        candidate = _make_result(mean_ttft_ms=50.01)
+        result = compare(baseline, candidate, threshold_pct=0.0)
+        assert result.has_regression
+
+
+class TestJsonDiffExport:
+    """JSON diff export matches expected structure."""
+
+    def test_export_structure(self) -> None:
+        baseline = _make_result()
+        candidate = _make_result(mean_ttft_ms=60.0)
+        result = compare(baseline, candidate)
+        d = result.to_dict()
+
+        assert "threshold_pct" in d
+        assert "has_regression" in d
+        assert "metrics" in d
+        assert isinstance(d["metrics"], list)
+        assert len(d["metrics"]) > 0
+
+        m = d["metrics"][0]
+        assert set(m.keys()) == {
+            "name",
+            "baseline",
+            "candidate",
+            "delta",
+            "pct_change",
+            "direction",
+            "regressed",
+        }
+
+    def test_json_serializable(self) -> None:
+        baseline = _make_result()
+        candidate = _make_result(output_throughput=4000.0)
+        result = compare(baseline, candidate)
+        # Must not raise
+        serialized = json.dumps(result.to_dict())
+        parsed = json.loads(serialized)
+        assert parsed["has_regression"] is True
+
+
+class TestCliIntegration:
+    """CLI integration test with real files."""
+
+    def test_no_regression_exit_0(self) -> None:
+        from xpyd_bench.cli import compare_main
+
+        data = _make_result()
+        with tempfile.TemporaryDirectory() as td:
+            bp = Path(td) / "base.json"
+            cp = Path(td) / "cand.json"
+            bp.write_text(json.dumps(data))
+            cp.write_text(json.dumps(data))
+
+            # Should NOT raise SystemExit
+            compare_main([str(bp), str(cp)])
+
+    def test_json_output_flag(self) -> None:
+        from xpyd_bench.cli import compare_main
+
+        baseline = _make_result()
+        candidate = _make_result(mean_ttft_ms=100.0)
+
+        with tempfile.TemporaryDirectory() as td:
+            bp = Path(td) / "base.json"
+            cp = Path(td) / "cand.json"
+            out = Path(td) / "diff.json"
+            bp.write_text(json.dumps(baseline))
+            cp.write_text(json.dumps(candidate))
+
+            with pytest.raises(SystemExit):
+                compare_main([str(bp), str(cp), "--output", str(out)])
+
+            assert out.exists()
+            diff = json.loads(out.read_text())
+            assert diff["has_regression"] is True
+
+    def test_custom_threshold_flag(self) -> None:
+        from xpyd_bench.cli import compare_main
+
+        baseline = _make_result()
+        # 3% regression
+        candidate = _make_result(mean_ttft_ms=51.5)
+
+        with tempfile.TemporaryDirectory() as td:
+            bp = Path(td) / "base.json"
+            cp = Path(td) / "cand.json"
+            bp.write_text(json.dumps(baseline))
+            cp.write_text(json.dumps(candidate))
+
+            # Default 5% threshold — no regression
+            compare_main([str(bp), str(cp)])
+
+            # 2% threshold — regression detected
+            with pytest.raises(SystemExit) as exc_info:
+                compare_main([str(bp), str(cp), "--threshold", "2.0"])
+            assert exc_info.value.code == 1
+
+
+class TestSummaryWrapper:
+    """Results wrapped in a 'summary' key should still work."""
+
+    def test_summary_key(self) -> None:
+        baseline = {"summary": _make_result()}
+        candidate = {"summary": _make_result(mean_ttft_ms=60.0)}
+        result = compare(baseline, candidate)
+        assert result.has_regression
+
+
+class TestFormatTable:
+    """format_comparison_table produces readable output."""
+
+    def test_table_contains_metrics(self) -> None:
+        baseline = _make_result()
+        candidate = _make_result(mean_ttft_ms=60.0)
+        result = compare(baseline, candidate)
+        table = format_comparison_table(result)
+        assert "mean_ttft_ms" in table
+        assert "REGRESS" in table
+
+    def test_table_no_regression(self) -> None:
+        data = _make_result()
+        result = compare(data, data)
+        table = format_comparison_table(result)
+        assert "No regressions" in table
+
+
+class TestLoadResult:
+    """load_result reads JSON files correctly."""
+
+    def test_load(self) -> None:
+        data = _make_result()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+            loaded = load_result(f.name)
+        assert loaded["mean_ttft_ms"] == 50.0
+
+
+class TestEdgeCases:
+    """Edge cases for comparison logic."""
+
+    def test_zero_baseline(self) -> None:
+        baseline = _make_result(mean_ttft_ms=0.0)
+        candidate = _make_result(mean_ttft_ms=10.0)
+        result = compare(baseline, candidate)
+        ttft = next(m for m in result.metrics if m.name == "mean_ttft_ms")
+        assert ttft.pct_change == float("inf")
+
+    def test_missing_metrics_skipped(self) -> None:
+        baseline = {"mean_ttft_ms": 50.0}
+        candidate = {"mean_ttft_ms": 60.0, "request_throughput": 100.0}
+        result = compare(baseline, candidate)
+        # Only mean_ttft_ms should be compared (common key)
+        assert len(result.metrics) == 1
+        assert result.metrics[0].name == "mean_ttft_ms"


### PR DESCRIPTION
## Summary

Add a `compare` module and `xpyd-bench-compare` CLI for comparing two benchmark result JSON files and detecting performance regressions.

### Changes
- **`src/xpyd_bench/compare.py`**: Core comparison logic
  - Side-by-side comparison of all latency percentiles (TTFT/TPOT/ITL/E2EL) and throughput metrics
  - Percentage delta with direction indicators (improved/regressed/unchanged)
  - Configurable regression threshold (default 5%)
  - Human-readable table formatter
  - JSON diff export
- **`src/xpyd_bench/cli.py`**: `compare_main` entry point
  - `xpyd-bench-compare baseline.json candidate.json`
  - `--threshold` flag for sensitivity control
  - `--output` flag for JSON diff export
  - Exit code 1 on regression (CI-friendly)
- **`pyproject.toml`**: `xpyd-bench-compare` console script entry point
- **`tests/test_compare.py`**: 18 tests covering all acceptance criteria

### Verification
- `ruff check src tests` ✅
- `isort --check src tests` ✅
- 135 tests pass (18 new + 117 existing) ✅

Closes #21