### PR TITLE
fix(dummy): complete streaming response format per OpenAI spec

### DIFF
--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -364,6 +364,8 @@ async def _stream_completions(
                         choice_data["logprobs"] = _make_logprobs_data(
                             token_text, logprobs_count
                         )
+                    else:
+                        choice_data["logprobs"] = None
                     chunk = {
                         "id": comp_id,
                         "object": "text_completion",
@@ -385,6 +387,8 @@ async def _stream_completions(
             }
             if logprobs_count is not None:
                 choice_data["logprobs"] = _make_logprobs_data(token_text, logprobs_count)
+            else:
+                choice_data["logprobs"] = None
 
             chunk = {
                 "id": comp_id,
@@ -546,6 +550,25 @@ async def _stream_chat_completions(
     total_completion_tokens = 0
 
     for choice_idx in range(n):
+        # Emit initial chunk with role for each choice (OpenAI spec)
+        role_chunk: dict = {
+            "id": comp_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": [
+                {
+                    "index": choice_idx,
+                    "delta": {"role": "assistant", "content": ""},
+                    "logprobs": None,
+                    "finish_reason": None,
+                }
+            ],
+        }
+        if seed is not None:
+            role_chunk["system_fingerprint"] = f"fp_seed_{seed}"
+        yield f"data: {json.dumps(role_chunk)}\n\n"
+
         accumulated = ""
         stopped = False
         for i in range(max_tokens):
@@ -566,6 +589,8 @@ async def _stream_chat_completions(
                         choice_data["logprobs"] = {
                             "content": [_make_logprobs_data(token_text, top_logprobs)]
                         }
+                    else:
+                        choice_data["logprobs"] = None
                     chunk: dict = {
                         "id": comp_id,
                         "object": "chat.completion.chunk",
@@ -590,6 +615,8 @@ async def _stream_chat_completions(
                 choice_data["logprobs"] = {
                     "content": [_make_logprobs_data(token_text, top_logprobs)]
                 }
+            else:
+                choice_data["logprobs"] = None
 
             chunk = {
                 "id": comp_id,

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -94,9 +94,11 @@ class TestChatCompletions:
                     break
                 chunks.append(json.loads(data))
 
-        assert len(chunks) == 3
+        assert len(chunks) == 4  # 1 role chunk + 3 content chunks
+        # First chunk has role: assistant
         assert chunks[0]["object"] == "chat.completion.chunk"
-        assert "delta" in chunks[0]["choices"][0]
+        assert chunks[0]["choices"][0]["delta"]["role"] == "assistant"
+        assert "delta" in chunks[1]["choices"][0]
 
 
 class TestUsageStats:

--- a/tests/test_issue18_streaming_format.py
+++ b/tests/test_issue18_streaming_format.py
@@ -1,0 +1,134 @@
+"""Tests for issue #18: Incomplete streaming response format in dummy server.
+
+Verifies:
+- Chat streaming first chunk includes role: assistant in delta
+- logprobs: null present in all streaming choice objects when not requested
+- Completions streaming includes logprobs: null when not requested
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from xpyd_bench.dummy.server import ServerConfig, create_app
+
+
+@pytest.fixture
+def app():
+    config = ServerConfig(
+        prefill_ms=0,
+        decode_ms=0,
+        max_tokens_default=3,
+    )
+    return create_app(config)
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def _collect_sse_chunks(resp) -> list[dict]:
+    chunks = []
+    async for line in resp.aiter_lines():
+        if line.startswith("data: ") and line != "data: [DONE]":
+            chunks.append(json.loads(line[6:]))
+    return chunks
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_first_chunk_has_role(client: AsyncClient):
+    """First chat streaming chunk should have role: assistant in delta."""
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 3,
+            "stream": True,
+        },
+    )
+    assert resp.status_code == 200
+    chunks = await _collect_sse_chunks(resp)
+    assert len(chunks) >= 2  # at least role chunk + content chunks
+    first = chunks[0]
+    delta = first["choices"][0]["delta"]
+    assert delta.get("role") == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_logprobs_null_when_not_requested(client: AsyncClient):
+    """All chat streaming choices should have logprobs: null when not requested."""
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 3,
+            "stream": True,
+        },
+    )
+    assert resp.status_code == 200
+    chunks = await _collect_sse_chunks(resp)
+    for chunk in chunks:
+        if chunk["choices"]:
+            choice = chunk["choices"][0]
+            assert "logprobs" in choice, f"Missing logprobs key in chunk: {chunk}"
+            assert choice["logprobs"] is None
+
+
+@pytest.mark.asyncio
+async def test_completions_stream_logprobs_null_when_not_requested(
+    client: AsyncClient,
+):
+    """All completions streaming choices should have logprobs: null when not requested."""
+    resp = await client.post(
+        "/v1/completions",
+        json={
+            "model": "dummy",
+            "prompt": "hello",
+            "max_tokens": 3,
+            "stream": True,
+        },
+    )
+    assert resp.status_code == 200
+    chunks = await _collect_sse_chunks(resp)
+    for chunk in chunks:
+        if chunk["choices"]:
+            choice = chunk["choices"][0]
+            assert "logprobs" in choice, f"Missing logprobs key in chunk: {chunk}"
+            assert choice["logprobs"] is None
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_logprobs_present_when_requested(client: AsyncClient):
+    """Chat streaming should include logprobs data when logprobs=true and top_logprobs set."""
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 2,
+            "stream": True,
+            "logprobs": True,
+            "top_logprobs": 3,
+        },
+    )
+    assert resp.status_code == 200
+    chunks = await _collect_sse_chunks(resp)
+    # Skip the role-only chunk (first), check content chunks
+    content_chunks = [
+        c for c in chunks if c["choices"] and c["choices"][0]["delta"].get("content")
+    ]
+    assert len(content_chunks) >= 1
+    for chunk in content_chunks:
+        lp = chunk["choices"][0]["logprobs"]
+        assert lp is not None
+        assert "content" in lp
+        assert len(lp["content"]) == 1
+        assert len(lp["content"][0]["top_logprobs"]) == 3


### PR DESCRIPTION
## Summary

Fixes the remaining gaps from #18 (incomplete streaming response format):

1. **Chat streaming first chunk now includes `role: assistant` in delta** — per OpenAI spec, the first chunk should identify the assistant role
2. **`logprobs: null` added to all streaming choice objects** — when logprobs not requested, both completions and chat streaming chunks now include `logprobs: null` for spec compliance
3. Updated existing test to account for new role chunk (4 chunks instead of 3)
4. Added 4 new tests covering format compliance

Note: Items 1 (stream_options.include_usage) and 3 (system_fingerprint in streaming) from the original issue were already resolved by PR #28.

Closes #18