### PR TITLE
fix(dummy): return 400 for invalid JSON body instead of 500

### DIFF
--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -190,7 +190,19 @@ def _check_stop(text: str, stop: list[str] | str | None) -> tuple[bool, str]:
 
 
 async def _handle_completions(request: Request) -> JSONResponse | StreamingResponse:
-    body = await request.json()
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            {
+                "error": {
+                    "message": "Invalid JSON body",
+                    "type": "invalid_request_error",
+                    "code": "invalid_json",
+                }
+            },
+            status_code=400,
+        )
 
     # Validate parameters
     err = _validate_params(body)
@@ -199,7 +211,6 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
             {"error": {"message": err, "type": "invalid_request_error"}},
             status_code=400,
         )
-
     prompt = body.get("prompt", "")
     max_tokens = body.get("max_tokens", _config.max_tokens_default)
     stream = body.get("stream", False)
@@ -415,7 +426,19 @@ async def _stream_completions(
 
 
 async def _handle_chat_completions(request: Request) -> JSONResponse | StreamingResponse:
-    body = await request.json()
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            {
+                "error": {
+                    "message": "Invalid JSON body",
+                    "type": "invalid_request_error",
+                    "code": "invalid_json",
+                }
+            },
+            status_code=400,
+        )
 
     # Validate parameters
     err = _validate_params(body)
@@ -424,7 +447,6 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
             {"error": {"message": err, "type": "invalid_request_error"}},
             status_code=400,
         )
-
     messages = body.get("messages", [])
     max_tokens = body.get("max_tokens", _config.max_tokens_default)
     stream = body.get("stream", False)

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -188,3 +188,45 @@ class TestDummyCLI:
         assert args.prefill_ms == 100.0
         assert args.decode_ms == 20.0
         assert args.model_name == "my-model"
+
+
+class TestInvalidJsonBody:
+    """Tests for invalid JSON body returning 400."""
+
+    def test_completions_invalid_json(self, client):
+        resp = client.post(
+            "/v1/completions",
+            content=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["type"] == "invalid_request_error"
+        assert body["error"]["code"] == "invalid_json"
+
+    def test_chat_completions_invalid_json(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            content=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["type"] == "invalid_request_error"
+        assert body["error"]["code"] == "invalid_json"
+
+    def test_completions_empty_body(self, client):
+        resp = client.post(
+            "/v1/completions",
+            content=b"",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+
+    def test_chat_completions_empty_body(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            content=b"",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Invalid JSON bodies sent to `/v1/completions` and `/v1/chat/completions` now return HTTP 400 with a structured error response matching OpenAI API format, instead of HTTP 500.

## Changes

- Added try/except around `request.json()` in both `_handle_completions` and `_handle_chat_completions`
- Returns `{"error": {"message": "Invalid JSON body", "type": "invalid_request_error", "code": "invalid_json"}}` with status 400
- Added 4 tests covering invalid JSON and empty body for both endpoints

Closes #27