### PR TITLE
feat: Custom HTTP Headers support (M13)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,3 +93,10 @@
 - `--save-result` saves partial results
 - Compare tool warns when comparing partial results
 - Tests covering graceful shutdown, partial metrics, and compare warnings
+
+## M13: Custom HTTP Headers
+- `--header "Key: Value"` CLI flag (repeatable) for arbitrary HTTP headers
+- YAML config support (`headers: {"X-Custom": "value"}`)
+- Headers merged with internal headers (Authorization); user headers take precedence
+- Dummy server echoes received custom headers in response metadata for validation
+- Tests covering CLI parsing, header injection, YAML config, precedence, and dummy echo

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -400,10 +400,14 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     is_streaming = is_chat  # streaming by default for chat endpoint
     url = f"{base_url}{args.endpoint}"
 
-    # Build default headers (authentication)
+    # Build default headers (authentication + custom)
     headers: dict[str, str] = {}
+    # Custom headers first (lower priority than auth unless explicitly overridden)
+    custom_headers = getattr(args, "custom_headers", None) or {}
+    headers.update(custom_headers)
+    # Auth header (can be overridden by custom headers if user explicitly sets Authorization)
     api_key = getattr(args, "api_key", None)
-    if api_key:
+    if api_key and "Authorization" not in custom_headers:
         headers["Authorization"] = f"Bearer {api_key}"
 
     # Generate or load prompts

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -302,6 +302,17 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Base delay between retries in seconds, with exponential backoff. Default: 1.0.",
     )
 
+    # Custom headers
+    parser.add_argument(
+        "--header",
+        type=str,
+        action="append",
+        default=None,
+        dest="header",
+        metavar="KEY:VALUE",
+        help='Custom HTTP header (repeatable). Format: "Key: Value".',
+    )
+
     # Extended config
     parser.add_argument(
         "--config",
@@ -366,6 +377,34 @@ def _resolve_base_url(args: argparse.Namespace) -> str:
     return f"http://{args.host}:{args.port}"
 
 
+def _parse_header(raw: str) -> tuple[str, str]:
+    """Parse a 'Key: Value' string into (key, value)."""
+    if ":" not in raw:
+        raise ValueError(f"Invalid header format (expected 'Key: Value'): {raw!r}")
+    key, value = raw.split(":", 1)
+    return key.strip(), value.strip()
+
+
+def _resolve_custom_headers(args: argparse.Namespace) -> dict[str, str]:
+    """Build custom headers dict from YAML config + CLI --header flags.
+
+    CLI headers take precedence over YAML ``headers`` dict.
+    """
+    headers: dict[str, str] = {}
+    # YAML headers (lower priority)
+    yaml_headers = getattr(args, "headers", None)
+    if isinstance(yaml_headers, dict):
+        for k, v in yaml_headers.items():
+            headers[str(k)] = str(v)
+    # CLI --header flags (higher priority)
+    cli_headers = getattr(args, "header", None)
+    if cli_headers:
+        for raw in cli_headers:
+            k, v = _parse_header(raw)
+            headers[k] = v
+    return headers
+
+
 def _load_yaml_config(path: str, args: argparse.Namespace) -> argparse.Namespace:
     """Merge YAML config into args (CLI takes precedence)."""
     with open(path) as f:
@@ -424,6 +463,9 @@ def bench_main(argv: list[str] | None = None) -> None:
 
     if args.api_key is None:
         args.api_key = os.environ.get("OPENAI_API_KEY")
+
+    # Resolve custom headers: YAML + CLI (CLI wins)
+    args.custom_headers = _resolve_custom_headers(args)
 
     from xpyd_bench import __version__
     from xpyd_bench.bench.runner import run_benchmark

--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -37,6 +37,31 @@ def set_config(config: ServerConfig) -> None:
     _config = config
 
 
+# Standard headers to exclude from echo
+_STANDARD_HEADERS = frozenset({
+    "host", "user-agent", "accept", "accept-encoding", "accept-language",
+    "connection", "content-length", "content-type", "authorization",
+    "transfer-encoding", "te",
+})
+
+
+def _extract_custom_headers(request: Request) -> dict[str, str]:
+    """Extract non-standard HTTP headers from the request for echo."""
+    custom: dict[str, str] = {}
+    for key, value in request.headers.items():
+        if key.lower() not in _STANDARD_HEADERS:
+            custom[key] = value
+    return custom
+
+
+def _echo_headers_dict(request: Request) -> dict[str, str]:
+    """Build response headers that echo custom request headers."""
+    custom = _extract_custom_headers(request)
+    if not custom:
+        return {}
+    return {"x-echo-headers": json.dumps(custom, separators=(",", ":"))}
+
+
 def _normalize_prompt(prompt: str | list | None) -> str:
     """Normalize all 4 OpenAI prompt formats to a single string.
 
@@ -256,7 +281,7 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
                 seed=seed,
                 ignore_eos=ignore_eos,
             ),
-            media_type="text/event-stream",
+            media_type="text/event-stream", headers=_echo_headers_dict(request),
         )
 
     # Non-streaming: simulate full latency
@@ -318,7 +343,7 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
     }
     if seed is not None:
         resp_body["system_fingerprint"] = f"fp_seed_{seed}"
-    return JSONResponse(resp_body)
+    return JSONResponse(resp_body, headers=_echo_headers_dict(request))
 
 
 async def _stream_completions(
@@ -516,7 +541,7 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
                 seed=seed,
                 ignore_eos=ignore_eos,
             ),
-            media_type="text/event-stream",
+            media_type="text/event-stream", headers=_echo_headers_dict(request),
         )
 
     # Non-streaming
@@ -566,7 +591,7 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
     }
     if seed is not None:
         resp_body["system_fingerprint"] = f"fp_seed_{seed}"
-    return JSONResponse(resp_body)
+    return JSONResponse(resp_body, headers=_echo_headers_dict(request))
 
 
 async def _stream_chat_completions(

--- a/tests/test_custom_headers.py
+++ b/tests/test_custom_headers.py
@@ -1,0 +1,244 @@
+"""Tests for M13: Custom HTTP Headers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from argparse import Namespace
+
+import httpx
+import pytest
+import uvicorn
+import yaml
+
+from xpyd_bench.cli import _parse_header, _resolve_custom_headers
+from xpyd_bench.dummy.server import ServerConfig, create_app, set_config
+
+# ---------------------------------------------------------------------------
+# CLI parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseHeader:
+    """Test _parse_header helper."""
+
+    def test_simple(self):
+        assert _parse_header("X-Custom: value") == ("X-Custom", "value")
+
+    def test_strips_whitespace(self):
+        assert _parse_header("  X-Key :  some value  ") == ("X-Key", "some value")
+
+    def test_value_with_colons(self):
+        k, v = _parse_header("X-Data: a:b:c")
+        assert k == "X-Data"
+        assert v == "a:b:c"
+
+    def test_missing_colon_raises(self):
+        with pytest.raises(ValueError, match="Invalid header format"):
+            _parse_header("NoColonHere")
+
+
+class TestResolveCustomHeaders:
+    """Test _resolve_custom_headers merging logic."""
+
+    def test_empty(self):
+        args = Namespace(header=None, headers=None)
+        assert _resolve_custom_headers(args) == {}
+
+    def test_yaml_only(self):
+        args = Namespace(header=None, headers={"X-From": "yaml", "X-Other": "v"})
+        result = _resolve_custom_headers(args)
+        assert result == {"X-From": "yaml", "X-Other": "v"}
+
+    def test_cli_only(self):
+        args = Namespace(header=["X-Cli: value1", "X-Cli2: value2"], headers=None)
+        result = _resolve_custom_headers(args)
+        assert result == {"X-Cli": "value1", "X-Cli2": "value2"}
+
+    def test_cli_overrides_yaml(self):
+        args = Namespace(
+            header=["X-Key: from-cli"],
+            headers={"X-Key": "from-yaml", "X-Only-Yaml": "y"},
+        )
+        result = _resolve_custom_headers(args)
+        assert result["X-Key"] == "from-cli"
+        assert result["X-Only-Yaml"] == "y"
+
+
+# ---------------------------------------------------------------------------
+# YAML config integration
+# ---------------------------------------------------------------------------
+
+
+class TestYamlHeaders:
+    """Test that YAML config headers are loaded correctly."""
+
+    def test_yaml_config_headers(self, tmp_path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            yaml.dump({"headers": {"X-Yaml-Header": "yaml-value"}})
+        )
+
+        from xpyd_bench.cli import _load_yaml_config
+
+        args = Namespace(
+            header=None,
+            headers=None,
+            base_url="http://localhost:8000",
+        )
+        args = _load_yaml_config(str(config_file), args)
+        assert args.headers == {"X-Yaml-Header": "yaml-value"}
+
+
+# ---------------------------------------------------------------------------
+# Dummy server echo tests
+# ---------------------------------------------------------------------------
+
+_DUMMY_PORT = 18923
+
+
+@pytest.fixture(scope="module")
+def dummy_server():
+    """Start a dummy server for header echo tests."""
+    set_config(ServerConfig(prefill_ms=1, decode_ms=1, model_name="echo-test"))
+    app = create_app()
+
+    server = uvicorn.Server(
+        uvicorn.Config(app, host="127.0.0.1", port=_DUMMY_PORT, log_level="error")
+    )
+
+    loop = asyncio.new_event_loop()
+    import threading
+
+    thread = threading.Thread(target=loop.run_until_complete, args=(server.serve(),), daemon=True)
+    thread.start()
+
+    # Wait for server to start
+    import time
+
+    for _ in range(50):
+        try:
+            httpx.get(f"http://127.0.0.1:{_DUMMY_PORT}/health")
+            break
+        except httpx.ConnectError:
+            time.sleep(0.1)
+    else:
+        raise RuntimeError("Dummy server did not start")
+
+    yield f"http://127.0.0.1:{_DUMMY_PORT}"
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+class TestDummyServerEcho:
+    """Test that the dummy server echoes custom headers."""
+
+    def test_completions_echo(self, dummy_server):
+        resp = httpx.post(
+            f"{dummy_server}/v1/completions",
+            json={"prompt": "hello", "max_tokens": 5, "model": "echo-test"},
+            headers={"X-Custom-Trace": "abc123", "X-Route": "pool-a"},
+        )
+        assert resp.status_code == 200
+        echo_raw = resp.headers.get("x-echo-headers")
+        assert echo_raw is not None
+        echoed = json.loads(echo_raw)
+        assert echoed["x-custom-trace"] == "abc123"
+        assert echoed["x-route"] == "pool-a"
+
+    def test_chat_echo(self, dummy_server):
+        resp = httpx.post(
+            f"{dummy_server}/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 5,
+                "model": "echo-test",
+            },
+            headers={"X-Session-Id": "sess-42"},
+        )
+        assert resp.status_code == 200
+        echo_raw = resp.headers.get("x-echo-headers")
+        assert echo_raw is not None
+        echoed = json.loads(echo_raw)
+        assert echoed["x-session-id"] == "sess-42"
+
+    def test_no_custom_headers_no_echo(self, dummy_server):
+        resp = httpx.post(
+            f"{dummy_server}/v1/completions",
+            json={"prompt": "hello", "max_tokens": 5, "model": "echo-test"},
+        )
+        assert resp.status_code == 200
+        # No custom headers → no echo header
+        assert resp.headers.get("x-echo-headers") is None
+
+    def test_streaming_echo(self, dummy_server):
+        with httpx.stream(
+            "POST",
+            f"{dummy_server}/v1/completions",
+            json={
+                "prompt": "hello",
+                "max_tokens": 3,
+                "model": "echo-test",
+                "stream": True,
+            },
+            headers={"X-Stream-Trace": "streamy"},
+        ) as resp:
+            assert resp.status_code == 200
+            echo_raw = resp.headers.get("x-echo-headers")
+            assert echo_raw is not None
+            echoed = json.loads(echo_raw)
+            assert echoed["x-stream-trace"] == "streamy"
+            # Drain the stream
+            for _ in resp.iter_lines():
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Runner integration: custom headers reach HTTP client
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerHeaderInjection:
+    """Verify custom headers are sent to the server."""
+
+    def test_custom_headers_in_request(self, dummy_server):
+        """Full integration: run bench with custom headers, verify echo."""
+        resp = httpx.post(
+            f"{dummy_server}/v1/completions",
+            json={"prompt": "test", "max_tokens": 2, "model": "echo-test"},
+            headers={
+                "Authorization": "Bearer test-key",
+                "X-Bench-Run": "run-99",
+            },
+        )
+        assert resp.status_code == 200
+        echo_raw = resp.headers.get("x-echo-headers")
+        assert echo_raw is not None
+        echoed = json.loads(echo_raw)
+        # Authorization is standard, should NOT be echoed
+        assert "authorization" not in echoed
+        # Custom header should be echoed
+        assert echoed["x-bench-run"] == "run-99"
+
+
+class TestAuthPrecedence:
+    """Test that explicit custom Authorization header overrides api_key."""
+
+    def test_custom_auth_overrides_api_key(self):
+        args = Namespace(
+            header=["Authorization: Token custom-tok"],
+            headers=None,
+            api_key="bearer-key",
+            custom_headers=None,
+        )
+        custom = _resolve_custom_headers(args)
+        assert custom["Authorization"] == "Token custom-tok"
+
+        # Simulate runner logic: custom_headers has Authorization,
+        # so api_key's Bearer should NOT override
+        headers: dict[str, str] = {}
+        headers.update(custom)
+        if args.api_key and "Authorization" not in custom:
+            headers["Authorization"] = f"Bearer {args.api_key}"
+        assert headers["Authorization"] == "Token custom-tok"


### PR DESCRIPTION
## Summary

Add support for custom HTTP headers in benchmark requests.

### Changes
- `--header "Key: Value"` CLI flag (repeatable) for arbitrary HTTP headers
- YAML config `headers` dict support
- CLI headers override YAML headers on conflict
- User headers override internal `Authorization` header if explicitly set
- Dummy server echoes received custom headers in `x-echo-headers` response header
- 15 new tests covering CLI parsing, header injection, YAML config, precedence, and dummy echo
- Updated ROADMAP.md with M13 milestone

### Use Cases
- Request tracing / correlation IDs (`X-Request-ID`)
- Load balancer routing headers (`X-Route-To`)
- Non-Bearer authentication schemes
- Custom metadata for logging/observability

Closes #42