### PR TITLE
feat: add echo, suffix, logit_bias, user parameters to bench client

### DIFF
--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -241,6 +241,19 @@ def _build_payload(
         payload["n"] = args.n
     if getattr(args, "api_seed", None) is not None:
         payload["seed"] = args.api_seed
+    if getattr(args, "echo", False):
+        payload["echo"] = True
+    if getattr(args, "suffix", None) is not None:
+        payload["suffix"] = args.suffix
+    if getattr(args, "logit_bias", None) is not None:
+        import json as _json
+
+        if isinstance(args.logit_bias, str):
+            payload["logit_bias"] = _json.loads(args.logit_bias)
+        else:
+            payload["logit_bias"] = args.logit_bias
+    if getattr(args, "user", None) is not None:
+        payload["user"] = args.user
 
     return payload
 

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -137,6 +137,30 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="Seed sent in API requests (deterministic generation).",
     )
+    sampling.add_argument(
+        "--echo",
+        action="store_true",
+        default=False,
+        help="Echo back the prompt in addition to the completion (completions only).",
+    )
+    sampling.add_argument(
+        "--suffix",
+        type=str,
+        default=None,
+        help="Suffix that comes after a completion of inserted text (completions only).",
+    )
+    sampling.add_argument(
+        "--logit-bias",
+        type=str,
+        default=None,
+        help="JSON string of token ID to bias value mappings, e.g. '{\"50256\": -100}'.",
+    )
+    sampling.add_argument(
+        "--user",
+        type=str,
+        default=None,
+        help="Unique identifier representing the end-user.",
+    )
 
     # Output
     parser.add_argument(

--- a/tests/test_issue15_params.py
+++ b/tests/test_issue15_params.py
@@ -1,0 +1,134 @@
+"""Tests for issue #15: echo, suffix, logit_bias, user parameters."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+from xpyd_bench.bench.runner import _build_payload
+
+
+class TestEchoParam:
+    def test_echo_included_when_true(self):
+        args = Namespace(
+            output_len=10, model="m", temperature=None, top_p=None, top_k=None,
+            frequency_penalty=None, presence_penalty=None, best_of=None,
+            use_beam_search=False, logprobs=None, ignore_eos=False,
+            stop=None, n=None, api_seed=None, echo=True, suffix=None,
+            logit_bias=None, user=None,
+        )
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert payload["echo"] is True
+
+    def test_echo_omitted_when_false(self):
+        args = Namespace(
+            output_len=10, model="m", temperature=None, top_p=None, top_k=None,
+            frequency_penalty=None, presence_penalty=None, best_of=None,
+            use_beam_search=False, logprobs=None, ignore_eos=False,
+            stop=None, n=None, api_seed=None, echo=False, suffix=None,
+            logit_bias=None, user=None,
+        )
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert "echo" not in payload
+
+
+class TestSuffixParam:
+    def test_suffix_included(self):
+        args = Namespace(
+            output_len=10, model="m", temperature=None, top_p=None, top_k=None,
+            frequency_penalty=None, presence_penalty=None, best_of=None,
+            use_beam_search=False, logprobs=None, ignore_eos=False,
+            stop=None, n=None, api_seed=None, echo=False, suffix="END",
+            logit_bias=None, user=None,
+        )
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert payload["suffix"] == "END"
+
+    def test_suffix_omitted_when_none(self):
+        args = Namespace(
+            output_len=10, model="m", temperature=None, top_p=None, top_k=None,
+            frequency_penalty=None, presence_penalty=None, best_of=None,
+            use_beam_search=False, logprobs=None, ignore_eos=False,
+            stop=None, n=None, api_seed=None, echo=False, suffix=None,
+            logit_bias=None, user=None,
+        )
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert "suffix" not in payload
+
+
+class TestLogitBiasParam:
+    def test_logit_bias_from_json_string(self):
+        args = Namespace(
+            output_len=10, model="m", temperature=None, top_p=None, top_k=None,
+            frequency_penalty=None, presence_penalty=None, best_of=None,
+            use_beam_search=False, logprobs=None, ignore_eos=False,
+            stop=None, n=None, api_seed=None, echo=False, suffix=None,
+            logit_bias='{"50256": -100}', user=None,
+        )
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert payload["logit_bias"] == {"50256": -100}
+
+    def test_logit_bias_from_dict(self):
+        args = Namespace(
+            output_len=10, model="m", temperature=None, top_p=None, top_k=None,
+            frequency_penalty=None, presence_penalty=None, best_of=None,
+            use_beam_search=False, logprobs=None, ignore_eos=False,
+            stop=None, n=None, api_seed=None, echo=False, suffix=None,
+            logit_bias={"50256": -100}, user=None,
+        )
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert payload["logit_bias"] == {"50256": -100}
+
+    def test_logit_bias_omitted_when_none(self):
+        args = Namespace(
+            output_len=10, model="m", temperature=None, top_p=None, top_k=None,
+            frequency_penalty=None, presence_penalty=None, best_of=None,
+            use_beam_search=False, logprobs=None, ignore_eos=False,
+            stop=None, n=None, api_seed=None, echo=False, suffix=None,
+            logit_bias=None, user=None,
+        )
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert "logit_bias" not in payload
+
+
+class TestUserParam:
+    def test_user_included(self):
+        args = Namespace(
+            output_len=10, model="m", temperature=None, top_p=None, top_k=None,
+            frequency_penalty=None, presence_penalty=None, best_of=None,
+            use_beam_search=False, logprobs=None, ignore_eos=False,
+            stop=None, n=None, api_seed=None, echo=False, suffix=None,
+            logit_bias=None, user="test-user-123",
+        )
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert payload["user"] == "test-user-123"
+
+    def test_user_omitted_when_none(self):
+        args = Namespace(
+            output_len=10, model="m", temperature=None, top_p=None, top_k=None,
+            frequency_penalty=None, presence_penalty=None, best_of=None,
+            use_beam_search=False, logprobs=None, ignore_eos=False,
+            stop=None, n=None, api_seed=None, echo=False, suffix=None,
+            logit_bias=None, user=None,
+        )
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert "user" not in payload
+
+
+class TestCLIParsing:
+    """Test that CLI args parse correctly."""
+
+    def test_echo_flag(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([
+            "--echo", "--suffix", "END",
+            "--logit-bias", '{"50256": -100}',
+            "--user", "test-user",
+        ])
+        assert args.echo is True
+        assert args.suffix == "END"
+        assert args.logit_bias == '{"50256": -100}'
+        assert args.user == "test-user"


### PR DESCRIPTION
## Summary

Add missing OpenAI API parameters to the bench client, closing the API gap identified in #15.

### Changes

- **CLI**: Added `--echo`, `--suffix`, `--logit-bias` (JSON string), and `--user` arguments
- **Runner**: Updated `_build_payload()` to include these parameters when set
- **Tests**: 10 new tests covering all parameters (inclusion, omission, JSON parsing, CLI parsing)

### Parameters Added

| Parameter | Type | Description |
|-----------|------|-------------|
| `--echo` | flag | Echo back prompt in completion |
| `--suffix` | string | Suffix after completion text |
| `--logit-bias` | JSON string | Token likelihood bias map |
| `--user` | string | End-user identifier |

All 145 tests pass. Lint clean.

Closes #15