### PR TITLE
feat: API key authentication support (--api-key / OPENAI_API_KEY)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,3 +76,11 @@
 - RequestResult tracks `retries` count
 - YAML config support (`timeout`, `retries`, `retry_delay`)
 - Tests covering timeout, retry success, retry exhaustion, backoff
+
+## M11: API Key Authentication
+- `--api-key` CLI flag for Bearer token authentication
+- `OPENAI_API_KEY` environment variable fallback when `--api-key` not provided
+- Authorization header (`Bearer <key>`) added to all HTTP requests
+- YAML config support (`api_key`)
+- Dummy server optionally validates API key (`--require-api-key`)
+- Tests covering auth header injection, env var fallback, missing key error, dummy server validation

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -399,6 +399,12 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     is_streaming = is_chat  # streaming by default for chat endpoint
     url = f"{base_url}{args.endpoint}"
 
+    # Build default headers (authentication)
+    headers: dict[str, str] = {}
+    api_key = getattr(args, "api_key", None)
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
     # Generate or load prompts
     dataset_path = getattr(args, "dataset_path", None)
     if dataset_path:
@@ -483,7 +489,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         warmup_prompts = prompts[:warmup_count] if len(prompts) >= warmup_count else (
             prompts * ((warmup_count // len(prompts)) + 1)
         )[:warmup_count]
-        async with httpx.AsyncClient() as warmup_client:
+        async with httpx.AsyncClient(headers=headers) as warmup_client:
             for wi, wp in enumerate(warmup_prompts):
                 payload = _build_payload(args, wp, is_chat)
                 wr = await _send_request(warmup_client, url, payload, is_streaming)
@@ -505,7 +511,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
             reporter.advance(success=r.success)
         return r
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(headers=headers) as client:
         for i, prompt in enumerate(prompts):
             if i > 0:
                 await asyncio.sleep(intervals[i])

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -273,6 +273,15 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         "(excluded from metrics). Default: 0.",
     )
 
+    # Authentication
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="API key for Bearer token authentication. "
+        "Falls back to OPENAI_API_KEY env var if not provided.",
+    )
+
     # Timeout & retry
     parser.add_argument(
         "--timeout",
@@ -409,6 +418,12 @@ def bench_main(argv: list[str] | None = None) -> None:
         args = _load_yaml_config(args.config, args)
 
     base_url = _resolve_base_url(args)
+
+    # Resolve API key: CLI > YAML config > env var
+    import os
+
+    if args.api_key is None:
+        args.api_key = os.environ.get("OPENAI_API_KEY")
 
     from xpyd_bench import __version__
     from xpyd_bench.bench.runner import run_benchmark

--- a/src/xpyd_bench/dummy/cli.py
+++ b/src/xpyd_bench/dummy/cli.py
@@ -45,6 +45,12 @@ def dummy_main(argv: list[str] | None = None) -> None:
         default=0.5,
         help="Minimum fraction of max_tokens before EOS can fire (default: 0.5).",
     )
+    parser.add_argument(
+        "--require-api-key",
+        type=str,
+        default=None,
+        help="Require this API key for authentication. Returns 401 for missing/wrong key.",
+    )
     args = parser.parse_args(argv)
 
     import uvicorn
@@ -57,6 +63,7 @@ def dummy_main(argv: list[str] | None = None) -> None:
         model_name=args.model_name,
         max_tokens_default=args.max_tokens_default,
         eos_min_ratio=args.eos_min_ratio,
+        require_api_key=args.require_api_key,
     )
     app = create_app(config)
 

--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -24,6 +24,7 @@ class ServerConfig:
     model_name: str = "dummy-model"
     max_tokens_default: int = 128
     eos_min_ratio: float = 0.5  # EOS won't fire before this fraction of max_tokens
+    require_api_key: str | None = None  # If set, require this API key for auth
 
 
 # Global config — set before starting the server
@@ -738,10 +739,30 @@ def create_app(config: ServerConfig | None = None) -> Starlette:
     if config is not None:
         set_config(config)
 
+    from starlette.middleware import Middleware
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    class AuthMiddleware(BaseHTTPMiddleware):
+        """Optionally enforce Bearer token auth."""
+
+        async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+            cfg = _config
+            if cfg.require_api_key and request.url.path.startswith("/v1/"):
+                auth = request.headers.get("authorization", "")
+                expected = f"Bearer {cfg.require_api_key}"
+                if auth != expected:
+                    return JSONResponse(
+                        {"error": {"message": "Invalid API key", "type": "auth_error"}},
+                        status_code=401,
+                    )
+            return await call_next(request)
+
     routes = [
         Route("/v1/completions", _handle_completions, methods=["POST"]),
         Route("/v1/chat/completions", _handle_chat_completions, methods=["POST"]),
         Route("/v1/models", _handle_models, methods=["GET"]),
         Route("/health", _handle_health, methods=["GET"]),
     ]
-    return Starlette(routes=routes)
+
+    middleware = [Middleware(AuthMiddleware)]
+    return Starlette(routes=routes, middleware=middleware)

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,0 +1,352 @@
+"""Tests for API key authentication (M11)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from argparse import Namespace
+from unittest.mock import patch
+
+import httpx
+import pytest
+import uvicorn
+
+from xpyd_bench.dummy.server import ServerConfig, create_app
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _find_free_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+async def _wait_healthy(base: str, timeout: float = 5.0) -> None:
+    async with httpx.AsyncClient() as c:
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                r = await c.get(f"{base}/health")
+                if r.status_code == 200:
+                    return
+            except httpx.ConnectError:
+                pass
+            await asyncio.sleep(0.1)
+    raise TimeoutError("server did not become healthy")
+
+
+# ---------------------------------------------------------------------------
+# CLI argument tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLIApiKeyArg:
+    """Test --api-key CLI argument parsing."""
+
+    def test_api_key_parsed(self) -> None:
+
+        import argparse
+
+        # Just verify the argument is accepted by the parser
+        parser = argparse.ArgumentParser()
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--api-key", "sk-test123"])
+        assert args.api_key == "sk-test123"
+
+    def test_api_key_default_none(self) -> None:
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        assert args.api_key is None
+
+    def test_api_key_env_fallback(self) -> None:
+        """OPENAI_API_KEY env var is used when --api-key not provided."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+
+        # Simulate what bench_main does
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-from-env"}):
+            if args.api_key is None:
+                args.api_key = os.environ.get("OPENAI_API_KEY")
+        assert args.api_key == "sk-from-env"
+
+    def test_api_key_cli_overrides_env(self) -> None:
+        """--api-key takes precedence over env var."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--api-key", "sk-cli"])
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-from-env"}):
+            if args.api_key is None:
+                args.api_key = os.environ.get("OPENAI_API_KEY")
+        assert args.api_key == "sk-cli"
+
+
+# ---------------------------------------------------------------------------
+# Dummy server auth tests
+# ---------------------------------------------------------------------------
+
+
+class TestDummyServerAuth:
+    """Test dummy server --require-api-key."""
+
+    @pytest.fixture()
+    def _server_with_auth(self):
+        """Start a dummy server that requires an API key."""
+        port = _find_free_port()
+        config = ServerConfig(
+            prefill_ms=1.0,
+            decode_ms=1.0,
+            model_name="test-model",
+            require_api_key="sk-secret",
+        )
+        app = create_app(config)
+
+        server = uvicorn.Server(
+            uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+        )
+
+        loop = asyncio.new_event_loop()
+        thread = None
+
+        import threading
+
+        def run():
+            loop.run_until_complete(server.serve())
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+
+        base = f"http://127.0.0.1:{port}"
+        asyncio.get_event_loop().run_until_complete(_wait_healthy(base))
+        yield base
+        server.should_exit = True
+        thread.join(timeout=3)
+
+    @pytest.fixture()
+    def server_url(self, _server_with_auth):
+        return _server_with_auth
+
+    def test_request_without_key_returns_401(self, server_url: str) -> None:
+        import httpx as hx
+
+        r = hx.post(
+            f"{server_url}/v1/completions",
+            json={"prompt": "hello", "max_tokens": 1, "model": "test-model"},
+        )
+        assert r.status_code == 401
+        assert "auth_error" in r.json()["error"]["type"]
+
+    def test_request_with_wrong_key_returns_401(self, server_url: str) -> None:
+        import httpx as hx
+
+        r = hx.post(
+            f"{server_url}/v1/completions",
+            json={"prompt": "hello", "max_tokens": 1, "model": "test-model"},
+            headers={"Authorization": "Bearer wrong-key"},
+        )
+        assert r.status_code == 401
+
+    def test_request_with_correct_key_succeeds(self, server_url: str) -> None:
+        import httpx as hx
+
+        r = hx.post(
+            f"{server_url}/v1/completions",
+            json={"prompt": "hello", "max_tokens": 1, "model": "test-model"},
+            headers={"Authorization": "Bearer sk-secret"},
+        )
+        assert r.status_code == 200
+
+    def test_health_endpoint_no_auth_required(self, server_url: str) -> None:
+        import httpx as hx
+
+        r = hx.get(f"{server_url}/health")
+        assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Runner auth header injection test
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerAuthHeaders:
+    """Test that runner injects Authorization header."""
+
+    @pytest.fixture()
+    def _server_no_auth(self):
+        """Start a dummy server without auth requirement."""
+        port = _find_free_port()
+        config = ServerConfig(
+            prefill_ms=1.0,
+            decode_ms=1.0,
+            model_name="test-model",
+        )
+        app = create_app(config)
+        server = uvicorn.Server(
+            uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+        )
+        loop = asyncio.new_event_loop()
+
+        import threading
+
+        def run():
+            loop.run_until_complete(server.serve())
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        base = f"http://127.0.0.1:{port}"
+        asyncio.get_event_loop().run_until_complete(_wait_healthy(base))
+        yield base
+        server.should_exit = True
+        thread.join(timeout=3)
+
+    @pytest.fixture()
+    def _server_with_key(self):
+        """Start a dummy server requiring auth."""
+        port = _find_free_port()
+        config = ServerConfig(
+            prefill_ms=1.0,
+            decode_ms=1.0,
+            model_name="test-model",
+            require_api_key="sk-runner-test",
+        )
+        app = create_app(config)
+        server = uvicorn.Server(
+            uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+        )
+        loop = asyncio.new_event_loop()
+
+        import threading
+
+        def run():
+            loop.run_until_complete(server.serve())
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        base = f"http://127.0.0.1:{port}"
+        asyncio.get_event_loop().run_until_complete(_wait_healthy(base))
+        yield base
+        server.should_exit = True
+        thread.join(timeout=3)
+
+    async def test_runner_sends_auth_header(self, _server_with_key: str) -> None:
+        """Benchmark runner sends Authorization header when api_key is set."""
+        from xpyd_bench.bench.runner import run_benchmark
+
+        base_url = _server_with_key
+        args = Namespace(
+            backend="openai",
+            endpoint="/v1/completions",
+            model="test-model",
+            num_prompts=2,
+            request_rate=float("inf"),
+            burstiness=1.0,
+            max_concurrency=None,
+            input_len=8,
+            output_len=4,
+            seed=42,
+            dataset_name="random",
+            dataset_path=None,
+            disable_tqdm=True,
+            save_result=False,
+            rich_progress=False,
+            warmup=0,
+            timeout=10.0,
+            retries=0,
+            retry_delay=1.0,
+            api_key="sk-runner-test",
+            # Sampling params
+            temperature=None,
+            top_p=None,
+            top_k=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            best_of=None,
+            use_beam_search=False,
+            logprobs=None,
+            ignore_eos=False,
+            stop=None,
+            n=None,
+            api_seed=None,
+            echo=False,
+            suffix=None,
+            logit_bias=None,
+            user=None,
+            stream_options_include_usage=False,
+        )
+
+        result_dict, bench_result = await run_benchmark(args, base_url)
+        assert bench_result.completed == 2
+        assert bench_result.failed == 0
+
+    async def test_runner_fails_without_key_when_required(
+        self, _server_with_key: str
+    ) -> None:
+        """Requests fail when server requires key but none provided."""
+        from xpyd_bench.bench.runner import run_benchmark
+
+        base_url = _server_with_key
+        args = Namespace(
+            backend="openai",
+            endpoint="/v1/completions",
+            model="test-model",
+            num_prompts=1,
+            request_rate=float("inf"),
+            burstiness=1.0,
+            max_concurrency=None,
+            input_len=8,
+            output_len=4,
+            seed=42,
+            dataset_name="random",
+            dataset_path=None,
+            disable_tqdm=True,
+            save_result=False,
+            rich_progress=False,
+            warmup=0,
+            timeout=10.0,
+            retries=0,
+            retry_delay=1.0,
+            api_key=None,
+            # Sampling params
+            temperature=None,
+            top_p=None,
+            top_k=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            best_of=None,
+            use_beam_search=False,
+            logprobs=None,
+            ignore_eos=False,
+            stop=None,
+            n=None,
+            api_seed=None,
+            echo=False,
+            suffix=None,
+            logit_bias=None,
+            user=None,
+            stream_options_include_usage=False,
+        )
+
+        result_dict, bench_result = await run_benchmark(args, base_url)
+        # All requests should fail with 401
+        assert bench_result.failed == 1
+        assert bench_result.completed == 0

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -148,7 +148,7 @@ async def test_warmup_sends_extra_requests():
     call_idx = {"i": 0}
 
     class MultiClient:
-        def __init__(self):
+        def __init__(self, **kwargs):
             self.idx = call_idx["i"]
             call_idx["i"] += 1
             self._client = clients[self.idx] if self.idx < len(clients) else FakeAsyncClient()
@@ -182,7 +182,7 @@ async def test_warmup_excluded_from_metrics():
     call_idx = {"i": 0}
 
     class MultiClient:
-        def __init__(self):
+        def __init__(self, **kwargs):
             self.idx = call_idx["i"]
             call_idx["i"] += 1
             self._client = clients[self.idx] if self.idx < len(clients) else FakeAsyncClient()
@@ -268,7 +268,7 @@ async def test_warmup_with_chat_endpoint():
     call_idx = {"i": 0}
 
     class MultiClient:
-        def __init__(self):
+        def __init__(self, **kwargs):
             self.idx = call_idx["i"]
             call_idx["i"] += 1
             self._client = (


### PR DESCRIPTION
## Summary
Add API key authentication support for benchmarking real OpenAI-compatible endpoints.

## Changes
- `--api-key` CLI flag for Bearer token authentication
- `OPENAI_API_KEY` environment variable fallback when `--api-key` not provided
- `Authorization: Bearer <key>` header injected into all HTTP requests (warmup + benchmark)
- Dummy server `--require-api-key KEY` flag returns 401 for missing/wrong keys
- Auth middleware on `/v1/*` endpoints; health endpoint remains open
- Fix existing warmup tests for `httpx.AsyncClient(headers=...)` compatibility
- M11 added to ROADMAP.md
- 10 new tests: CLI args, env fallback, dummy server auth validation, runner integration

## Testing
- All 267 tests pass
- Lint clean: `ruff check` + `isort --check`

Closes #38