### PR TITLE
feat: configurable request timeout and retry logic

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,3 +68,11 @@
 - Works with completions, chat, streaming and non-streaming
 - YAML config support (`warmup: N`)
 - Tests covering warmup logic and metrics exclusion
+
+## M10: Configurable Timeouts & Retry Logic
+- `--timeout SECONDS` CLI flag for per-request HTTP timeout (default 300s)
+- `--retries N` for automatic retry on transient errors (connection, 429, 503)
+- `--retry-delay SECONDS` with exponential backoff (delay * 2^attempt)
+- RequestResult tracks `retries` count
+- YAML config support (`timeout`, `retries`, `retry_delay`)
+- Tests covering timeout, retry success, retry exhaustion, backoff

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -15,6 +15,7 @@ class RequestResult:
     tpot_ms: float | None = None  # Time per output token
     itl_ms: list[float] = field(default_factory=list)  # Inter-token latencies
     latency_ms: float = 0.0  # End-to-end latency
+    retries: int = 0
     success: bool = True
     error: str | None = None
 

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -97,39 +97,73 @@ def _generate_intervals(
 # ---------------------------------------------------------------------------
 
 
+# Status codes that are retryable
+_RETRYABLE_STATUS_CODES = {429, 503}
+
+
+def _is_retryable(exc: Exception) -> bool:
+    """Check if an exception is retryable (connection error or retryable HTTP status)."""
+    if isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in _RETRYABLE_STATUS_CODES
+    return False
+
+
 async def _send_request(
     client: httpx.AsyncClient,
     url: str,
     payload: dict[str, Any],
     is_streaming: bool,
+    request_timeout: float = 300.0,
+    retries: int = 0,
+    retry_delay: float = 1.0,
 ) -> RequestResult:
-    """Send one request and collect metrics."""
-    result = RequestResult()
-    start = time.perf_counter()
+    """Send one request and collect metrics, with optional retry."""
+    last_result = RequestResult()
+    attempts = 0
 
-    try:
-        if is_streaming:
-            result = await _send_streaming(client, url, payload, start)
-        else:
-            resp = await client.post(url, json=payload, timeout=300.0)
-            resp.raise_for_status()
+    for attempt in range(retries + 1):
+        attempts = attempt
+        result = RequestResult()
+        start = time.perf_counter()
+
+        try:
+            if is_streaming:
+                result = await _send_streaming(
+                    client, url, payload, start, request_timeout=request_timeout
+                )
+            else:
+                resp = await client.post(url, json=payload, timeout=request_timeout)
+                resp.raise_for_status()
+                end = time.perf_counter()
+                result.latency_ms = (end - start) * 1000.0
+
+                body = resp.json()
+                usage = body.get("usage", {})
+                result.prompt_tokens = usage.get("prompt_tokens", 0)
+                result.completion_tokens = usage.get("completion_tokens", 0)
+                if result.completion_tokens > 0:
+                    result.tpot_ms = result.latency_ms / result.completion_tokens
+
+        except Exception as exc:  # noqa: BLE001
             end = time.perf_counter()
             result.latency_ms = (end - start) * 1000.0
+            result.success = False
+            result.error = str(exc)
 
-            body = resp.json()
-            usage = body.get("usage", {})
-            result.prompt_tokens = usage.get("prompt_tokens", 0)
-            result.completion_tokens = usage.get("completion_tokens", 0)
-            if result.completion_tokens > 0:
-                result.tpot_ms = result.latency_ms / result.completion_tokens
+            # Retry if applicable
+            if attempt < retries and _is_retryable(exc):
+                delay = retry_delay * (2**attempt)
+                await asyncio.sleep(delay)
+                continue
 
-    except Exception as exc:  # noqa: BLE001
-        end = time.perf_counter()
-        result.latency_ms = (end - start) * 1000.0
-        result.success = False
-        result.error = str(exc)
+        result.retries = attempt
+        return result
 
-    return result
+    # Should not reach here, but just in case
+    last_result.retries = attempts
+    return last_result
 
 
 async def _send_streaming(
@@ -137,6 +171,7 @@ async def _send_streaming(
     url: str,
     payload: dict[str, Any],
     start: float,
+    request_timeout: float = 300.0,
 ) -> RequestResult:
     """Send a streaming request, measure TTFT / ITL."""
     result = RequestResult()
@@ -147,7 +182,7 @@ async def _send_streaming(
     stream_usage: dict[str, Any] | None = None
 
     try:
-        async with client.stream("POST", url, json=payload, timeout=300.0) as resp:
+        async with client.stream("POST", url, json=payload, timeout=request_timeout) as resp:
             resp.raise_for_status()
             async for line in resp.aiter_lines():
                 if not line.startswith("data: "):
@@ -411,14 +446,25 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         output_len=args.output_len,
     )
 
+    # Timeout & retry settings
+    request_timeout = getattr(args, "timeout", 300.0) or 300.0
+    req_retries = getattr(args, "retries", 0) or 0
+    req_retry_delay = getattr(args, "retry_delay", 1.0) or 1.0
+
     async def _task(client: httpx.AsyncClient, prompt: str) -> RequestResult:
         if semaphore:
             async with semaphore:
                 return await _send_request(
-                    client, url, _build_payload(args, prompt, is_chat), is_streaming
+                    client, url, _build_payload(args, prompt, is_chat), is_streaming,
+                    request_timeout=request_timeout,
+                    retries=req_retries,
+                    retry_delay=req_retry_delay,
                 )
         return await _send_request(
-            client, url, _build_payload(args, prompt, is_chat), is_streaming
+            client, url, _build_payload(args, prompt, is_chat), is_streaming,
+            request_timeout=request_timeout,
+            retries=req_retries,
+            retry_delay=req_retry_delay,
         )
 
     # Rich progress bar

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -273,6 +273,26 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         "(excluded from metrics). Default: 0.",
     )
 
+    # Timeout & retry
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=300.0,
+        help="Per-request HTTP timeout in seconds (default: 300).",
+    )
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=0,
+        help="Number of retries on transient errors (connection, 429, 503). Default: 0.",
+    )
+    parser.add_argument(
+        "--retry-delay",
+        type=float,
+        default=1.0,
+        help="Base delay between retries in seconds, with exponential backoff. Default: 1.0.",
+    )
+
     # Extended config
     parser.add_argument(
         "--config",

--- a/tests/test_timeout_retry.py
+++ b/tests/test_timeout_retry.py
@@ -1,0 +1,265 @@
+"""Tests for configurable timeout and retry logic (M10)."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from xpyd_bench.bench.models import RequestResult
+from xpyd_bench.bench.runner import _is_retryable, _send_request
+
+# ---------------------------------------------------------------------------
+# _is_retryable tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsRetryable:
+    def test_connect_error(self):
+        exc = httpx.ConnectError("connection refused")
+        assert _is_retryable(exc) is True
+
+    def test_connect_timeout(self):
+        exc = httpx.ConnectTimeout("timed out")
+        assert _is_retryable(exc) is True
+
+    def test_pool_timeout(self):
+        exc = httpx.PoolTimeout("pool full")
+        assert _is_retryable(exc) is True
+
+    def test_http_429(self):
+        resp = httpx.Response(429, request=httpx.Request("POST", "http://x"))
+        exc = httpx.HTTPStatusError("rate limit", request=resp.request, response=resp)
+        assert _is_retryable(exc) is True
+
+    def test_http_503(self):
+        resp = httpx.Response(503, request=httpx.Request("POST", "http://x"))
+        exc = httpx.HTTPStatusError("unavailable", request=resp.request, response=resp)
+        assert _is_retryable(exc) is True
+
+    def test_http_400_not_retryable(self):
+        resp = httpx.Response(400, request=httpx.Request("POST", "http://x"))
+        exc = httpx.HTTPStatusError("bad request", request=resp.request, response=resp)
+        assert _is_retryable(exc) is False
+
+    def test_http_500_not_retryable(self):
+        resp = httpx.Response(500, request=httpx.Request("POST", "http://x"))
+        exc = httpx.HTTPStatusError("server error", request=resp.request, response=resp)
+        assert _is_retryable(exc) is False
+
+    def test_generic_exception_not_retryable(self):
+        exc = ValueError("something")
+        assert _is_retryable(exc) is False
+
+
+# ---------------------------------------------------------------------------
+# _send_request with timeout
+# ---------------------------------------------------------------------------
+
+
+class TestTimeout:
+    @pytest.mark.asyncio
+    async def test_custom_timeout_passed_to_client(self):
+        """Verify custom timeout is used for non-streaming requests."""
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"usage": {"prompt_tokens": 5, "completion_tokens": 3}}
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.return_value = mock_resp
+
+        result = await _send_request(
+            mock_client, "http://test/v1/completions", {"prompt": "hi"}, False,
+            request_timeout=42.0,
+        )
+
+        assert result.success is True
+        mock_client.post.assert_called_once()
+        _, kwargs = mock_client.post.call_args
+        assert kwargs["timeout"] == 42.0
+
+
+# ---------------------------------------------------------------------------
+# _send_request with retries
+# ---------------------------------------------------------------------------
+
+
+class TestRetry:
+    @pytest.mark.asyncio
+    async def test_retry_on_connect_error_then_succeed(self):
+        """First call fails with ConnectError, second succeeds."""
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"usage": {"prompt_tokens": 5, "completion_tokens": 3}}
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.side_effect = [
+            httpx.ConnectError("refused"),
+            mock_resp,
+        ]
+
+        result = await _send_request(
+            mock_client, "http://test/v1/completions", {"prompt": "hi"}, False,
+            retries=2, retry_delay=0.01,
+        )
+
+        assert result.success is True
+        assert result.retries == 1
+        assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_exhausted(self):
+        """All retries fail → final result is failure."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.side_effect = httpx.ConnectError("refused")
+
+        result = await _send_request(
+            mock_client, "http://test/v1/completions", {"prompt": "hi"}, False,
+            retries=2, retry_delay=0.01,
+        )
+
+        assert result.success is False
+        assert result.retries == 2
+        assert mock_client.post.call_count == 3  # 1 initial + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_non_retryable_error(self):
+        """Non-retryable errors should not be retried."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.side_effect = ValueError("bad value")
+
+        result = await _send_request(
+            mock_client, "http://test/v1/completions", {"prompt": "hi"}, False,
+            retries=3, retry_delay=0.01,
+        )
+
+        assert result.success is False
+        assert result.retries == 0
+        assert mock_client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_on_429(self):
+        """HTTP 429 should trigger retry."""
+        resp_429 = httpx.Response(429, request=httpx.Request("POST", "http://test"))
+        resp_ok = MagicMock()
+        resp_ok.raise_for_status = MagicMock()
+        resp_ok.json.return_value = {"usage": {"prompt_tokens": 5, "completion_tokens": 3}}
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.side_effect = [
+            httpx.HTTPStatusError("rate limit", request=resp_429.request, response=resp_429),
+            resp_ok,
+        ]
+
+        result = await _send_request(
+            mock_client, "http://test/v1/completions", {"prompt": "hi"}, False,
+            retries=1, retry_delay=0.01,
+        )
+
+        assert result.success is True
+        assert result.retries == 1
+
+    @pytest.mark.asyncio
+    async def test_exponential_backoff_timing(self):
+        """Verify exponential backoff increases delay between retries."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.side_effect = httpx.ConnectError("refused")
+
+        start = time.monotonic()
+        result = await _send_request(
+            mock_client, "http://test/v1/completions", {"prompt": "hi"}, False,
+            retries=2, retry_delay=0.05,
+        )
+        elapsed = time.monotonic() - start
+
+        # retry_delay=0.05: attempt 0→1 sleeps 0.05, attempt 1→2 sleeps 0.10
+        # total minimum sleep ≈ 0.15s
+        assert result.success is False
+        assert elapsed >= 0.12  # allow small timing margin
+
+    @pytest.mark.asyncio
+    async def test_zero_retries_no_retry(self):
+        """retries=0 means no retry at all."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.side_effect = httpx.ConnectError("refused")
+
+        result = await _send_request(
+            mock_client, "http://test/v1/completions", {"prompt": "hi"}, False,
+            retries=0, retry_delay=0.01,
+        )
+
+        assert result.success is False
+        assert result.retries == 0
+        assert mock_client.post.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# RequestResult.retries field
+# ---------------------------------------------------------------------------
+
+
+class TestRequestResultRetries:
+    def test_default_retries(self):
+        r = RequestResult()
+        assert r.retries == 0
+
+    def test_retries_field(self):
+        r = RequestResult(retries=3)
+        assert r.retries == 3
+
+
+# ---------------------------------------------------------------------------
+# CLI argument tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLIArgs:
+    def test_timeout_arg(self):
+
+        import argparse
+
+        # Just test the parser accepts the args
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+
+        args = parser.parse_args(["--timeout", "60"])
+        assert args.timeout == 60.0
+
+    def test_retries_arg(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+
+        args = parser.parse_args(["--retries", "3"])
+        assert args.retries == 3
+
+    def test_retry_delay_arg(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+
+        args = parser.parse_args(["--retry-delay", "2.5"])
+        assert args.retry_delay == 2.5
+
+    def test_default_values(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+
+        args = parser.parse_args([])
+        assert args.timeout == 300.0
+        assert args.retries == 0
+        assert args.retry_delay == 1.0


### PR DESCRIPTION
## Summary

Add configurable per-request HTTP timeout and automatic retry with exponential backoff for transient failures.

## Changes

- **CLI**: `--timeout SECONDS` (default 300), `--retries N` (default 0), `--retry-delay SECONDS` (default 1.0)
- **Runner**: Retry on connection errors, HTTP 429/503 with exponential backoff (delay × 2^attempt)
- **Models**: `RequestResult.retries` field tracks retry count per request
- **YAML config**: Supports `timeout`, `retries`, `retry_delay` keys
- **Tests**: 21 new tests covering retryable detection, timeout propagation, retry success/exhaustion, backoff timing, CLI args

## Milestone

M10: Configurable Timeouts & Retry Logic

Closes #36