### PR TITLE
feat(cli): add chat-specific OpenAI API parameters

### DIFF
--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -266,6 +266,41 @@ def _build_payload(
     if getattr(args, "stream_options_include_usage", False):
         payload["stream_options"] = {"include_usage": True}
 
+    # Chat-specific parameters (only for chat endpoints)
+    if is_chat:
+        if getattr(args, "response_format", None) is not None:
+            import json as _json
+
+            if isinstance(args.response_format, str):
+                payload["response_format"] = _json.loads(args.response_format)
+            else:
+                payload["response_format"] = args.response_format
+        if getattr(args, "tools", None) is not None:
+            import json as _json
+            from pathlib import Path
+
+            tools_path = Path(args.tools)
+            if tools_path.is_file():
+                with open(tools_path) as f:
+                    payload["tools"] = _json.load(f)
+            else:
+                payload["tools"] = _json.loads(args.tools)
+        if getattr(args, "tool_choice", None) is not None:
+            import json as _json
+
+            try:
+                payload["tool_choice"] = _json.loads(args.tool_choice)
+            except (ValueError, TypeError):
+                payload["tool_choice"] = args.tool_choice
+        if getattr(args, "parallel_tool_calls", None) is not None:
+            payload["parallel_tool_calls"] = args.parallel_tool_calls
+        if getattr(args, "top_logprobs", None) is not None:
+            payload["top_logprobs"] = args.top_logprobs
+        if getattr(args, "max_completion_tokens", None) is not None:
+            payload["max_completion_tokens"] = args.max_completion_tokens
+        if getattr(args, "service_tier", None) is not None:
+            payload["service_tier"] = args.service_tier
+
     return payload
 
 

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -191,6 +191,54 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="[vLLM only] Use beam search instead of sampling. Not in OpenAI API spec.",
     )
 
+    # Chat-specific parameters (OpenAI API)
+    chat_params = parser.add_argument_group(
+        "chat-specific parameters",
+        "Parameters specific to /v1/chat/completions (OpenAI API standard).",
+    )
+    chat_params.add_argument(
+        "--response-format",
+        type=str,
+        default=None,
+        help='Force output format. JSON string, e.g. \'{"type": "json_object"}\'.',
+    )
+    chat_params.add_argument(
+        "--tools",
+        type=str,
+        default=None,
+        help="Path to JSON file defining tools/functions the model may call.",
+    )
+    chat_params.add_argument(
+        "--tool-choice",
+        type=str,
+        default=None,
+        help='Tool choice: "none", "auto", "required", or JSON string for specific function.',
+    )
+    chat_params.add_argument(
+        "--parallel-tool-calls",
+        action="store_true",
+        default=None,
+        help="Allow parallel tool calls (default: server decides).",
+    )
+    chat_params.add_argument(
+        "--top-logprobs",
+        type=int,
+        default=None,
+        help="Number of most likely tokens to return at each position (0-20).",
+    )
+    chat_params.add_argument(
+        "--max-completion-tokens",
+        type=int,
+        default=None,
+        help="Upper bound on completion tokens (newer alternative to max_tokens).",
+    )
+    chat_params.add_argument(
+        "--service-tier",
+        type=str,
+        default=None,
+        help='Latency tier for processing, e.g. "auto" or "default".',
+    )
+
     # Output
     parser.add_argument(
         "--save-result",

--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -489,6 +489,16 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
     ignore_eos = body.get("ignore_eos", False)
     stream_options = body.get("stream_options") or {}
     include_usage = stream_options.get("include_usage", False)
+    # Chat-specific params (accepted but not simulated by dummy)
+    body.get("response_format")
+    body.get("tools")
+    body.get("tool_choice")
+    body.get("parallel_tool_calls")
+    max_completion_tokens = body.get("max_completion_tokens")
+    body.get("service_tier")
+    # Use max_completion_tokens as fallback for max_tokens if provided
+    if max_completion_tokens is not None and body.get("max_tokens") is None:
+        max_tokens = max_completion_tokens
     prompt_tokens = _estimate_prompt_tokens(None, messages)
 
     if stream:

--- a/tests/test_chat_params.py
+++ b/tests/test_chat_params.py
@@ -1,0 +1,267 @@
+"""Tests for issue #20: Chat-specific OpenAI API parameters."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from xpyd_bench.bench.runner import _build_payload
+from xpyd_bench.dummy.server import ServerConfig, create_app
+
+
+@pytest.fixture
+def client():
+    config = ServerConfig(prefill_ms=0, decode_ms=0, model_name="test-model", eos_min_ratio=1.0)
+    app = create_app(config)
+    return TestClient(app)
+
+
+# ── CLI argument tests ────────────────────────────────────────────────
+
+
+class TestChatCLIArgs:
+    """Verify chat-specific CLI arguments exist and parse correctly."""
+
+    def _get_parser(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        return parser
+
+    def test_chat_group_exists(self):
+        parser = self._get_parser()
+        group_titles = [g.title for g in parser._action_groups]
+        assert "chat-specific parameters" in group_titles
+
+    def test_response_format_parses(self):
+        parser = self._get_parser()
+        args = parser.parse_args(["--response-format", '{"type": "json_object"}'])
+        assert args.response_format == '{"type": "json_object"}'
+
+    def test_tools_parses(self):
+        parser = self._get_parser()
+        args = parser.parse_args(["--tools", "/path/to/tools.json"])
+        assert args.tools == "/path/to/tools.json"
+
+    def test_tool_choice_parses(self):
+        parser = self._get_parser()
+        args = parser.parse_args(["--tool-choice", "auto"])
+        assert args.tool_choice == "auto"
+
+    def test_top_logprobs_parses(self):
+        parser = self._get_parser()
+        args = parser.parse_args(["--top-logprobs", "5"])
+        assert args.top_logprobs == 5
+
+    def test_max_completion_tokens_parses(self):
+        parser = self._get_parser()
+        args = parser.parse_args(["--max-completion-tokens", "1024"])
+        assert args.max_completion_tokens == 1024
+
+    def test_service_tier_parses(self):
+        parser = self._get_parser()
+        args = parser.parse_args(["--service-tier", "auto"])
+        assert args.service_tier == "auto"
+
+
+# ── _build_payload tests ─────────────────────────────────────────────
+
+
+class TestBuildPayloadChatParams:
+    """Verify _build_payload includes chat-specific params for chat endpoints."""
+
+    def _make_args(self, **kwargs):
+        defaults = {
+            "output_len": 128,
+            "model": "test",
+            "temperature": None,
+            "top_p": None,
+            "top_k": None,
+            "frequency_penalty": None,
+            "presence_penalty": None,
+            "best_of": None,
+            "use_beam_search": False,
+            "logprobs": None,
+            "ignore_eos": False,
+            "stop": None,
+            "n": None,
+            "api_seed": None,
+            "echo": False,
+            "suffix": None,
+            "logit_bias": None,
+            "user": None,
+            "stream_options_include_usage": False,
+            "response_format": None,
+            "tools": None,
+            "tool_choice": None,
+            "parallel_tool_calls": None,
+            "top_logprobs": None,
+            "max_completion_tokens": None,
+            "service_tier": None,
+        }
+        defaults.update(kwargs)
+        return Namespace(**defaults)
+
+    def test_response_format_included(self):
+        args = self._make_args(response_format='{"type": "json_object"}')
+        payload = _build_payload(args, "hello", is_chat=True)
+        assert payload["response_format"] == {"type": "json_object"}
+
+    def test_response_format_excluded_for_completions(self):
+        args = self._make_args(response_format='{"type": "json_object"}')
+        payload = _build_payload(args, "hello", is_chat=False)
+        assert "response_format" not in payload
+
+    def test_tools_from_file(self):
+        tools_data = [{"type": "function", "function": {"name": "test_fn"}}]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(tools_data, f)
+            f.flush()
+            args = self._make_args(tools=f.name)
+            payload = _build_payload(args, "hello", is_chat=True)
+            assert payload["tools"] == tools_data
+        Path(f.name).unlink()
+
+    def test_tool_choice_string(self):
+        args = self._make_args(tool_choice="auto")
+        payload = _build_payload(args, "hello", is_chat=True)
+        assert payload["tool_choice"] == "auto"
+
+    def test_tool_choice_json(self):
+        args = self._make_args(
+            tool_choice='{"type": "function", "function": {"name": "test_fn"}}'
+        )
+        payload = _build_payload(args, "hello", is_chat=True)
+        assert payload["tool_choice"] == {
+            "type": "function",
+            "function": {"name": "test_fn"},
+        }
+
+    def test_top_logprobs_included(self):
+        args = self._make_args(top_logprobs=5)
+        payload = _build_payload(args, "hello", is_chat=True)
+        assert payload["top_logprobs"] == 5
+
+    def test_max_completion_tokens_included(self):
+        args = self._make_args(max_completion_tokens=1024)
+        payload = _build_payload(args, "hello", is_chat=True)
+        assert payload["max_completion_tokens"] == 1024
+
+    def test_service_tier_included(self):
+        args = self._make_args(service_tier="auto")
+        payload = _build_payload(args, "hello", is_chat=True)
+        assert payload["service_tier"] == "auto"
+
+    def test_none_params_excluded(self):
+        args = self._make_args()
+        payload = _build_payload(args, "hello", is_chat=True)
+        for key in (
+            "response_format",
+            "tools",
+            "tool_choice",
+            "parallel_tool_calls",
+            "top_logprobs",
+            "max_completion_tokens",
+            "service_tier",
+        ):
+            assert key not in payload
+
+
+# ── Dummy server tests ───────────────────────────────────────────────
+
+
+class TestDummyChatParams:
+    """Verify dummy server accepts chat-specific parameters."""
+
+    def test_response_format_accepted(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 5,
+                "response_format": {"type": "json_object"},
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_tools_accepted(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 5,
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {"name": "get_weather", "parameters": {}},
+                    }
+                ],
+                "tool_choice": "auto",
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_max_completion_tokens_as_fallback(self, client):
+        """max_completion_tokens should be used when max_tokens is absent."""
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_completion_tokens": 3,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        tokens = body["choices"][0]["message"]["content"].split()
+        assert len(tokens) == 3
+
+    def test_service_tier_accepted(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 5,
+                "service_tier": "auto",
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_top_logprobs_accepted(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 5,
+                "logprobs": True,
+                "top_logprobs": 3,
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_streaming_with_chat_params(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 3,
+                "stream": True,
+                "response_format": {"type": "json_object"},
+                "service_tier": "auto",
+            },
+        )
+        assert resp.status_code == 200
+        assert "data: " in resp.text


### PR DESCRIPTION
## Summary

Add support for chat-specific OpenAI API parameters that were missing from the bench client.

## New Parameters

- `--response-format`: Force JSON output (`{"type": "json_object"}`)
- `--tools`: Path to JSON file defining tools/functions
- `--tool-choice`: Controls tool calling behavior ("none", "auto", "required", or JSON)
- `--parallel-tool-calls`: Allow parallel tool calls
- `--top-logprobs`: Number of most likely tokens at each position (0-20)
- `--max-completion-tokens`: Upper bound on completion tokens (newer alternative to max_tokens)
- `--service-tier`: Latency tier for processing

## Changes

- Added CLI argument group "chat-specific parameters" 
- Updated `_build_payload()` to include these params only for chat endpoints
- Updated dummy server to accept all new params (max_completion_tokens used as fallback for max_tokens)
- Added 22 tests covering CLI parsing, payload building, and dummy server acceptance

Closes #20