### PR TITLE
feat: CSV & Markdown Export Formats (M14)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,9 +94,17 @@
 - Compare tool warns when comparing partial results
 - Tests covering graceful shutdown, partial metrics, and compare warnings
 
-## M13: Custom HTTP Headers
+## M13: Custom HTTP Headers ✅
 - `--header "Key: Value"` CLI flag (repeatable) for arbitrary HTTP headers
 - YAML config support (`headers: {"X-Custom": "value"}`)
 - Headers merged with internal headers (Authorization); user headers take precedence
 - Dummy server echoes received custom headers in response metadata for validation
 - Tests covering CLI parsing, header injection, YAML config, precedence, and dummy echo
+
+## M14: CSV & Markdown Export Formats
+- `--csv-report <path>` CLI flag to export summary metrics as CSV
+- `--markdown-report <path>` CLI flag to export summary as Markdown table
+- Per-request CSV export via `--export-requests-csv <path>`
+- YAML config support (`csv_report`, `markdown_report`, `export_requests_csv`)
+- Consistent column ordering across formats
+- Tests covering all export paths, file content validation, and CLI integration

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -364,6 +364,27 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Time-series bucketing window in seconds (default: 1.0).",
     )
     reporting.add_argument(
+        "--csv-report",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Export summary metrics as a single-row CSV file.",
+    )
+    reporting.add_argument(
+        "--markdown-report",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Export summary metrics as a Markdown table.",
+    )
+    reporting.add_argument(
+        "--export-requests-csv",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Export per-request detailed metrics as CSV.",
+    )
+    reporting.add_argument(
         "--rich-progress",
         action="store_true",
         help="Use rich progress bar and summary table.",
@@ -506,6 +527,24 @@ def bench_main(argv: list[str] | None = None) -> None:
         rpath.parent.mkdir(parents=True, exist_ok=True)
         rpath.write_text(text)
         print(f"\nText report saved to {rpath}")
+
+    if args.csv_report:
+        from xpyd_bench.reporting.formats import export_csv_report
+
+        p = export_csv_report(bench_result, args.csv_report)
+        print(f"\nCSV report saved to {p}")
+
+    if args.markdown_report:
+        from xpyd_bench.reporting.formats import export_markdown_report
+
+        p = export_markdown_report(bench_result, args.markdown_report)
+        print(f"\nMarkdown report saved to {p}")
+
+    if args.export_requests_csv:
+        from xpyd_bench.reporting.formats import export_per_request_csv
+
+        p = export_per_request_csv(bench_result, args.export_requests_csv)
+        print(f"\nPer-request CSV saved to {p}")
 
     # Save results if requested
     if args.save_result:

--- a/src/xpyd_bench/reporting/__init__.py
+++ b/src/xpyd_bench/reporting/__init__.py
@@ -1,13 +1,23 @@
 """Reporting module — extended metrics, formats, and rich terminal output."""
 
-from xpyd_bench.reporting.formats import export_json_report, export_per_request, format_text_report
+from xpyd_bench.reporting.formats import (
+    export_csv_report,
+    export_json_report,
+    export_markdown_report,
+    export_per_request,
+    export_per_request_csv,
+    format_text_report,
+)
 from xpyd_bench.reporting.metrics import compute_time_series
 from xpyd_bench.reporting.rich_output import RichProgressReporter
 
 __all__ = [
     "RichProgressReporter",
     "compute_time_series",
+    "export_csv_report",
     "export_json_report",
+    "export_markdown_report",
     "export_per_request",
+    "export_per_request_csv",
     "format_text_report",
 ]

--- a/src/xpyd_bench/reporting/formats.py
+++ b/src/xpyd_bench/reporting/formats.py
@@ -1,7 +1,9 @@
-"""Report format generators — JSON and human-readable text."""
+"""Report format generators — JSON, text, CSV, and Markdown."""
 
 from __future__ import annotations
 
+import csv
+import io
 import json
 from pathlib import Path
 from typing import Any
@@ -97,3 +99,110 @@ def format_text_report(result: BenchmarkResult) -> str:
     lines.append("  " + "-" * 66)
     lines.append("=" * 70)
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Summary column definitions (shared by CSV and Markdown)
+# ---------------------------------------------------------------------------
+
+_SUMMARY_COLUMNS = [
+    ("backend", lambda r: r.backend),
+    ("model", lambda r: r.model),
+    ("num_prompts", lambda r: r.num_prompts),
+    ("completed", lambda r: r.completed),
+    ("failed", lambda r: r.failed),
+    ("total_duration_s", lambda r: f"{r.total_duration_s:.2f}"),
+    ("request_throughput", lambda r: f"{r.request_throughput:.2f}"),
+    ("output_throughput", lambda r: f"{r.output_throughput:.2f}"),
+    ("total_token_throughput", lambda r: f"{r.total_token_throughput:.2f}"),
+    ("mean_ttft_ms", lambda r: f"{r.mean_ttft_ms:.2f}"),
+    ("p50_ttft_ms", lambda r: f"{r.p50_ttft_ms:.2f}"),
+    ("p90_ttft_ms", lambda r: f"{r.p90_ttft_ms:.2f}"),
+    ("p95_ttft_ms", lambda r: f"{r.p95_ttft_ms:.2f}"),
+    ("p99_ttft_ms", lambda r: f"{r.p99_ttft_ms:.2f}"),
+    ("mean_tpot_ms", lambda r: f"{r.mean_tpot_ms:.2f}"),
+    ("p50_tpot_ms", lambda r: f"{r.p50_tpot_ms:.2f}"),
+    ("p90_tpot_ms", lambda r: f"{r.p90_tpot_ms:.2f}"),
+    ("p95_tpot_ms", lambda r: f"{r.p95_tpot_ms:.2f}"),
+    ("p99_tpot_ms", lambda r: f"{r.p99_tpot_ms:.2f}"),
+    ("mean_itl_ms", lambda r: f"{r.mean_itl_ms:.2f}"),
+    ("p50_itl_ms", lambda r: f"{r.p50_itl_ms:.2f}"),
+    ("p90_itl_ms", lambda r: f"{r.p90_itl_ms:.2f}"),
+    ("p95_itl_ms", lambda r: f"{r.p95_itl_ms:.2f}"),
+    ("p99_itl_ms", lambda r: f"{r.p99_itl_ms:.2f}"),
+    ("mean_e2el_ms", lambda r: f"{r.mean_e2el_ms:.2f}"),
+    ("p50_e2el_ms", lambda r: f"{r.p50_e2el_ms:.2f}"),
+    ("p90_e2el_ms", lambda r: f"{r.p90_e2el_ms:.2f}"),
+    ("p95_e2el_ms", lambda r: f"{r.p95_e2el_ms:.2f}"),
+    ("p99_e2el_ms", lambda r: f"{r.p99_e2el_ms:.2f}"),
+]
+
+_PER_REQUEST_COLUMNS = [
+    "prompt_tokens",
+    "completion_tokens",
+    "ttft_ms",
+    "tpot_ms",
+    "latency_ms",
+    "success",
+    "error",
+    "retries",
+]
+
+
+def export_csv_report(result: BenchmarkResult, path: str | Path) -> Path:
+    """Export summary metrics as a single-row CSV with header.
+
+    Returns the written path.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    headers = [col[0] for col in _SUMMARY_COLUMNS]
+    values = [str(col[1](result)) for col in _SUMMARY_COLUMNS]
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(headers)
+    writer.writerow(values)
+    p.write_text(buf.getvalue())
+    return p
+
+
+def export_markdown_report(result: BenchmarkResult, path: str | Path) -> Path:
+    """Export summary metrics as a Markdown table.
+
+    Returns the written path.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    headers = [col[0] for col in _SUMMARY_COLUMNS]
+    values = [str(col[1](result)) for col in _SUMMARY_COLUMNS]
+    header_line = "| " + " | ".join(headers) + " |"
+    separator = "| " + " | ".join("---" for _ in headers) + " |"
+    data_line = "| " + " | ".join(values) + " |"
+    content = f"{header_line}\n{separator}\n{data_line}\n"
+    p.write_text(content)
+    return p
+
+
+def export_per_request_csv(result: BenchmarkResult, path: str | Path) -> Path:
+    """Export per-request detailed metrics as CSV.
+
+    Returns the written path.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(_PER_REQUEST_COLUMNS)
+    for r in result.requests:
+        writer.writerow([
+            r.prompt_tokens,
+            r.completion_tokens,
+            r.ttft_ms if r.ttft_ms is not None else "",
+            r.tpot_ms if r.tpot_ms is not None else "",
+            r.latency_ms,
+            r.success,
+            r.error or "",
+            r.retries,
+        ])
+    p.write_text(buf.getvalue())
+    return p

--- a/tests/test_csv_markdown_export.py
+++ b/tests/test_csv_markdown_export.py
@@ -1,0 +1,276 @@
+"""Tests for M14: CSV & Markdown Export Formats."""
+
+from __future__ import annotations
+
+import csv
+import io
+from pathlib import Path
+
+import pytest
+
+from xpyd_bench.bench.models import BenchmarkResult, RequestResult
+from xpyd_bench.reporting.formats import (
+    _PER_REQUEST_COLUMNS,
+    _SUMMARY_COLUMNS,
+    export_csv_report,
+    export_markdown_report,
+    export_per_request_csv,
+)
+
+
+@pytest.fixture()
+def sample_result() -> BenchmarkResult:
+    """Build a minimal BenchmarkResult for testing."""
+    reqs = [
+        RequestResult(
+            prompt_tokens=10,
+            completion_tokens=20,
+            ttft_ms=5.0,
+            tpot_ms=2.0,
+            itl_ms=[2.0, 2.0],
+            latency_ms=50.0,
+            retries=0,
+            success=True,
+            error=None,
+        ),
+        RequestResult(
+            prompt_tokens=15,
+            completion_tokens=25,
+            ttft_ms=7.0,
+            tpot_ms=3.0,
+            itl_ms=[3.0, 3.0],
+            latency_ms=70.0,
+            retries=1,
+            success=True,
+            error=None,
+        ),
+        RequestResult(
+            prompt_tokens=10,
+            completion_tokens=0,
+            ttft_ms=None,
+            tpot_ms=None,
+            itl_ms=[],
+            latency_ms=100.0,
+            retries=2,
+            success=False,
+            error="timeout",
+        ),
+    ]
+    return BenchmarkResult(
+        backend="openai",
+        model="test-model",
+        num_prompts=3,
+        completed=2,
+        failed=1,
+        total_duration_s=1.5,
+        request_throughput=2.0,
+        output_throughput=30.0,
+        total_token_throughput=50.0,
+        mean_ttft_ms=6.0,
+        p50_ttft_ms=5.0,
+        p90_ttft_ms=7.0,
+        p95_ttft_ms=7.0,
+        p99_ttft_ms=7.0,
+        mean_tpot_ms=2.5,
+        p50_tpot_ms=2.0,
+        p90_tpot_ms=3.0,
+        p95_tpot_ms=3.0,
+        p99_tpot_ms=3.0,
+        mean_itl_ms=2.5,
+        p50_itl_ms=2.0,
+        p90_itl_ms=3.0,
+        p95_itl_ms=3.0,
+        p99_itl_ms=3.0,
+        mean_e2el_ms=60.0,
+        p50_e2el_ms=50.0,
+        p90_e2el_ms=70.0,
+        p95_e2el_ms=70.0,
+        p99_e2el_ms=70.0,
+        requests=reqs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CSV summary report
+# ---------------------------------------------------------------------------
+
+
+class TestCsvReport:
+    def test_creates_file(self, tmp_path: Path, sample_result: BenchmarkResult) -> None:
+        out = tmp_path / "report.csv"
+        result_path = export_csv_report(sample_result, out)
+        assert result_path == out
+        assert out.exists()
+
+    def test_header_row(self, tmp_path: Path, sample_result: BenchmarkResult) -> None:
+        out = tmp_path / "report.csv"
+        export_csv_report(sample_result, out)
+        reader = csv.reader(io.StringIO(out.read_text()))
+        header = next(reader)
+        expected = [col[0] for col in _SUMMARY_COLUMNS]
+        assert header == expected
+
+    def test_data_row_count(self, tmp_path: Path, sample_result: BenchmarkResult) -> None:
+        out = tmp_path / "report.csv"
+        export_csv_report(sample_result, out)
+        rows = list(csv.reader(io.StringIO(out.read_text())))
+        assert len(rows) == 2  # header + 1 data row
+
+    def test_model_value(self, tmp_path: Path, sample_result: BenchmarkResult) -> None:
+        out = tmp_path / "report.csv"
+        export_csv_report(sample_result, out)
+        reader = csv.DictReader(io.StringIO(out.read_text()))
+        row = next(reader)
+        assert row["model"] == "test-model"
+        assert row["completed"] == "2"
+
+    def test_creates_parent_dirs(self, tmp_path: Path, sample_result: BenchmarkResult) -> None:
+        out = tmp_path / "sub" / "dir" / "report.csv"
+        export_csv_report(sample_result, out)
+        assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# Markdown summary report
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownReport:
+    def test_creates_file(self, tmp_path: Path, sample_result: BenchmarkResult) -> None:
+        out = tmp_path / "report.md"
+        result_path = export_markdown_report(sample_result, out)
+        assert result_path == out
+        assert out.exists()
+
+    def test_has_three_lines(self, tmp_path: Path, sample_result: BenchmarkResult) -> None:
+        out = tmp_path / "report.md"
+        export_markdown_report(sample_result, out)
+        lines = out.read_text().strip().split("\n")
+        assert len(lines) == 3  # header, separator, data
+
+    def test_separator_format(self, tmp_path: Path, sample_result: BenchmarkResult) -> None:
+        out = tmp_path / "report.md"
+        export_markdown_report(sample_result, out)
+        lines = out.read_text().strip().split("\n")
+        # Separator line should contain only |, -, and spaces
+        sep = lines[1]
+        assert sep.startswith("|")
+        assert all(c in "|- " for c in sep.replace("|", ""))
+
+    def test_column_count_consistent(
+        self, tmp_path: Path, sample_result: BenchmarkResult
+    ) -> None:
+        out = tmp_path / "report.md"
+        export_markdown_report(sample_result, out)
+        lines = out.read_text().strip().split("\n")
+        for line in lines:
+            # Count pipe-delimited columns (strip outer pipes)
+            cols = [c.strip() for c in line.strip("|").split("|")]
+            assert len(cols) == len(_SUMMARY_COLUMNS)
+
+    def test_contains_model(self, tmp_path: Path, sample_result: BenchmarkResult) -> None:
+        out = tmp_path / "report.md"
+        export_markdown_report(sample_result, out)
+        content = out.read_text()
+        assert "test-model" in content
+
+
+# ---------------------------------------------------------------------------
+# Per-request CSV
+# ---------------------------------------------------------------------------
+
+
+class TestPerRequestCsv:
+    def test_creates_file(self, tmp_path: Path, sample_result: BenchmarkResult) -> None:
+        out = tmp_path / "requests.csv"
+        result_path = export_per_request_csv(sample_result, out)
+        assert result_path == out
+        assert out.exists()
+
+    def test_header_columns(self, tmp_path: Path, sample_result: BenchmarkResult) -> None:
+        out = tmp_path / "requests.csv"
+        export_per_request_csv(sample_result, out)
+        reader = csv.reader(io.StringIO(out.read_text()))
+        header = next(reader)
+        assert header == list(_PER_REQUEST_COLUMNS)
+
+    def test_row_count(self, tmp_path: Path, sample_result: BenchmarkResult) -> None:
+        out = tmp_path / "requests.csv"
+        export_per_request_csv(sample_result, out)
+        rows = list(csv.reader(io.StringIO(out.read_text())))
+        # header + 3 data rows
+        assert len(rows) == 4
+
+    def test_failed_request_error(
+        self, tmp_path: Path, sample_result: BenchmarkResult
+    ) -> None:
+        out = tmp_path / "requests.csv"
+        export_per_request_csv(sample_result, out)
+        reader = csv.DictReader(io.StringIO(out.read_text()))
+        rows = list(reader)
+        failed = [r for r in rows if r["success"] == "False"]
+        assert len(failed) == 1
+        assert failed[0]["error"] == "timeout"
+        assert failed[0]["retries"] == "2"
+
+    def test_none_ttft_becomes_empty(
+        self, tmp_path: Path, sample_result: BenchmarkResult
+    ) -> None:
+        out = tmp_path / "requests.csv"
+        export_per_request_csv(sample_result, out)
+        reader = csv.DictReader(io.StringIO(out.read_text()))
+        rows = list(reader)
+        failed = [r for r in rows if r["success"] == "False"]
+        assert failed[0]["ttft_ms"] == ""
+        assert failed[0]["tpot_ms"] == ""
+
+    def test_successful_request_values(
+        self, tmp_path: Path, sample_result: BenchmarkResult
+    ) -> None:
+        out = tmp_path / "requests.csv"
+        export_per_request_csv(sample_result, out)
+        reader = csv.DictReader(io.StringIO(out.read_text()))
+        row = next(reader)
+        assert row["prompt_tokens"] == "10"
+        assert row["completion_tokens"] == "20"
+        assert row["ttft_ms"] == "5.0"
+        assert row["latency_ms"] == "50.0"
+        assert row["retries"] == "0"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration (argument parsing)
+# ---------------------------------------------------------------------------
+
+
+class TestCliArgs:
+    def _make_parser(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        return parser
+
+    def test_csv_report_arg(self) -> None:
+        parser = self._make_parser()
+        args = parser.parse_args(["--model", "m", "--csv-report", "/tmp/r.csv"])
+        assert args.csv_report == "/tmp/r.csv"
+
+    def test_markdown_report_arg(self) -> None:
+        parser = self._make_parser()
+        args = parser.parse_args(["--model", "m", "--markdown-report", "/tmp/r.md"])
+        assert args.markdown_report == "/tmp/r.md"
+
+    def test_export_requests_csv_arg(self) -> None:
+        parser = self._make_parser()
+        args = parser.parse_args(["--model", "m", "--export-requests-csv", "/tmp/r.csv"])
+        assert args.export_requests_csv == "/tmp/r.csv"
+
+    def test_defaults_none(self) -> None:
+        parser = self._make_parser()
+        args = parser.parse_args(["--model", "m"])
+        assert args.csv_report is None
+        assert args.markdown_report is None
+        assert args.export_requests_csv is None


### PR DESCRIPTION
## Summary

Add CSV and Markdown export formats for benchmark results.

### Changes
- `--csv-report <path>` CLI flag for summary metrics as single-row CSV with header
- `--markdown-report <path>` CLI flag for summary as Markdown table (embeddable in READMEs/PRs)
- `--export-requests-csv <path>` for per-request detailed metrics as CSV
- YAML config support (`csv_report`, `markdown_report`, `export_requests_csv`)
- Shared column definitions (`_SUMMARY_COLUMNS`, `_PER_REQUEST_COLUMNS`) for consistency
- 20 new tests covering file creation, content validation, column ordering, CLI integration
- Mark M13 ✅, add M14 to ROADMAP.md

### Use Cases
- CI dashboards importing CSV results
- Embedding benchmark tables in Markdown PRs/READMEs
- Spreadsheet analysis of per-request data

Closes #44