### PR TITLE
feat(dummy): simulate realistic EOS behavior with random output length

### DIFF
--- a/src/xpyd_bench/dummy/cli.py
+++ b/src/xpyd_bench/dummy/cli.py
@@ -39,6 +39,12 @@ def dummy_main(argv: list[str] | None = None) -> None:
         default=128,
         help="Default max_tokens when not specified in request (default: 128).",
     )
+    parser.add_argument(
+        "--eos-min-ratio",
+        type=float,
+        default=0.5,
+        help="Minimum fraction of max_tokens before EOS can fire (default: 0.5).",
+    )
     args = parser.parse_args(argv)
 
     import uvicorn
@@ -50,6 +56,7 @@ def dummy_main(argv: list[str] | None = None) -> None:
         decode_ms=args.decode_ms,
         model_name=args.model_name,
         max_tokens_default=args.max_tokens_default,
+        eos_min_ratio=args.eos_min_ratio,
     )
     app = create_app(config)
 

--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -23,6 +23,7 @@ class ServerConfig:
     decode_ms: float = 10.0  # Simulated per-token decode latency
     model_name: str = "dummy-model"
     max_tokens_default: int = 128
+    eos_min_ratio: float = 0.5  # EOS won't fire before this fraction of max_tokens
 
 
 # Global config — set before starting the server
@@ -168,6 +169,19 @@ def _make_logprobs_data(token: str, num_logprobs: int = 1) -> dict:
     }
 
 
+def _eos_index(max_tokens: int, ignore_eos: bool = False) -> int | None:
+    """Return the 0-based token index at which to emit EOS, or None to skip.
+
+    Uses ``_config.eos_min_ratio`` to set the lower bound.  When
+    *ignore_eos* is ``True`` the model should produce all *max_tokens*
+    so we return ``None``.
+    """
+    if ignore_eos or max_tokens <= 0:
+        return None
+    lo = max(1, int(max_tokens * _config.eos_min_ratio))
+    return random.randint(lo, max_tokens)  # inclusive; max_tokens means "no early stop"
+
+
 def _check_stop(text: str, stop: list[str] | str | None) -> tuple[bool, str]:
     """Check if any stop sequence is found in text.
 
@@ -220,6 +234,7 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
     echo = body.get("echo", False)
     stop = body.get("stop")
     logprobs_count = body.get("logprobs")  # int or None
+    ignore_eos = body.get("ignore_eos", False)
     stream_options = body.get("stream_options") or {}
     include_usage = stream_options.get("include_usage", False)
     prompt_tokens = _estimate_prompt_tokens(prompt, None)
@@ -238,6 +253,7 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
                 logprobs_count=logprobs_count,
                 include_usage=include_usage,
                 seed=seed,
+                ignore_eos=ignore_eos,
             ),
             media_type="text/event-stream",
         )
@@ -249,8 +265,10 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
     choices = []
     total_completion_tokens = 0
     for i in range(n):
-        generated_text = " ".join(["token"] * max_tokens)
-        finish_reason = "length"
+        eos_idx = _eos_index(max_tokens, ignore_eos)
+        actual_tokens = eos_idx if eos_idx is not None and eos_idx < max_tokens else max_tokens
+        generated_text = " ".join(["token"] * actual_tokens)
+        finish_reason = "stop" if (eos_idx is not None and eos_idx < max_tokens) else "length"
         stopped, generated_text = _check_stop(generated_text, stop)
         if stopped:
             finish_reason = "stop"
@@ -314,6 +332,7 @@ async def _stream_completions(
     logprobs_count: int | None = None,
     include_usage: bool = False,
     seed: int | None = None,
+    ignore_eos: bool = False,
 ):
     """Generate SSE stream for completions endpoint."""
     comp_id = _make_completion_id()
@@ -325,6 +344,9 @@ async def _stream_completions(
     total_completion_tokens = 0
 
     for choice_idx in range(n):
+        eos_idx = _eos_index(max_tokens, ignore_eos)
+        effective_max = eos_idx if eos_idx is not None and eos_idx < max_tokens else max_tokens
+
         # Echo prefix as first chunk if requested
         if echo and prompt_text:
             chunk: dict = {
@@ -346,8 +368,8 @@ async def _stream_completions(
 
         accumulated = ""
         stopped = False
-        for i in range(max_tokens):
-            token_text = "token " if i < max_tokens - 1 else "token"
+        for i in range(effective_max):
+            token_text = "token " if i < effective_max - 1 else "token"
             accumulated += token_text
 
             # Check stop sequences
@@ -379,11 +401,15 @@ async def _stream_completions(
                     yield f"data: {json.dumps(chunk)}\n\n"
                     break
 
-            is_last = i == max_tokens - 1
+            is_last = i == effective_max - 1
+            is_eos = effective_max < max_tokens and is_last
+            finish_reason: str | None = None
+            if is_last:
+                finish_reason = "stop" if is_eos else "length"
             choice_data = {
                 "index": choice_idx,
                 "text": token_text,
-                "finish_reason": "length" if is_last else None,
+                "finish_reason": finish_reason,
             }
             if logprobs_count is not None:
                 choice_data["logprobs"] = _make_logprobs_data(token_text, logprobs_count)
@@ -403,7 +429,7 @@ async def _stream_completions(
             await asyncio.sleep(_config.decode_ms / 1000.0)
 
         if not stopped:
-            total_completion_tokens += max_tokens
+            total_completion_tokens += effective_max
 
     # Include usage chunk if requested
     if include_usage:
@@ -460,6 +486,7 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
     stop = body.get("stop")
     logprobs = body.get("logprobs", False)
     top_logprobs = body.get("top_logprobs")
+    ignore_eos = body.get("ignore_eos", False)
     stream_options = body.get("stream_options") or {}
     include_usage = stream_options.get("include_usage", False)
     prompt_tokens = _estimate_prompt_tokens(None, messages)
@@ -476,6 +503,7 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
                 top_logprobs=top_logprobs,
                 include_usage=include_usage,
                 seed=seed,
+                ignore_eos=ignore_eos,
             ),
             media_type="text/event-stream",
         )
@@ -487,8 +515,10 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
     choices = []
     total_completion_tokens = 0
     for i in range(n):
-        generated_text = " ".join(["token"] * max_tokens)
-        finish_reason = "length"
+        eos_idx = _eos_index(max_tokens, ignore_eos)
+        actual_tokens = eos_idx if eos_idx is not None and eos_idx < max_tokens else max_tokens
+        generated_text = " ".join(["token"] * actual_tokens)
+        finish_reason = "stop" if (eos_idx is not None and eos_idx < max_tokens) else "length"
         stopped, generated_text = _check_stop(generated_text, stop)
         if stopped:
             finish_reason = "stop"
@@ -539,6 +569,7 @@ async def _stream_chat_completions(
     top_logprobs: int | None = None,
     include_usage: bool = False,
     seed: int | None = None,
+    ignore_eos: bool = False,
 ):
     """Generate SSE stream for chat completions endpoint."""
     comp_id = _make_chat_completion_id()
@@ -550,6 +581,9 @@ async def _stream_chat_completions(
     total_completion_tokens = 0
 
     for choice_idx in range(n):
+        eos_idx = _eos_index(max_tokens, ignore_eos)
+        effective_max = eos_idx if eos_idx is not None and eos_idx < max_tokens else max_tokens
+
         # Emit initial chunk with role for each choice (OpenAI spec)
         role_chunk: dict = {
             "id": comp_id,
@@ -571,8 +605,8 @@ async def _stream_chat_completions(
 
         accumulated = ""
         stopped = False
-        for i in range(max_tokens):
-            token_text = "token " if i < max_tokens - 1 else "token"
+        for i in range(effective_max):
+            token_text = "token " if i < effective_max - 1 else "token"
             accumulated += token_text
 
             # Check stop sequences
@@ -604,12 +638,16 @@ async def _stream_chat_completions(
                     yield f"data: {json.dumps(chunk)}\n\n"
                     break
 
-            is_last = i == max_tokens - 1
+            is_last = i == effective_max - 1
+            is_eos = effective_max < max_tokens and is_last
+            finish_reason: str | None = None
+            if is_last:
+                finish_reason = "stop" if is_eos else "length"
             delta = {"content": token_text}
             choice_data = {
                 "index": choice_idx,
                 "delta": delta,
-                "finish_reason": "length" if is_last else None,
+                "finish_reason": finish_reason,
             }
             if logprobs and top_logprobs is not None:
                 choice_data["logprobs"] = {
@@ -631,9 +669,9 @@ async def _stream_chat_completions(
             await asyncio.sleep(_config.decode_ms / 1000.0)
 
         if not stopped:
-            total_completion_tokens += max_tokens
+            total_completion_tokens += effective_max
 
-    # Include usage chunk if requested
+    # Include usage chunk if requested (chat)
     if include_usage:
         usage_chunk = {
             "id": comp_id,

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -13,7 +13,7 @@ from xpyd_bench.dummy.server import ServerConfig, create_app
 @pytest.fixture
 def client():
     """Create a test client with fast config."""
-    config = ServerConfig(prefill_ms=0, decode_ms=0, model_name="test-model")
+    config = ServerConfig(prefill_ms=0, decode_ms=0, model_name="test-model", eos_min_ratio=1.0)
     app = create_app(config)
     return TestClient(app)
 

--- a/tests/test_dummy_params.py
+++ b/tests/test_dummy_params.py
@@ -12,7 +12,7 @@ from xpyd_bench.dummy.server import ServerConfig, create_app
 
 @pytest.fixture
 def client():
-    config = ServerConfig(prefill_ms=0, decode_ms=0, model_name="test-model")
+    config = ServerConfig(prefill_ms=0, decode_ms=0, model_name="test-model", eos_min_ratio=1.0)
     app = create_app(config)
     return TestClient(app)
 

--- a/tests/test_eos_behavior.py
+++ b/tests/test_eos_behavior.py
@@ -1,0 +1,252 @@
+"""Tests for issue #23: Realistic EOS behavior with random output length."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from xpyd_bench.dummy.server import ServerConfig, create_app
+
+
+@pytest.fixture
+def app():
+    """Create app with fast timings for testing."""
+    config = ServerConfig(prefill_ms=0, decode_ms=0, eos_min_ratio=0.5)
+    return create_app(config)
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _parse_sse_chunks(text: str) -> list[dict]:
+    """Parse SSE response into list of JSON objects."""
+    chunks = []
+    for line in text.strip().split("\n"):
+        line = line.strip()
+        if line.startswith("data: ") and line != "data: [DONE]":
+            chunks.append(json.loads(line[6:]))
+    return chunks
+
+
+# ── Non-streaming completions ────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_completions_eos_before_max_tokens(client: AsyncClient):
+    """EOS should fire before max_tokens, producing finish_reason='stop'."""
+    results = {"stop": 0, "length": 0}
+    # Run multiple times to observe randomness
+    for _ in range(50):
+        resp = await client.post(
+            "/v1/completions",
+            json={"model": "test", "prompt": "hello", "max_tokens": 20},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        fr = body["choices"][0]["finish_reason"]
+        assert fr in ("stop", "length")
+        results[fr] += 1
+        tokens = body["choices"][0]["text"].split()
+        assert len(tokens) >= 10  # eos_min_ratio=0.5 → at least 10 of 20
+        assert len(tokens) <= 20
+
+    # Should see a mix of stop and length over 50 runs
+    assert results["stop"] > 0, "Expected at least some EOS stops"
+
+
+@pytest.mark.anyio
+async def test_completions_ignore_eos(client: AsyncClient):
+    """ignore_eos=true should always produce max_tokens and finish_reason='length'."""
+    for _ in range(10):
+        resp = await client.post(
+            "/v1/completions",
+            json={
+                "model": "test",
+                "prompt": "hello",
+                "max_tokens": 20,
+                "ignore_eos": True,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["choices"][0]["finish_reason"] == "length"
+        tokens = body["choices"][0]["text"].split()
+        assert len(tokens) == 20
+
+
+# ── Non-streaming chat completions ───────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_chat_eos_before_max_tokens(client: AsyncClient):
+    """Chat completions should also produce EOS stops."""
+    results = {"stop": 0, "length": 0}
+    for _ in range(50):
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 20,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        fr = body["choices"][0]["finish_reason"]
+        assert fr in ("stop", "length")
+        results[fr] += 1
+        tokens = body["choices"][0]["message"]["content"].split()
+        assert len(tokens) >= 10
+        assert len(tokens) <= 20
+
+    assert results["stop"] > 0
+
+
+@pytest.mark.anyio
+async def test_chat_ignore_eos(client: AsyncClient):
+    """Chat with ignore_eos=true should always produce max_tokens."""
+    for _ in range(10):
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 20,
+                "ignore_eos": True,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["choices"][0]["finish_reason"] == "length"
+        tokens = body["choices"][0]["message"]["content"].split()
+        assert len(tokens) == 20
+
+
+# ── Streaming completions ────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_stream_completions_eos(client: AsyncClient):
+    """Streaming completions should emit EOS with finish_reason='stop'."""
+    saw_stop = False
+    for _ in range(30):
+        resp = await client.post(
+            "/v1/completions",
+            json={
+                "model": "test",
+                "prompt": "hello",
+                "max_tokens": 20,
+                "stream": True,
+            },
+        )
+        chunks = _parse_sse_chunks(resp.text)
+        last = chunks[-1]
+        fr = last["choices"][0]["finish_reason"]
+        assert fr in ("stop", "length")
+        if fr == "stop":
+            saw_stop = True
+            assert len(chunks) < 20  # Fewer chunks than max_tokens
+
+    assert saw_stop, "Expected at least one streaming EOS stop"
+
+
+@pytest.mark.anyio
+async def test_stream_completions_ignore_eos(client: AsyncClient):
+    """Streaming completions with ignore_eos should produce all tokens."""
+    for _ in range(5):
+        resp = await client.post(
+            "/v1/completions",
+            json={
+                "model": "test",
+                "prompt": "hello",
+                "max_tokens": 10,
+                "stream": True,
+                "ignore_eos": True,
+            },
+        )
+        chunks = _parse_sse_chunks(resp.text)
+        last = chunks[-1]
+        assert last["choices"][0]["finish_reason"] == "length"
+        assert len(chunks) == 10
+
+
+# ── Streaming chat completions ───────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_stream_chat_eos(client: AsyncClient):
+    """Streaming chat completions should emit EOS stops."""
+    saw_stop = False
+    for _ in range(30):
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 20,
+                "stream": True,
+            },
+        )
+        chunks = _parse_sse_chunks(resp.text)
+        # First chunk is role chunk, skip it
+        content_chunks = [
+            c for c in chunks
+            if c["choices"][0].get("delta", {}).get("content") is not None
+            or c["choices"][0].get("finish_reason")
+        ]
+        last = content_chunks[-1]
+        fr = last["choices"][0]["finish_reason"]
+        assert fr in ("stop", "length")
+        if fr == "stop":
+            saw_stop = True
+
+    assert saw_stop, "Expected at least one streaming chat EOS stop"
+
+
+@pytest.mark.anyio
+async def test_stream_chat_ignore_eos(client: AsyncClient):
+    """Streaming chat with ignore_eos should produce all tokens."""
+    for _ in range(5):
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 10,
+                "stream": True,
+                "ignore_eos": True,
+            },
+        )
+        chunks = _parse_sse_chunks(resp.text)
+        # First chunk is role-only, skip it; remaining are content chunks
+        content_chunks = chunks[1:]
+        assert len(content_chunks) == 10
+        last_content = content_chunks[-1]
+        assert last_content["choices"][0]["finish_reason"] == "length"
+
+
+# ── ServerConfig.eos_min_ratio ───────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_eos_min_ratio_respected():
+    """eos_min_ratio should control the minimum output length."""
+    config = ServerConfig(prefill_ms=0, decode_ms=0, eos_min_ratio=0.8)
+    app = create_app(config)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(30):
+            resp = await client.post(
+                "/v1/completions",
+                json={"model": "test", "prompt": "hello", "max_tokens": 20},
+            )
+            body = resp.json()
+            tokens = body["choices"][0]["text"].split()
+            # With eos_min_ratio=0.8, minimum should be 16 tokens
+            assert len(tokens) >= 16

--- a/tests/test_issue18_streaming_format.py
+++ b/tests/test_issue18_streaming_format.py
@@ -22,6 +22,7 @@ def app():
         prefill_ms=0,
         decode_ms=0,
         max_tokens_default=3,
+        eos_min_ratio=1.0,
     )
     return create_app(config)
 

--- a/tests/test_m3_params.py
+++ b/tests/test_m3_params.py
@@ -10,7 +10,7 @@ from xpyd_bench.dummy.server import ServerConfig, create_app
 
 @pytest.fixture()
 def client():
-    app = create_app(ServerConfig(prefill_ms=0, decode_ms=0))
+    app = create_app(ServerConfig(prefill_ms=0, decode_ms=0, eos_min_ratio=1.0))
     return TestClient(app)
 
 


### PR DESCRIPTION
## Summary

Implements realistic EOS (end-of-sequence) behavior in the dummy server. Instead of always generating exactly `max_tokens` tokens, the server now randomly selects an output length per request.

## Changes

- **`ServerConfig.eos_min_ratio`** (default 0.5): Controls the minimum fraction of `max_tokens` before EOS can fire. Output length is `uniform(eos_min_ratio * max_tokens, max_tokens)`.
- **`finish_reason`**: Returns `"stop"` when EOS fires early, `"length"` when `max_tokens` is reached.
- **`ignore_eos` parameter**: When `true`, forces full `max_tokens` output regardless of EOS (vLLM extension).
- **All 4 code paths** updated: completions (streaming + non-streaming) and chat completions (streaming + non-streaming).
- **`--eos-min-ratio` CLI flag** added to the dummy server.
- **9 new tests** covering: EOS before max_tokens, ignore_eos, streaming EOS, eos_min_ratio configuration.
- **Existing tests** updated to use `eos_min_ratio=1.0` for deterministic behavior.

## Test Results

All 200 tests pass. Lint clean.

Closes #23