### PR TITLE
feat(dummy): validate request parameters and simulate stop/echo/logprobs/streaming-n/include_usage

### DIFF
--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import random
 import time
 import uuid
 from dataclasses import dataclass
@@ -84,23 +85,149 @@ def _make_chat_completion_id() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Parameter validation
+# ---------------------------------------------------------------------------
+
+_PARAM_RANGES = {
+    "temperature": (0.0, 2.0),
+    "top_p": (0.0, 1.0),
+    "frequency_penalty": (-2.0, 2.0),
+    "presence_penalty": (-2.0, 2.0),
+}
+
+
+def _validate_params(body: dict) -> str | None:
+    """Validate request parameters. Returns error message or None."""
+    for param, (lo, hi) in _PARAM_RANGES.items():
+        if param in body and body[param] is not None:
+            val = body[param]
+            if not isinstance(val, (int, float)):
+                return f"'{param}' must be a number"
+            if val < lo or val > hi:
+                return f"'{param}' must be between {lo} and {hi}, got {val}"
+
+    n = body.get("n")
+    if n is not None:
+        if not isinstance(n, int) or n < 1:
+            return "'n' must be a positive integer"
+
+    max_tokens = body.get("max_tokens")
+    if max_tokens is not None:
+        if not isinstance(max_tokens, int) or max_tokens < 1:
+            return "'max_tokens' must be a positive integer"
+
+    best_of = body.get("best_of")
+    if best_of is not None:
+        if not isinstance(best_of, int) or best_of < 1:
+            return "'best_of' must be a positive integer"
+        n_val = body.get("n", 1)
+        if best_of < n_val:
+            return f"'best_of' ({best_of}) must be >= 'n' ({n_val})"
+
+    logprobs_val = body.get("logprobs")
+    if logprobs_val is not None:
+        # Completions: integer 0-5; Chat: boolean (handled separately)
+        if isinstance(logprobs_val, bool):
+            pass  # valid for chat
+        elif isinstance(logprobs_val, int):
+            if logprobs_val < 0 or logprobs_val > 5:
+                return "'logprobs' must be between 0 and 5"
+        else:
+            return "'logprobs' must be an integer (0-5) or boolean"
+
+    top_logprobs = body.get("top_logprobs")
+    if top_logprobs is not None:
+        if not isinstance(top_logprobs, int) or top_logprobs < 0 or top_logprobs > 20:
+            return "'top_logprobs' must be an integer between 0 and 20"
+
+    return None
+
+
+def _make_logprobs_data(token: str, num_logprobs: int = 1) -> dict:
+    """Generate dummy logprobs data for a token."""
+    log_prob = -random.uniform(0.01, 5.0)
+    top = [
+        {
+            "token": f"tok_{i}",
+            "logprob": -random.uniform(0.01, 10.0),
+            "bytes": list(f"tok_{i}".encode()),
+        }
+        for i in range(max(num_logprobs, 1))
+    ]
+    # Insert the actual token at position 0
+    top[0] = {
+        "token": token,
+        "logprob": log_prob,
+        "bytes": list(token.encode()),
+    }
+    return {
+        "token": token,
+        "logprob": log_prob,
+        "bytes": list(token.encode()),
+        "top_logprobs": top,
+    }
+
+
+def _check_stop(text: str, stop: list[str] | str | None) -> tuple[bool, str]:
+    """Check if any stop sequence is found in text.
+
+    Returns (should_stop, truncated_text).
+    """
+    if stop is None:
+        return False, text
+    if isinstance(stop, str):
+        stop = [stop]
+    for seq in stop:
+        idx = text.find(seq)
+        if idx >= 0:
+            return True, text[:idx]
+    return False, text
+
+
+# ---------------------------------------------------------------------------
 # /v1/completions
 # ---------------------------------------------------------------------------
 
 
 async def _handle_completions(request: Request) -> JSONResponse | StreamingResponse:
     body = await request.json()
+
+    # Validate parameters
+    err = _validate_params(body)
+    if err:
+        return JSONResponse(
+            {"error": {"message": err, "type": "invalid_request_error"}},
+            status_code=400,
+        )
+
     prompt = body.get("prompt", "")
     max_tokens = body.get("max_tokens", _config.max_tokens_default)
     stream = body.get("stream", False)
     model = body.get("model", _config.model_name)
     n = body.get("n", 1)
     seed = body.get("seed", None)
+    echo = body.get("echo", False)
+    stop = body.get("stop")
+    logprobs_count = body.get("logprobs")  # int or None
+    stream_options = body.get("stream_options") or {}
+    include_usage = stream_options.get("include_usage", False)
     prompt_tokens = _estimate_prompt_tokens(prompt, None)
+    prompt_text = _normalize_prompt(prompt)
 
     if stream:
         return StreamingResponse(
-            _stream_completions(model, prompt_tokens, max_tokens),
+            _stream_completions(
+                model,
+                prompt_tokens,
+                max_tokens,
+                n=n,
+                echo=echo,
+                prompt_text=prompt_text,
+                stop=stop,
+                logprobs_count=logprobs_count,
+                include_usage=include_usage,
+                seed=seed,
+            ),
             media_type="text/event-stream",
         )
 
@@ -108,15 +235,45 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
     total_ms = _config.prefill_ms + _config.decode_ms * max_tokens
     await asyncio.sleep(total_ms / 1000.0)
 
-    generated_text = " ".join(["token"] * max_tokens)
-    choices = [
-        {
+    choices = []
+    total_completion_tokens = 0
+    for i in range(n):
+        generated_text = " ".join(["token"] * max_tokens)
+        finish_reason = "length"
+        stopped, generated_text = _check_stop(generated_text, stop)
+        if stopped:
+            finish_reason = "stop"
+
+        if echo:
+            generated_text = prompt_text + generated_text
+
+        choice: dict = {
             "index": i,
             "text": generated_text,
-            "finish_reason": "length",
+            "finish_reason": finish_reason,
         }
-        for i in range(n)
-    ]
+
+        if logprobs_count is not None:
+            tokens = generated_text.split(" ") if generated_text else []
+            choice["logprobs"] = {
+                "tokens": tokens,
+                "token_logprobs": [-random.uniform(0.01, 5.0) for _ in tokens],
+                "top_logprobs": [
+                    {f"tok_{j}": -random.uniform(0.01, 10.0) for j in range(logprobs_count)}
+                    for _ in tokens
+                ],
+                "text_offset": list(range(0, len(generated_text), max(1, len(generated_text) // max(len(tokens), 1)))),  # noqa: E501
+            }
+
+        # Count completion tokens based on generated token count (not echo)
+        gen_token_count = len(generated_text.split()) if generated_text else 0
+        if echo and prompt_text:
+            # Subtract prompt tokens from word count
+            prompt_word_count = len(prompt_text.split()) if prompt_text else 0
+            gen_token_count = max(0, gen_token_count - prompt_word_count)
+        total_completion_tokens += gen_token_count
+        choices.append(choice)
+
     resp_body: dict = {
         "id": _make_completion_id(),
         "object": "text_completion",
@@ -125,8 +282,8 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
         "choices": choices,
         "usage": {
             "prompt_tokens": prompt_tokens,
-            "completion_tokens": max_tokens * n,
-            "total_tokens": prompt_tokens + max_tokens * n,
+            "completion_tokens": total_completion_tokens,
+            "total_tokens": prompt_tokens + total_completion_tokens,
         },
     }
     if seed is not None:
@@ -134,7 +291,19 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
     return JSONResponse(resp_body)
 
 
-async def _stream_completions(model: str, prompt_tokens: int, max_tokens: int):
+async def _stream_completions(
+    model: str,
+    prompt_tokens: int,
+    max_tokens: int,
+    *,
+    n: int = 1,
+    echo: bool = False,
+    prompt_text: str = "",
+    stop: list[str] | str | None = None,
+    logprobs_count: int | None = None,
+    include_usage: bool = False,
+    seed: int | None = None,
+):
     """Generate SSE stream for completions endpoint."""
     comp_id = _make_completion_id()
     created = int(time.time())
@@ -142,24 +311,101 @@ async def _stream_completions(model: str, prompt_tokens: int, max_tokens: int):
     # Prefill delay
     await asyncio.sleep(_config.prefill_ms / 1000.0)
 
-    for i in range(max_tokens):
-        chunk = {
+    total_completion_tokens = 0
+
+    for choice_idx in range(n):
+        # Echo prefix as first chunk if requested
+        if echo and prompt_text:
+            chunk: dict = {
+                "id": comp_id,
+                "object": "text_completion",
+                "created": created,
+                "model": model,
+                "choices": [
+                    {
+                        "index": choice_idx,
+                        "text": prompt_text,
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            if seed is not None:
+                chunk["system_fingerprint"] = f"fp_seed_{seed}"
+            yield f"data: {json.dumps(chunk)}\n\n"
+
+        accumulated = ""
+        stopped = False
+        for i in range(max_tokens):
+            token_text = "token " if i < max_tokens - 1 else "token"
+            accumulated += token_text
+
+            # Check stop sequences
+            if stop:
+                stopped, _ = _check_stop(accumulated, stop)
+                if stopped:
+                    # Emit final chunk with stop reason
+                    choice_data: dict = {
+                        "index": choice_idx,
+                        "text": token_text,
+                        "finish_reason": "stop",
+                    }
+                    if logprobs_count is not None:
+                        choice_data["logprobs"] = _make_logprobs_data(
+                            token_text, logprobs_count
+                        )
+                    chunk = {
+                        "id": comp_id,
+                        "object": "text_completion",
+                        "created": created,
+                        "model": model,
+                        "choices": [choice_data],
+                    }
+                    if seed is not None:
+                        chunk["system_fingerprint"] = f"fp_seed_{seed}"
+                    total_completion_tokens += i + 1
+                    yield f"data: {json.dumps(chunk)}\n\n"
+                    break
+
+            is_last = i == max_tokens - 1
+            choice_data = {
+                "index": choice_idx,
+                "text": token_text,
+                "finish_reason": "length" if is_last else None,
+            }
+            if logprobs_count is not None:
+                choice_data["logprobs"] = _make_logprobs_data(token_text, logprobs_count)
+
+            chunk = {
+                "id": comp_id,
+                "object": "text_completion",
+                "created": created,
+                "model": model,
+                "choices": [choice_data],
+            }
+            if seed is not None:
+                chunk["system_fingerprint"] = f"fp_seed_{seed}"
+            yield f"data: {json.dumps(chunk)}\n\n"
+            await asyncio.sleep(_config.decode_ms / 1000.0)
+
+        if not stopped:
+            total_completion_tokens += max_tokens
+
+    # Include usage chunk if requested
+    if include_usage:
+        usage_chunk = {
             "id": comp_id,
             "object": "text_completion",
             "created": created,
             "model": model,
-            "choices": [
-                {
-                    "index": 0,
-                    "text": "token " if i < max_tokens - 1 else "token",
-                    "finish_reason": None if i < max_tokens - 1 else "length",
-                }
-            ],
+            "choices": [],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": total_completion_tokens,
+                "total_tokens": prompt_tokens + total_completion_tokens,
+            },
         }
-        yield f"data: {json.dumps(chunk)}\n\n"
-        await asyncio.sleep(_config.decode_ms / 1000.0)
+        yield f"data: {json.dumps(usage_chunk)}\n\n"
 
-    # Include usage in final data before [DONE]
     yield "data: [DONE]\n\n"
 
 
@@ -170,17 +416,41 @@ async def _stream_completions(model: str, prompt_tokens: int, max_tokens: int):
 
 async def _handle_chat_completions(request: Request) -> JSONResponse | StreamingResponse:
     body = await request.json()
+
+    # Validate parameters
+    err = _validate_params(body)
+    if err:
+        return JSONResponse(
+            {"error": {"message": err, "type": "invalid_request_error"}},
+            status_code=400,
+        )
+
     messages = body.get("messages", [])
     max_tokens = body.get("max_tokens", _config.max_tokens_default)
     stream = body.get("stream", False)
     model = body.get("model", _config.model_name)
     n = body.get("n", 1)
     seed = body.get("seed", None)
+    stop = body.get("stop")
+    logprobs = body.get("logprobs", False)
+    top_logprobs = body.get("top_logprobs")
+    stream_options = body.get("stream_options") or {}
+    include_usage = stream_options.get("include_usage", False)
     prompt_tokens = _estimate_prompt_tokens(None, messages)
 
     if stream:
         return StreamingResponse(
-            _stream_chat_completions(model, prompt_tokens, max_tokens),
+            _stream_chat_completions(
+                model,
+                prompt_tokens,
+                max_tokens,
+                n=n,
+                stop=stop,
+                logprobs=logprobs,
+                top_logprobs=top_logprobs,
+                include_usage=include_usage,
+                seed=seed,
+            ),
             media_type="text/event-stream",
         )
 
@@ -188,15 +458,33 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
     total_ms = _config.prefill_ms + _config.decode_ms * max_tokens
     await asyncio.sleep(total_ms / 1000.0)
 
-    generated_text = " ".join(["token"] * max_tokens)
-    choices = [
-        {
+    choices = []
+    total_completion_tokens = 0
+    for i in range(n):
+        generated_text = " ".join(["token"] * max_tokens)
+        finish_reason = "length"
+        stopped, generated_text = _check_stop(generated_text, stop)
+        if stopped:
+            finish_reason = "stop"
+
+        choice: dict = {
             "index": i,
             "message": {"role": "assistant", "content": generated_text},
-            "finish_reason": "length",
+            "finish_reason": finish_reason,
         }
-        for i in range(n)
-    ]
+
+        if logprobs and top_logprobs is not None:
+            tokens = generated_text.split(" ") if generated_text else []
+            choice["logprobs"] = {
+                "content": [
+                    _make_logprobs_data(tok, top_logprobs) for tok in tokens
+                ],
+            }
+
+        gen_token_count = len(generated_text.split()) if generated_text else 0
+        total_completion_tokens += gen_token_count
+        choices.append(choice)
+
     resp_body: dict = {
         "id": _make_chat_completion_id(),
         "object": "chat.completion",
@@ -205,8 +493,8 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
         "choices": choices,
         "usage": {
             "prompt_tokens": prompt_tokens,
-            "completion_tokens": max_tokens * n,
-            "total_tokens": prompt_tokens + max_tokens * n,
+            "completion_tokens": total_completion_tokens,
+            "total_tokens": prompt_tokens + total_completion_tokens,
         },
     }
     if seed is not None:
@@ -214,7 +502,18 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
     return JSONResponse(resp_body)
 
 
-async def _stream_chat_completions(model: str, prompt_tokens: int, max_tokens: int):
+async def _stream_chat_completions(
+    model: str,
+    prompt_tokens: int,
+    max_tokens: int,
+    *,
+    n: int = 1,
+    stop: list[str] | str | None = None,
+    logprobs: bool = False,
+    top_logprobs: int | None = None,
+    include_usage: bool = False,
+    seed: int | None = None,
+):
     """Generate SSE stream for chat completions endpoint."""
     comp_id = _make_chat_completion_id()
     created = int(time.time())
@@ -222,24 +521,84 @@ async def _stream_chat_completions(model: str, prompt_tokens: int, max_tokens: i
     # Prefill delay
     await asyncio.sleep(_config.prefill_ms / 1000.0)
 
-    for i in range(max_tokens):
-        chunk = {
+    total_completion_tokens = 0
+
+    for choice_idx in range(n):
+        accumulated = ""
+        stopped = False
+        for i in range(max_tokens):
+            token_text = "token " if i < max_tokens - 1 else "token"
+            accumulated += token_text
+
+            # Check stop sequences
+            if stop:
+                stopped, _ = _check_stop(accumulated, stop)
+                if stopped:
+                    delta: dict = {"content": token_text}
+                    choice_data: dict = {
+                        "index": choice_idx,
+                        "delta": delta,
+                        "finish_reason": "stop",
+                    }
+                    if logprobs and top_logprobs is not None:
+                        choice_data["logprobs"] = {
+                            "content": [_make_logprobs_data(token_text, top_logprobs)]
+                        }
+                    chunk: dict = {
+                        "id": comp_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": model,
+                        "choices": [choice_data],
+                    }
+                    if seed is not None:
+                        chunk["system_fingerprint"] = f"fp_seed_{seed}"
+                    total_completion_tokens += i + 1
+                    yield f"data: {json.dumps(chunk)}\n\n"
+                    break
+
+            is_last = i == max_tokens - 1
+            delta = {"content": token_text}
+            choice_data = {
+                "index": choice_idx,
+                "delta": delta,
+                "finish_reason": "length" if is_last else None,
+            }
+            if logprobs and top_logprobs is not None:
+                choice_data["logprobs"] = {
+                    "content": [_make_logprobs_data(token_text, top_logprobs)]
+                }
+
+            chunk = {
+                "id": comp_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [choice_data],
+            }
+            if seed is not None:
+                chunk["system_fingerprint"] = f"fp_seed_{seed}"
+            yield f"data: {json.dumps(chunk)}\n\n"
+            await asyncio.sleep(_config.decode_ms / 1000.0)
+
+        if not stopped:
+            total_completion_tokens += max_tokens
+
+    # Include usage chunk if requested
+    if include_usage:
+        usage_chunk = {
             "id": comp_id,
             "object": "chat.completion.chunk",
             "created": created,
             "model": model,
-            "choices": [
-                {
-                    "index": 0,
-                    "delta": {
-                        "content": "token " if i < max_tokens - 1 else "token",
-                    },
-                    "finish_reason": None if i < max_tokens - 1 else "length",
-                }
-            ],
+            "choices": [],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": total_completion_tokens,
+                "total_tokens": prompt_tokens + total_completion_tokens,
+            },
         }
-        yield f"data: {json.dumps(chunk)}\n\n"
-        await asyncio.sleep(_config.decode_ms / 1000.0)
+        yield f"data: {json.dumps(usage_chunk)}\n\n"
 
     yield "data: [DONE]\n\n"
 

--- a/tests/test_dummy_params.py
+++ b/tests/test_dummy_params.py
@@ -1,0 +1,328 @@
+"""Tests for dummy server parameter validation and simulation (issue #17)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+from xpyd_bench.dummy.server import ServerConfig, create_app
+
+
+@pytest.fixture
+def client():
+    config = ServerConfig(prefill_ms=0, decode_ms=0, model_name="test-model")
+    app = create_app(config)
+    return TestClient(app)
+
+
+class TestParameterValidation:
+    """Reject out-of-range parameters with 400."""
+
+    @pytest.mark.parametrize(
+        "param,bad_value",
+        [
+            ("temperature", -0.1),
+            ("temperature", 2.1),
+            ("top_p", -0.1),
+            ("top_p", 1.1),
+            ("frequency_penalty", -2.1),
+            ("frequency_penalty", 2.1),
+            ("presence_penalty", -2.1),
+            ("presence_penalty", 2.1),
+        ],
+    )
+    def test_completions_rejects_bad_range(self, client, param, bad_value):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 1, param: bad_value},
+        )
+        assert resp.status_code == 400
+        assert "error" in resp.json()
+
+    @pytest.mark.parametrize(
+        "param,bad_value",
+        [
+            ("temperature", -0.1),
+            ("top_p", 1.1),
+        ],
+    )
+    def test_chat_rejects_bad_range(self, client, param, bad_value):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 1,
+                param: bad_value,
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_n_must_be_positive(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 1, "n": 0},
+        )
+        assert resp.status_code == 400
+
+    def test_best_of_less_than_n(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 1, "n": 3, "best_of": 2},
+        )
+        assert resp.status_code == 400
+
+    def test_logprobs_out_of_range(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 1, "logprobs": 6},
+        )
+        assert resp.status_code == 400
+
+    def test_valid_params_accepted(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={
+                "prompt": "hi",
+                "max_tokens": 2,
+                "temperature": 1.0,
+                "top_p": 0.9,
+                "frequency_penalty": 0.5,
+                "presence_penalty": 0.5,
+            },
+        )
+        assert resp.status_code == 200
+
+
+class TestEchoSupport:
+    """Completions echo parameter."""
+
+    def test_echo_prepends_prompt(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "Hello ", "max_tokens": 3, "echo": True},
+        )
+        assert resp.status_code == 200
+        text = resp.json()["choices"][0]["text"]
+        assert text.startswith("Hello ")
+
+    def test_no_echo_default(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "Hello ", "max_tokens": 3},
+        )
+        text = resp.json()["choices"][0]["text"]
+        assert not text.startswith("Hello ")
+
+    def test_echo_streaming(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "PREFIX", "max_tokens": 2, "stream": True, "echo": True},
+        )
+        chunks = []
+        for line in resp.iter_lines():
+            if line.startswith("data: ") and "[DONE]" not in line:
+                chunks.append(json.loads(line[6:]))
+        # First chunk should contain the echo prefix
+        assert chunks[0]["choices"][0]["text"] == "PREFIX"
+
+
+class TestStopSequences:
+    """Stop sequence simulation."""
+
+    def test_stop_string_completions(self, client):
+        # "token token token" — stop on "token token" should truncate
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 5, "stop": "token token"},
+        )
+        assert resp.status_code == 200
+        choice = resp.json()["choices"][0]
+        assert choice["finish_reason"] == "stop"
+
+    def test_stop_list_completions(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 5, "stop": ["token token"]},
+        )
+        choice = resp.json()["choices"][0]
+        assert choice["finish_reason"] == "stop"
+
+    def test_no_stop_gives_length(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 3},
+        )
+        choice = resp.json()["choices"][0]
+        assert choice["finish_reason"] == "length"
+
+    def test_stop_chat(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 5,
+                "stop": "token token",
+            },
+        )
+        choice = resp.json()["choices"][0]
+        assert choice["finish_reason"] == "stop"
+
+
+class TestLogprobs:
+    """Logprobs in responses."""
+
+    def test_completions_logprobs(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 3, "logprobs": 2},
+        )
+        assert resp.status_code == 200
+        choice = resp.json()["choices"][0]
+        assert "logprobs" in choice
+        assert "tokens" in choice["logprobs"]
+        assert "token_logprobs" in choice["logprobs"]
+        assert "top_logprobs" in choice["logprobs"]
+
+    def test_chat_logprobs(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 3,
+                "logprobs": True,
+                "top_logprobs": 3,
+            },
+        )
+        assert resp.status_code == 200
+        choice = resp.json()["choices"][0]
+        assert "logprobs" in choice
+        assert "content" in choice["logprobs"]
+        assert len(choice["logprobs"]["content"]) > 0
+        entry = choice["logprobs"]["content"][0]
+        assert "token" in entry
+        assert "logprob" in entry
+        assert "top_logprobs" in entry
+
+    def test_no_logprobs_by_default(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 3},
+        )
+        choice = resp.json()["choices"][0]
+        assert "logprobs" not in choice
+
+
+class TestStreamingN:
+    """Streaming with n > 1."""
+
+    def test_streaming_n_completions(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 2, "stream": True, "n": 2},
+        )
+        chunks = []
+        for line in resp.iter_lines():
+            if line.startswith("data: ") and "[DONE]" not in line:
+                chunks.append(json.loads(line[6:]))
+        # Should have chunks for both choice indices
+        indices = {c["choices"][0]["index"] for c in chunks if c["choices"]}
+        assert 0 in indices
+        assert 1 in indices
+
+    def test_streaming_n_chat(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 2,
+                "stream": True,
+                "n": 2,
+            },
+        )
+        chunks = []
+        for line in resp.iter_lines():
+            if line.startswith("data: ") and "[DONE]" not in line:
+                chunks.append(json.loads(line[6:]))
+        indices = {c["choices"][0]["index"] for c in chunks if c["choices"]}
+        assert 0 in indices
+        assert 1 in indices
+
+
+class TestStreamOptionsIncludeUsage:
+    """stream_options.include_usage support."""
+
+    def test_completions_include_usage(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={
+                "prompt": "hi",
+                "max_tokens": 2,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            },
+        )
+        chunks = []
+        for line in resp.iter_lines():
+            if line.startswith("data: ") and "[DONE]" not in line:
+                chunks.append(json.loads(line[6:]))
+        # Last chunk before [DONE] should have usage
+        usage_chunks = [c for c in chunks if "usage" in c]
+        assert len(usage_chunks) == 1
+        assert "prompt_tokens" in usage_chunks[0]["usage"]
+
+    def test_chat_include_usage(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 2,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            },
+        )
+        chunks = []
+        for line in resp.iter_lines():
+            if line.startswith("data: ") and "[DONE]" not in line:
+                chunks.append(json.loads(line[6:]))
+        usage_chunks = [c for c in chunks if "usage" in c]
+        assert len(usage_chunks) == 1
+
+    def test_no_usage_by_default(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 2, "stream": True},
+        )
+        chunks = []
+        for line in resp.iter_lines():
+            if line.startswith("data: ") and "[DONE]" not in line:
+                chunks.append(json.loads(line[6:]))
+        usage_chunks = [c for c in chunks if "usage" in c]
+        assert len(usage_chunks) == 0
+
+
+class TestNonStreamingN:
+    """Non-streaming n > 1."""
+
+    def test_completions_n(self, client):
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 3, "n": 3},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()["choices"]) == 3
+        indices = [c["index"] for c in resp.json()["choices"]]
+        assert indices == [0, 1, 2]
+
+    def test_chat_n(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 3,
+                "n": 3,
+            },
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()["choices"]) == 3


### PR DESCRIPTION
## Summary

Implement parameter validation and simulation for the dummy server, addressing issue #17.

### Changes

**Parameter Validation (400 errors):**
- temperature (0-2), top_p (0-1), frequency/presence_penalty (-2 to 2)
- n (positive int), max_tokens (positive int), best_of (>= n), logprobs (0-5)

**New Simulations:**
- `echo`: prepends prompt text to completion output
- `stop`: truncates output at stop sequences, returns `finish_reason: stop`
- `logprobs`: returns dummy log probability data (completions format)
- `logprobs` + `top_logprobs`: returns chat-style logprobs with top alternatives
- Streaming `n > 1`: emits chunks for each choice index
- `stream_options.include_usage`: emits usage statistics chunk before `[DONE]`

### Tests
31 new tests in `tests/test_dummy_params.py` covering all new functionality.
All 183 existing tests continue to pass.

Closes #17