### PR TITLE
feat: add stream_options.include_usage support for streaming benchmarks

### DIFF
--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -144,6 +144,7 @@ async def _send_streaming(
     first_token_time: float | None = None
     last_token_time: float = start
     token_count = 0
+    stream_usage: dict[str, Any] | None = None
 
     try:
         async with client.stream("POST", url, json=payload, timeout=300.0) as resp:
@@ -160,6 +161,10 @@ async def _send_streaming(
                     chunk = json.loads(data_str)
                 except json.JSONDecodeError:
                     continue
+
+                # Capture usage from final streaming chunk (stream_options.include_usage)
+                if "usage" in chunk and chunk["usage"] is not None:
+                    stream_usage = chunk["usage"]
 
                 # Check if this chunk has content
                 choices = chunk.get("choices", [])
@@ -188,6 +193,10 @@ async def _send_streaming(
     end = time.perf_counter()
     result.latency_ms = (end - start) * 1000.0
     result.completion_tokens = token_count
+    if stream_usage:
+        result.prompt_tokens = stream_usage.get("prompt_tokens", 0)
+        if stream_usage.get("completion_tokens"):
+            result.completion_tokens = stream_usage["completion_tokens"]
     if token_count > 1 and first_token_time is not None:
         generation_time_ms = (last_token_time - first_token_time) * 1000.0
         result.tpot_ms = generation_time_ms / (token_count - 1)
@@ -254,6 +263,8 @@ def _build_payload(
             payload["logit_bias"] = args.logit_bias
     if getattr(args, "user", None) is not None:
         payload["user"] = args.user
+    if getattr(args, "stream_options_include_usage", False):
+        payload["stream_options"] = {"include_usage": True}
 
     return payload
 

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -161,6 +161,12 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="Unique identifier representing the end-user.",
     )
+    sampling.add_argument(
+        "--stream-options-include-usage",
+        action="store_true",
+        default=False,
+        help="Request usage stats in the final streaming chunk (stream_options).",
+    )
 
     # Output
     parser.add_argument(

--- a/tests/test_issue16_stream_options.py
+++ b/tests/test_issue16_stream_options.py
@@ -1,0 +1,111 @@
+"""Tests for issue #16: stream_options parameter."""
+
+from __future__ import annotations
+
+import argparse
+from argparse import Namespace
+
+from xpyd_bench.bench.runner import _build_payload
+
+
+class TestStreamOptionsInPayload:
+    def _base_args(self, **kwargs):
+        defaults = dict(
+            output_len=10, model="m", temperature=None, top_p=None, top_k=None,
+            frequency_penalty=None, presence_penalty=None, best_of=None,
+            use_beam_search=False, logprobs=None, ignore_eos=False,
+            stop=None, n=None, api_seed=None, echo=False, suffix=None,
+            logit_bias=None, user=None, stream_options_include_usage=False,
+        )
+        defaults.update(kwargs)
+        return Namespace(**defaults)
+
+    def test_stream_options_included_when_true(self):
+        args = self._base_args(stream_options_include_usage=True)
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert payload["stream_options"] == {"include_usage": True}
+
+    def test_stream_options_omitted_when_false(self):
+        args = self._base_args(stream_options_include_usage=False)
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert "stream_options" not in payload
+
+    def test_stream_options_omitted_when_missing(self):
+        args = self._base_args()
+        delattr(args, "stream_options_include_usage")
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert "stream_options" not in payload
+
+    def test_stream_options_with_chat(self):
+        args = self._base_args(stream_options_include_usage=True)
+        payload = _build_payload(args, "hello", is_chat=True)
+        assert payload["stream_options"] == {"include_usage": True}
+        assert "messages" in payload
+
+
+class TestStreamOptionsUsageCapture:
+    """Test that streaming usage is captured from final chunk."""
+
+    def test_usage_from_stream_chunk(self):
+        """Integration-style test: verify _send_streaming captures usage."""
+        import asyncio
+        import time
+        from unittest.mock import AsyncMock, MagicMock
+
+        from xpyd_bench.bench.runner import _send_streaming
+
+        # Build mock streaming response lines
+        usage_data = (
+            '{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}'
+        )
+        lines = [
+            'data: {"choices":[{"delta":{"content":"Hello"}}]}',
+            'data: {"choices":[{"delta":{"content":" world"}}]}',
+            f'data: {{"choices":[],"usage":{usage_data}}}',
+            "data: [DONE]",
+        ]
+
+        async def mock_aiter_lines():
+            for line in lines:
+                yield line
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.aiter_lines = mock_aiter_lines
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_client = MagicMock()
+        mock_client.stream = MagicMock(return_value=mock_resp)
+
+        payload = {"model": "test", "max_tokens": 10}
+
+        async def run():
+            return await _send_streaming(
+                mock_client,
+                "http://localhost/v1/chat/completions",
+                payload,
+                time.perf_counter(),
+            )
+
+        result = asyncio.run(run())
+        assert result.prompt_tokens == 5
+        assert result.completion_tokens == 2
+
+
+class TestCLIParsing:
+    def test_stream_options_flag(self):
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--stream-options-include-usage"])
+        assert args.stream_options_include_usage is True
+
+    def test_stream_options_default_false(self):
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        assert args.stream_options_include_usage is False


### PR DESCRIPTION
## Summary

Add the missing `stream_options` parameter support to the bench client, enabling usage statistics capture during streaming benchmarks.

### Changes

- **CLI**: Added `--stream-options-include-usage` flag
- **Runner**: `_build_payload()` includes `stream_options: {include_usage: true}` when enabled
- **Streaming**: `_send_streaming()` captures `usage` from the final streaming chunk and populates `prompt_tokens` and `completion_tokens`
- **Tests**: 7 new tests covering payload construction, usage capture, and CLI parsing

All 152 tests pass. Lint clean.

Closes #16