### PR TITLE
fix(cli): group vLLM-specific params into dedicated argument group

### DIFF
--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -108,15 +108,14 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Output length distribution for synthetic datasets (default: fixed).",
     )
 
-    # Sampling parameters
-    sampling = parser.add_argument_group("sampling parameters")
-    sampling.add_argument("--temperature", type=float, default=None)
-    sampling.add_argument("--top-p", type=float, default=None)
-    sampling.add_argument("--top-k", type=int, default=None)
+    # Sampling parameters (OpenAI API standard)
+    sampling = parser.add_argument_group("sampling parameters (OpenAI API standard)")
+    sampling.add_argument(
+        "--temperature", type=float, default=None, help="Sampling temperature."
+    )
+    sampling.add_argument("--top-p", type=float, default=None, help="Nucleus sampling top-p.")
     sampling.add_argument("--frequency-penalty", type=float, default=None)
     sampling.add_argument("--presence-penalty", type=float, default=None)
-    sampling.add_argument("--best-of", type=int, default=None)
-    sampling.add_argument("--use-beam-search", action="store_true")
     sampling.add_argument("--logprobs", type=int, default=None)
     sampling.add_argument(
         "--stop",
@@ -168,6 +167,30 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Request usage stats in the final streaming chunk (stream_options).",
     )
 
+    # vLLM-specific extensions (not part of the OpenAI API spec)
+    vllm_ext = parser.add_argument_group(
+        "vLLM extensions",
+        "Parameters specific to vLLM serving. These are NOT part of the "
+        "OpenAI API spec and may cause errors with non-vLLM backends.",
+    )
+    vllm_ext.add_argument(
+        "--top-k",
+        type=int,
+        default=None,
+        help="[vLLM only] Top-k sampling. Not in OpenAI API spec.",
+    )
+    vllm_ext.add_argument(
+        "--best-of",
+        type=int,
+        default=None,
+        help="[vLLM only] Generate best_of sequences and return the best. Not in OpenAI API spec.",
+    )
+    vllm_ext.add_argument(
+        "--use-beam-search",
+        action="store_true",
+        help="[vLLM only] Use beam search instead of sampling. Not in OpenAI API spec.",
+    )
+
     # Output
     parser.add_argument(
         "--save-result",
@@ -187,10 +210,10 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Disable progress bar.",
     )
-    parser.add_argument(
+    vllm_ext.add_argument(
         "--ignore-eos",
         action="store_true",
-        help="Ignore EOS token in generation.",
+        help="[vLLM only] Ignore EOS token in generation. Not in OpenAI API spec.",
     )
 
     # Extended config

--- a/tests/test_vllm_compat_args.py
+++ b/tests/test_vllm_compat_args.py
@@ -1,0 +1,84 @@
+"""Tests for issue #19: vLLM-specific parameters are properly grouped and documented."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def _get_parser() -> argparse.ArgumentParser:
+    """Build the bench CLI parser without running anything."""
+    parser = argparse.ArgumentParser(prog="xpyd-bench")
+    # Re-use the same function that bench_main uses
+    from xpyd_bench.cli import _add_vllm_compat_args
+
+    _add_vllm_compat_args(parser)
+    return parser
+
+
+class TestVLLMExtensionsGroup:
+    """Verify vLLM-specific params are in their own argument group."""
+
+    def test_vllm_group_exists(self):
+        parser = _get_parser()
+        group_titles = [g.title for g in parser._action_groups]
+        assert "vLLM extensions" in group_titles
+
+    def test_vllm_params_in_group(self):
+        parser = _get_parser()
+        vllm_group = None
+        for g in parser._action_groups:
+            if g.title == "vLLM extensions":
+                vllm_group = g
+                break
+        assert vllm_group is not None
+        option_strings = []
+        for action in vllm_group._group_actions:
+            option_strings.extend(action.option_strings)
+        assert "--top-k" in option_strings
+        assert "--use-beam-search" in option_strings
+        assert "--ignore-eos" in option_strings
+        assert "--best-of" in option_strings
+
+    def test_vllm_params_not_in_standard_sampling(self):
+        parser = _get_parser()
+        sampling_group = None
+        for g in parser._action_groups:
+            if "sampling" in (g.title or "").lower() and "standard" in (g.title or "").lower():
+                sampling_group = g
+                break
+        assert sampling_group is not None
+        option_strings = []
+        for action in sampling_group._group_actions:
+            option_strings.extend(action.option_strings)
+        # These should NOT be in the standard sampling group
+        assert "--top-k" not in option_strings
+        assert "--use-beam-search" not in option_strings
+        assert "--ignore-eos" not in option_strings
+        assert "--best-of" not in option_strings
+
+    def test_vllm_help_text_contains_warning(self):
+        parser = _get_parser()
+        vllm_group = None
+        for g in parser._action_groups:
+            if g.title == "vLLM extensions":
+                vllm_group = g
+                break
+        assert vllm_group is not None
+        for action in vllm_group._group_actions:
+            if action.help:
+                assert "vLLM" in action.help or "not in OpenAI" in action.help.lower()
+
+    def test_standard_params_remain(self):
+        """Standard OpenAI params should still be accessible."""
+        parser = _get_parser()
+        args = parser.parse_args(["--temperature", "0.7", "--top-p", "0.9"])
+        assert args.temperature == 0.7
+        assert args.top_p == 0.9
+
+    def test_vllm_params_parse(self):
+        """vLLM extension params should still parse correctly."""
+        parser = _get_parser()
+        args = parser.parse_args(["--top-k", "50", "--use-beam-search", "--ignore-eos"])
+        assert args.top_k == 50
+        assert args.use_beam_search is True
+        assert args.ignore_eos is True


### PR DESCRIPTION
## Summary

Move `top_k`, `best_of`, `use_beam_search`, and `ignore_eos` into a separate **vLLM extensions** argument group with clear help text warning that these are not part of the OpenAI API spec.

## Changes

- Created new `vLLM extensions` argument group in CLI with descriptive group help
- Moved `--top-k`, `--best-of`, `--use-beam-search`, `--ignore-eos` out of standard sampling group
- Added `[vLLM only]` prefix and `Not in OpenAI API spec` to each help string
- Added tests verifying group structure, param placement, and help text

Closes #19