### PR TITLE
feat(m12): graceful shutdown & progress persistence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,3 +84,12 @@
 - YAML config support (`api_key`)
 - Dummy server optionally validates API key (`--require-api-key`)
 - Tests covering auth header injection, env var fallback, missing key error, dummy server validation
+
+## M12: Graceful Shutdown & Progress Persistence
+- SIGINT during benchmark triggers graceful shutdown instead of losing all data
+- In-flight requests get a grace period (default 5s) to complete
+- Partial `BenchmarkResult` computed from completed requests
+- Result JSON includes `"partial": true` flag
+- `--save-result` saves partial results
+- Compare tool warns when comparing partial results
+- Tests covering graceful shutdown, partial metrics, and compare warnings

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -73,3 +73,6 @@ class BenchmarkResult:
     p90_e2el_ms: float = 0.0
     p95_e2el_ms: float = 0.0
     p99_e2el_ms: float = 0.0
+
+    # Partial result flag (set when benchmark was interrupted)
+    partial: bool = False

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import random
+import signal
 import time
 from argparse import Namespace
 from typing import Any
@@ -504,6 +505,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
 
     tasks: list[asyncio.Task] = []
     overall_start = time.perf_counter()
+    shutdown_requested = False
 
     async def _tracked_task(client: httpx.AsyncClient, prompt: str) -> RequestResult:
         r = await _task(client, prompt)
@@ -511,27 +513,79 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
             reporter.advance(success=r.success)
         return r
 
+    grace_period = getattr(args, "shutdown_grace_period", 5.0) or 5.0
+
     async with httpx.AsyncClient(headers=headers) as client:
+        # Install signal handler for graceful shutdown
+        loop = asyncio.get_running_loop()
+
+        def _signal_handler() -> None:
+            nonlocal shutdown_requested
+            if not shutdown_requested:
+                shutdown_requested = True
+                print("\n⚠️  SIGINT received — graceful shutdown initiated. "
+                      "Waiting for in-flight requests...")
+
+        try:
+            loop.add_signal_handler(signal.SIGINT, _signal_handler)
+        except NotImplementedError:
+            pass  # Windows doesn't support add_signal_handler
+
         for i, prompt in enumerate(prompts):
+            if shutdown_requested:
+                break
             if i > 0:
                 await asyncio.sleep(intervals[i])
+                if shutdown_requested:
+                    break
             task = asyncio.create_task(_tracked_task(client, prompt))
             tasks.append(task)
 
             if not use_rich and not args.disable_tqdm and (i + 1) % 100 == 0:
                 print(f"  Launched {i + 1}/{args.num_prompts} requests...")
 
-        # Wait for all to complete
-        results_list = await asyncio.gather(*tasks)
+        # Wait for all launched tasks to complete (with grace period if shutting down)
+        if shutdown_requested and tasks:
+            done, pending = await asyncio.wait(
+                tasks, timeout=grace_period, return_when=asyncio.ALL_COMPLETED
+            )
+            for t in pending:
+                t.cancel()
+            # Suppress CancelledError from cancelled tasks
+            await asyncio.gather(*pending, return_exceptions=True)
+        elif tasks:
+            await asyncio.gather(*tasks)
+
+        try:
+            loop.remove_signal_handler(signal.SIGINT)
+        except NotImplementedError:
+            pass
 
     overall_end = time.perf_counter()
     if reporter:
         reporter.stop()
 
+    # Collect results from completed (non-cancelled) tasks
+    results_list = []
+    for t in tasks:
+        if t.done() and not t.cancelled():
+            try:
+                results_list.append(t.result())
+            except Exception:  # noqa: BLE001
+                pass
+
     result.total_duration_s = overall_end - overall_start
-    result.requests = list(results_list)
+    result.requests = results_list
+    result.partial = shutdown_requested
 
     _compute_metrics(result)
+
+    if shutdown_requested:
+        print(
+            f"\n⚠️  Partial results: {result.completed} completed, "
+            f"{len(prompts) - len(tasks)} not launched, "
+            f"{len(tasks) - len(results_list)} cancelled"
+        )
 
     if reporter:
         reporter.print_summary_table(result)
@@ -591,4 +645,6 @@ def _to_dict(r: BenchmarkResult) -> dict:
         for stat in ("mean", "median", "p50", "p90", "p95", "p99"):
             key = f"{stat}_{prefix}_ms"
             d[key] = getattr(r, key)
+    if r.partial:
+        d["partial"] = True
     return d

--- a/src/xpyd_bench/compare.py
+++ b/src/xpyd_bench/compare.py
@@ -66,10 +66,12 @@ class ComparisonResult:
     metrics: list[MetricDelta]
     has_regression: bool
     threshold_pct: float
+    baseline_partial: bool = False
+    candidate_partial: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-friendly dict."""
-        return {
+        d: dict[str, Any] = {
             "threshold_pct": self.threshold_pct,
             "has_regression": self.has_regression,
             "metrics": [
@@ -85,6 +87,11 @@ class ComparisonResult:
                 for m in self.metrics
             ],
         }
+        if self.baseline_partial:
+            d["baseline_partial"] = True
+        if self.candidate_partial:
+            d["candidate_partial"] = True
+        return d
 
 
 def _extract_metrics(data: dict[str, Any]) -> dict[str, float]:
@@ -177,6 +184,8 @@ def compare(
         metrics=deltas,
         has_regression=has_regression,
         threshold_pct=threshold_pct,
+        baseline_partial=bool(baseline.get("partial")),
+        candidate_partial=bool(candidate.get("partial")),
     )
 
 
@@ -186,6 +195,19 @@ def format_comparison_table(result: ComparisonResult) -> str:
     lines.append("=" * 90)
     lines.append("  xPyD-bench — Benchmark Comparison")
     lines.append(f"  Regression threshold: {result.threshold_pct}%")
+
+    # Warn about partial results
+    warnings: list[str] = []
+    if result.baseline_partial:
+        warnings.append("baseline")
+    if result.candidate_partial:
+        warnings.append("candidate")
+    if warnings:
+        lines.append(
+            f"  ⚠️  WARNING: {' and '.join(warnings)} result(s) are PARTIAL "
+            "(benchmark was interrupted)"
+        )
+
     lines.append("=" * 90)
     lines.append("")
 

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -1,0 +1,171 @@
+"""Tests for M12: Graceful Shutdown & Progress Persistence."""
+
+from __future__ import annotations
+
+from xpyd_bench.bench.models import BenchmarkResult, RequestResult
+from xpyd_bench.bench.runner import _compute_metrics, _to_dict
+from xpyd_bench.compare import compare, format_comparison_table
+
+# ---------------------------------------------------------------------------
+# BenchmarkResult.partial field
+# ---------------------------------------------------------------------------
+
+
+class TestPartialFlag:
+    """Test that the partial flag is correctly set and serialized."""
+
+    def test_default_not_partial(self) -> None:
+        result = BenchmarkResult()
+        assert result.partial is False
+
+    def test_partial_flag_set(self) -> None:
+        result = BenchmarkResult(partial=True)
+        assert result.partial is True
+
+    def test_to_dict_includes_partial_when_true(self) -> None:
+        result = BenchmarkResult(partial=True)
+        d = _to_dict(result)
+        assert d["partial"] is True
+
+    def test_to_dict_excludes_partial_when_false(self) -> None:
+        result = BenchmarkResult(partial=False)
+        d = _to_dict(result)
+        assert "partial" not in d
+
+
+# ---------------------------------------------------------------------------
+# Partial results produce valid metrics
+# ---------------------------------------------------------------------------
+
+
+class TestPartialMetrics:
+    """Verify that _compute_metrics works on partial (incomplete) results."""
+
+    def test_metrics_from_subset(self) -> None:
+        result = BenchmarkResult(partial=True)
+        result.total_duration_s = 2.0
+        result.requests = [
+            RequestResult(
+                prompt_tokens=10,
+                completion_tokens=20,
+                latency_ms=100.0,
+                success=True,
+            ),
+            RequestResult(
+                prompt_tokens=10,
+                completion_tokens=20,
+                latency_ms=150.0,
+                success=True,
+            ),
+        ]
+        _compute_metrics(result)
+        assert result.completed == 2
+        assert result.failed == 0
+        assert result.request_throughput > 0
+        assert result.total_input_tokens == 20
+        assert result.total_output_tokens == 40
+
+    def test_metrics_with_mixed_success(self) -> None:
+        result = BenchmarkResult(partial=True)
+        result.total_duration_s = 1.0
+        result.requests = [
+            RequestResult(latency_ms=50.0, success=True, completion_tokens=5, prompt_tokens=5),
+            RequestResult(latency_ms=200.0, success=False, error="cancelled"),
+        ]
+        _compute_metrics(result)
+        assert result.completed == 1
+        assert result.failed == 1
+
+    def test_empty_requests(self) -> None:
+        result = BenchmarkResult(partial=True)
+        result.total_duration_s = 0.5
+        result.requests = []
+        _compute_metrics(result)
+        assert result.completed == 0
+        assert result.failed == 0
+
+
+# ---------------------------------------------------------------------------
+# Compare warns on partial results
+# ---------------------------------------------------------------------------
+
+
+class TestComparePartialWarning:
+    """Test that the compare tool detects and warns about partial results."""
+
+    def _make_result(self, throughput: float = 100.0, partial: bool = False) -> dict:
+        d = {
+            "request_throughput": throughput,
+            "output_throughput": throughput * 10,
+            "total_token_throughput": throughput * 15,
+            "mean_ttft_ms": 50.0,
+            "p50_ttft_ms": 48.0,
+            "p90_ttft_ms": 70.0,
+            "p95_ttft_ms": 80.0,
+            "p99_ttft_ms": 95.0,
+            "mean_tpot_ms": 10.0,
+            "p50_tpot_ms": 9.0,
+            "p90_tpot_ms": 15.0,
+            "p95_tpot_ms": 18.0,
+            "p99_tpot_ms": 22.0,
+            "mean_itl_ms": 8.0,
+            "p50_itl_ms": 7.0,
+            "p90_itl_ms": 12.0,
+            "p95_itl_ms": 14.0,
+            "p99_itl_ms": 18.0,
+            "mean_e2el_ms": 200.0,
+            "p50_e2el_ms": 190.0,
+            "p90_e2el_ms": 250.0,
+            "p95_e2el_ms": 270.0,
+            "p99_e2el_ms": 300.0,
+        }
+        if partial:
+            d["partial"] = True
+        return d
+
+    def test_no_partial_no_warning(self) -> None:
+        result = compare(self._make_result(), self._make_result())
+        assert result.baseline_partial is False
+        assert result.candidate_partial is False
+        table = format_comparison_table(result)
+        assert "PARTIAL" not in table
+
+    def test_baseline_partial_warning(self) -> None:
+        result = compare(
+            self._make_result(partial=True),
+            self._make_result(),
+        )
+        assert result.baseline_partial is True
+        assert result.candidate_partial is False
+        table = format_comparison_table(result)
+        assert "PARTIAL" in table
+        assert "baseline" in table
+
+    def test_candidate_partial_warning(self) -> None:
+        result = compare(
+            self._make_result(),
+            self._make_result(partial=True),
+        )
+        assert result.candidate_partial is True
+        table = format_comparison_table(result)
+        assert "candidate" in table
+
+    def test_both_partial_warning(self) -> None:
+        result = compare(
+            self._make_result(partial=True),
+            self._make_result(partial=True),
+        )
+        assert result.baseline_partial is True
+        assert result.candidate_partial is True
+        table = format_comparison_table(result)
+        assert "baseline" in table
+        assert "candidate" in table
+
+    def test_partial_flag_in_to_dict(self) -> None:
+        result = compare(
+            self._make_result(partial=True),
+            self._make_result(),
+        )
+        d = result.to_dict()
+        assert d["baseline_partial"] is True
+        assert "candidate_partial" not in d


### PR DESCRIPTION
## Summary

Implements M12: Graceful Shutdown & Progress Persistence.

When a long-running benchmark is interrupted (Ctrl+C / SIGINT), partial results are now preserved instead of lost.

### Changes

- **runner.py**: Install SIGINT handler during benchmark execution. On interrupt, stop launching new requests, give in-flight requests a 5s grace period, then compute metrics from completed requests. Mark result as `partial: true`.
- **models.py**: Add `partial: bool` field to `BenchmarkResult`.
- **compare.py**: Detect `partial` flag in input files, display warning in comparison table, include in JSON diff output.
- **ROADMAP.md**: Add M12 milestone.
- **tests/test_graceful_shutdown.py**: 12 tests covering partial flag serialization, partial metric computation, and compare partial warnings.

### Testing

All 279 tests pass. Lint clean (ruff + isort).

Closes #40