### PR TITLE
feat: multi-endpoint comparison mode (M15)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
 [project.scripts]
 xpyd-bench = "xpyd_bench.cli:bench_main"
 xpyd-bench-compare = "xpyd_bench.cli:compare_main"
+xpyd-bench-multi = "xpyd_bench.cli:multi_main"
 xpyd-dummy = "xpyd_bench.dummy.cli:dummy_main"
 
 # Reserved for future xpyd CLI subcommand discovery

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -597,6 +597,90 @@ def compare_main(argv: list[str] | None = None) -> None:
         raise SystemExit(1)
 
 
+def multi_main(argv: list[str] | None = None) -> None:
+    """Entry point for ``xpyd-bench-multi`` command."""
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench-multi",
+        description="Benchmark multiple endpoints with the same workload and compare results",
+    )
+    parser.add_argument(
+        "--endpoints",
+        type=str,
+        nargs="+",
+        required=True,
+        help="Base URLs of endpoints to benchmark (at least 2).",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=5.0,
+        help="Regression threshold percentage (default: 5.0).",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Export all results and comparisons to a JSON file.",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Export comparison as a Markdown table.",
+    )
+    _add_vllm_compat_args(parser)
+    args = parser.parse_args(argv)
+
+    if len(args.endpoints) < 2:
+        parser.error("--endpoints requires at least 2 URLs")
+
+    # Merge YAML config if provided
+    if args.config:
+        args = _load_yaml_config(args.config, args)
+
+    # Resolve API key
+    import os
+
+    if args.api_key is None:
+        args.api_key = os.environ.get("OPENAI_API_KEY")
+
+    # Resolve custom headers
+    args.custom_headers = _resolve_custom_headers(args)
+
+    from xpyd_bench import __version__
+    from xpyd_bench.multi import (
+        export_multi_json,
+        export_multi_markdown,
+        format_multi_summary,
+        run_multi_benchmark,
+    )
+
+    print(f"xpyd-bench-multi v{__version__}")
+    print(f"  Endpoints: {', '.join(args.endpoints)}")
+    print(f"  Threshold: {args.threshold}%")
+    print()
+
+    multi = asyncio.run(
+        run_multi_benchmark(args, args.endpoints, threshold_pct=args.threshold)
+    )
+
+    print(format_multi_summary(multi))
+
+    if args.json_output:
+        p = export_multi_json(multi, args.json_output)
+        print(f"\nJSON output saved to {p}")
+
+    if args.markdown_output:
+        p = export_multi_markdown(multi, args.markdown_output)
+        print(f"\nMarkdown output saved to {p}")
+
+    # Exit code 1 if any regression detected
+    if any(c.has_regression for c in multi.comparisons):
+        raise SystemExit(1)
+
+
 def _save_result(args: argparse.Namespace, result: dict) -> None:
     """Save benchmark result to JSON."""
     from datetime import datetime

--- a/src/xpyd_bench/multi.py
+++ b/src/xpyd_bench/multi.py
@@ -1,0 +1,211 @@
+"""Multi-endpoint benchmark comparison.
+
+Runs the same workload against multiple endpoints and produces
+side-by-side comparison results.
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from xpyd_bench.bench.models import BenchmarkResult
+from xpyd_bench.bench.runner import run_benchmark
+from xpyd_bench.compare import (
+    ComparisonResult,
+    compare,
+)
+
+
+@dataclass
+class MultiEndpointResult:
+    """Results from benchmarking multiple endpoints."""
+
+    endpoints: list[str] = field(default_factory=list)
+    results: list[BenchmarkResult] = field(default_factory=list)
+    raw_dicts: list[dict[str, Any]] = field(default_factory=list)
+    comparisons: list[ComparisonResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-friendly dict."""
+        d: dict[str, Any] = {
+            "endpoints": self.endpoints,
+            "results": self.raw_dicts,
+        }
+        if self.comparisons:
+            d["comparisons"] = [c.to_dict() for c in self.comparisons]
+        return d
+
+
+async def run_multi_benchmark(
+    args: Namespace,
+    endpoints: list[str],
+    threshold_pct: float = 5.0,
+) -> MultiEndpointResult:
+    """Run benchmarks against multiple endpoints sequentially.
+
+    The same prompts and parameters are used for each endpoint to ensure
+    fair comparison. The first endpoint is treated as the baseline for
+    pairwise regression detection.
+
+    Args:
+        args: Parsed CLI arguments (same as single-endpoint bench).
+        endpoints: List of base URLs to benchmark.
+        threshold_pct: Regression detection threshold.
+
+    Returns:
+        MultiEndpointResult with per-endpoint results and comparisons.
+    """
+    multi = MultiEndpointResult(endpoints=list(endpoints))
+
+    for ep in endpoints:
+        ep_args = deepcopy(args)
+        # Override base_url-related args
+        ep_args.base_url = ep
+        result_dict, bench_result = await run_benchmark(ep_args, ep)
+        multi.results.append(bench_result)
+        multi.raw_dicts.append(result_dict)
+
+    # Pairwise comparison: first endpoint is baseline
+    if len(multi.raw_dicts) >= 2:
+        baseline = multi.raw_dicts[0]
+        for candidate in multi.raw_dicts[1:]:
+            cmp = compare(baseline, candidate, threshold_pct=threshold_pct)
+            multi.comparisons.append(cmp)
+
+    return multi
+
+
+def format_multi_summary(multi: MultiEndpointResult) -> str:
+    """Format a side-by-side summary table for multiple endpoints."""
+    lines: list[str] = []
+    lines.append("=" * 100)
+    lines.append("  xPyD-bench — Multi-Endpoint Comparison")
+    lines.append("=" * 100)
+
+    if not multi.results:
+        lines.append("  No results.")
+        return "\n".join(lines)
+
+    # Header
+    ep_labels = [f"EP{i}" for i in range(len(multi.endpoints))]
+    header_parts = [f"{'Metric':<28s}"]
+    for i, ep in enumerate(multi.endpoints):
+        label = f"{ep_labels[i]} ({ep})"
+        header_parts.append(f"{label:>20s}")
+    lines.append("  " + " ".join(header_parts))
+    lines.append("  " + "-" * (28 + 21 * len(multi.endpoints)))
+
+    # Key metrics to display
+    display_metrics = [
+        ("completed", "completed"),
+        ("failed", "failed"),
+        ("total_duration_s", "total_duration_s"),
+        ("request_throughput", "request_throughput"),
+        ("output_throughput", "output_throughput"),
+        ("total_token_throughput", "total_token_throughput"),
+        ("mean_ttft_ms", "mean_ttft_ms"),
+        ("p50_ttft_ms", "p50_ttft_ms"),
+        ("p90_ttft_ms", "p90_ttft_ms"),
+        ("p99_ttft_ms", "p99_ttft_ms"),
+        ("mean_tpot_ms", "mean_tpot_ms"),
+        ("p50_tpot_ms", "p50_tpot_ms"),
+        ("p90_tpot_ms", "p90_tpot_ms"),
+        ("p99_tpot_ms", "p99_tpot_ms"),
+        ("mean_e2el_ms", "mean_e2el_ms"),
+        ("p50_e2el_ms", "p50_e2el_ms"),
+        ("p90_e2el_ms", "p90_e2el_ms"),
+        ("p99_e2el_ms", "p99_e2el_ms"),
+    ]
+
+    for label, attr in display_metrics:
+        row = [f"{label:<28s}"]
+        for r in multi.results:
+            val = getattr(r, attr, 0)
+            if isinstance(val, float):
+                row.append(f"{val:>20.2f}")
+            else:
+                row.append(f"{val!s:>20s}")
+        lines.append("  " + " ".join(row))
+
+    lines.append("  " + "-" * (28 + 21 * len(multi.endpoints)))
+
+    # Regression summary
+    for i, cmp in enumerate(multi.comparisons):
+        ep_idx = i + 1
+        if cmp.has_regression:
+            lines.append(
+                f"  ⚠️  EP{ep_idx} ({multi.endpoints[ep_idx]}) "
+                f"has regressions vs EP0 ({multi.endpoints[0]})"
+            )
+        else:
+            lines.append(
+                f"  ✅  EP{ep_idx} ({multi.endpoints[ep_idx]}) "
+                f"— no regressions vs EP0"
+            )
+
+    lines.append("=" * 100)
+    return "\n".join(lines)
+
+
+def export_multi_json(multi: MultiEndpointResult, path: str | Path) -> Path:
+    """Export multi-endpoint results to JSON."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "w") as f:
+        json.dump(multi.to_dict(), f, indent=2, default=str)
+    return p
+
+
+def format_multi_markdown(multi: MultiEndpointResult) -> str:
+    """Format multi-endpoint results as a Markdown table."""
+    if not multi.results:
+        return "No results.\n"
+
+    display_metrics = [
+        "completed",
+        "failed",
+        "request_throughput",
+        "output_throughput",
+        "mean_ttft_ms",
+        "p50_ttft_ms",
+        "p90_ttft_ms",
+        "p99_ttft_ms",
+        "mean_tpot_ms",
+        "p50_tpot_ms",
+        "p90_tpot_ms",
+        "p99_tpot_ms",
+        "mean_e2el_ms",
+        "p50_e2el_ms",
+        "p90_e2el_ms",
+        "p99_e2el_ms",
+    ]
+
+    headers = ["Metric"] + [ep for ep in multi.endpoints]
+    header_line = "| " + " | ".join(headers) + " |"
+    sep_line = "| " + " | ".join("---" for _ in headers) + " |"
+
+    rows = [header_line, sep_line]
+    for metric in display_metrics:
+        cells = [metric]
+        for r in multi.results:
+            val = getattr(r, metric, 0)
+            if isinstance(val, float):
+                cells.append(f"{val:.2f}")
+            else:
+                cells.append(str(val))
+        rows.append("| " + " | ".join(cells) + " |")
+
+    return "\n".join(rows) + "\n"
+
+
+def export_multi_markdown(multi: MultiEndpointResult, path: str | Path) -> Path:
+    """Export multi-endpoint Markdown table to a file."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(format_multi_markdown(multi))
+    return p

--- a/tests/test_multi_endpoint.py
+++ b/tests/test_multi_endpoint.py
@@ -1,0 +1,395 @@
+"""Tests for M15: Multi-Endpoint Comparison Mode."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from xpyd_bench.bench.models import BenchmarkResult
+from xpyd_bench.multi import (
+    MultiEndpointResult,
+    export_multi_json,
+    export_multi_markdown,
+    format_multi_markdown,
+    format_multi_summary,
+    run_multi_benchmark,
+)
+
+
+def _make_bench_result(
+    base_url: str = "http://localhost:8000",
+    completed: int = 10,
+    mean_ttft: float = 5.0,
+    request_throughput: float = 100.0,
+) -> BenchmarkResult:
+    """Build a minimal BenchmarkResult for testing."""
+    return BenchmarkResult(
+        backend="openai",
+        base_url=base_url,
+        endpoint="/v1/completions",
+        model="test-model",
+        num_prompts=10,
+        completed=completed,
+        failed=0,
+        total_duration_s=1.0,
+        request_throughput=request_throughput,
+        output_throughput=500.0,
+        total_token_throughput=700.0,
+        mean_ttft_ms=mean_ttft,
+        p50_ttft_ms=mean_ttft,
+        p90_ttft_ms=mean_ttft + 1,
+        p95_ttft_ms=mean_ttft + 2,
+        p99_ttft_ms=mean_ttft + 3,
+        mean_tpot_ms=2.0,
+        p50_tpot_ms=2.0,
+        p90_tpot_ms=3.0,
+        p95_tpot_ms=3.0,
+        p99_tpot_ms=3.0,
+        mean_itl_ms=2.0,
+        p50_itl_ms=2.0,
+        p90_itl_ms=3.0,
+        p95_itl_ms=3.0,
+        p99_itl_ms=3.0,
+        mean_e2el_ms=50.0,
+        p50_e2el_ms=50.0,
+        p90_e2el_ms=60.0,
+        p95_e2el_ms=65.0,
+        p99_e2el_ms=70.0,
+        requests=[],
+    )
+
+
+def _make_result_dict(
+    base_url: str = "http://localhost:8000",
+    request_throughput: float = 100.0,
+    mean_ttft: float = 5.0,
+) -> dict:
+    """Build a minimal result dict matching runner._to_dict output."""
+    return {
+        "backend": "openai",
+        "base_url": base_url,
+        "endpoint": "/v1/completions",
+        "model": "test-model",
+        "num_prompts": 10,
+        "request_rate": float("inf"),
+        "max_concurrency": None,
+        "input_len": 256,
+        "output_len": 128,
+        "total_duration_s": 1.0,
+        "completed": 10,
+        "failed": 0,
+        "total_input_tokens": 2560,
+        "total_output_tokens": 500,
+        "request_throughput": request_throughput,
+        "output_throughput": 500.0,
+        "total_token_throughput": 700.0,
+        "mean_ttft_ms": mean_ttft,
+        "median_ttft_ms": mean_ttft,
+        "p50_ttft_ms": mean_ttft,
+        "p90_ttft_ms": mean_ttft + 1,
+        "p95_ttft_ms": mean_ttft + 2,
+        "p99_ttft_ms": mean_ttft + 3,
+        "mean_tpot_ms": 2.0,
+        "median_tpot_ms": 2.0,
+        "p50_tpot_ms": 2.0,
+        "p90_tpot_ms": 3.0,
+        "p95_tpot_ms": 3.0,
+        "p99_tpot_ms": 3.0,
+        "mean_itl_ms": 2.0,
+        "median_itl_ms": 2.0,
+        "p50_itl_ms": 2.0,
+        "p90_itl_ms": 3.0,
+        "p95_itl_ms": 3.0,
+        "p99_itl_ms": 3.0,
+        "mean_e2el_ms": 50.0,
+        "median_e2el_ms": 50.0,
+        "p50_e2el_ms": 50.0,
+        "p90_e2el_ms": 60.0,
+        "p95_e2el_ms": 65.0,
+        "p99_e2el_ms": 70.0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# MultiEndpointResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestMultiEndpointResult:
+    def test_to_dict_empty(self) -> None:
+        m = MultiEndpointResult()
+        d = m.to_dict()
+        assert d["endpoints"] == []
+        assert d["results"] == []
+
+    def test_to_dict_with_results(self) -> None:
+        m = MultiEndpointResult(
+            endpoints=["http://a", "http://b"],
+            raw_dicts=[{"a": 1}, {"b": 2}],
+        )
+        d = m.to_dict()
+        assert len(d["results"]) == 2
+        assert d["endpoints"] == ["http://a", "http://b"]
+
+
+# ---------------------------------------------------------------------------
+# run_multi_benchmark
+# ---------------------------------------------------------------------------
+
+
+class TestRunMultiBenchmark:
+    @pytest.mark.asyncio
+    async def test_runs_all_endpoints(self) -> None:
+        urls = ["http://ep1:8000", "http://ep2:8000"]
+        call_count = 0
+
+        async def mock_run(args, base_url):
+            nonlocal call_count
+            call_count += 1
+            return (
+                _make_result_dict(base_url=base_url),
+                _make_bench_result(base_url=base_url),
+            )
+
+        from argparse import Namespace
+
+        args = Namespace(
+            backend="openai",
+            base_url=None,
+            host="127.0.0.1",
+            port=8000,
+            endpoint="/v1/completions",
+            model="m",
+            num_prompts=10,
+            request_rate=float("inf"),
+            burstiness=1.0,
+            max_concurrency=None,
+            input_len=256,
+            output_len=128,
+            seed=0,
+            disable_tqdm=True,
+            save_result=False,
+            warmup=0,
+            api_key=None,
+            custom_headers={},
+            timeout=300.0,
+            retries=0,
+            retry_delay=1.0,
+            config=None,
+            dataset_path=None,
+            dataset_name="random",
+            rich_progress=False,
+            scenario=None,
+        )
+
+        with patch("xpyd_bench.multi.run_benchmark", side_effect=mock_run):
+            multi = await run_multi_benchmark(args, urls, threshold_pct=5.0)
+
+        assert call_count == 2
+        assert len(multi.results) == 2
+        assert len(multi.raw_dicts) == 2
+        assert multi.endpoints == urls
+
+    @pytest.mark.asyncio
+    async def test_comparisons_generated(self) -> None:
+        urls = ["http://ep1:8000", "http://ep2:8000", "http://ep3:8000"]
+
+        async def mock_run(args, base_url):
+            return (
+                _make_result_dict(base_url=base_url),
+                _make_bench_result(base_url=base_url),
+            )
+
+        from argparse import Namespace
+
+        args = Namespace(
+            backend="openai",
+            base_url=None,
+            host="127.0.0.1",
+            port=8000,
+            endpoint="/v1/completions",
+            model="m",
+            num_prompts=10,
+            request_rate=float("inf"),
+            burstiness=1.0,
+            max_concurrency=None,
+            input_len=256,
+            output_len=128,
+            seed=0,
+            disable_tqdm=True,
+            save_result=False,
+            warmup=0,
+            api_key=None,
+            custom_headers={},
+            timeout=300.0,
+            retries=0,
+            retry_delay=1.0,
+            config=None,
+            dataset_path=None,
+            dataset_name="random",
+            rich_progress=False,
+            scenario=None,
+        )
+
+        with patch("xpyd_bench.multi.run_benchmark", side_effect=mock_run):
+            multi = await run_multi_benchmark(args, urls)
+
+        # 3 endpoints → 2 comparisons (EP1 vs EP0, EP2 vs EP0)
+        assert len(multi.comparisons) == 2
+
+
+# ---------------------------------------------------------------------------
+# format_multi_summary
+# ---------------------------------------------------------------------------
+
+
+class TestFormatMultiSummary:
+    def test_empty(self) -> None:
+        m = MultiEndpointResult()
+        text = format_multi_summary(m)
+        assert "No results" in text
+
+    def test_two_endpoints(self) -> None:
+        m = MultiEndpointResult(
+            endpoints=["http://a", "http://b"],
+            results=[
+                _make_bench_result("http://a"),
+                _make_bench_result("http://b"),
+            ],
+            raw_dicts=[
+                _make_result_dict("http://a"),
+                _make_result_dict("http://b"),
+            ],
+        )
+        from xpyd_bench.compare import compare
+
+        m.comparisons = [compare(m.raw_dicts[0], m.raw_dicts[1])]
+        text = format_multi_summary(m)
+        assert "EP0" in text
+        assert "EP1" in text
+        assert "http://a" in text
+        assert "http://b" in text
+
+    def test_regression_shown(self) -> None:
+        m = MultiEndpointResult(
+            endpoints=["http://a", "http://b"],
+            results=[
+                _make_bench_result("http://a", mean_ttft=5.0),
+                _make_bench_result("http://b", mean_ttft=50.0),
+            ],
+            raw_dicts=[
+                _make_result_dict("http://a", mean_ttft=5.0),
+                _make_result_dict("http://b", mean_ttft=50.0),
+            ],
+        )
+        from xpyd_bench.compare import compare
+
+        m.comparisons = [compare(m.raw_dicts[0], m.raw_dicts[1], threshold_pct=5.0)]
+        text = format_multi_summary(m)
+        assert "regressions" in text.lower() or "⚠️" in text
+
+
+# ---------------------------------------------------------------------------
+# Export functions
+# ---------------------------------------------------------------------------
+
+
+class TestExportMultiJson:
+    def test_creates_file(self, tmp_path: Path) -> None:
+        m = MultiEndpointResult(
+            endpoints=["http://a"],
+            raw_dicts=[{"x": 1}],
+        )
+        p = export_multi_json(m, tmp_path / "out.json")
+        assert p.exists()
+        data = json.loads(p.read_text())
+        assert data["endpoints"] == ["http://a"]
+
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        m = MultiEndpointResult()
+        p = export_multi_json(m, tmp_path / "sub" / "dir" / "out.json")
+        assert p.exists()
+
+
+class TestExportMultiMarkdown:
+    def test_creates_file(self, tmp_path: Path) -> None:
+        m = MultiEndpointResult(
+            endpoints=["http://a", "http://b"],
+            results=[
+                _make_bench_result("http://a"),
+                _make_bench_result("http://b"),
+            ],
+        )
+        p = export_multi_markdown(m, tmp_path / "out.md")
+        assert p.exists()
+        content = p.read_text()
+        assert "http://a" in content
+        assert "http://b" in content
+
+    def test_table_structure(self, tmp_path: Path) -> None:
+        m = MultiEndpointResult(
+            endpoints=["http://a", "http://b"],
+            results=[
+                _make_bench_result("http://a"),
+                _make_bench_result("http://b"),
+            ],
+        )
+        p = export_multi_markdown(m, tmp_path / "out.md")
+        lines = p.read_text().strip().split("\n")
+        assert len(lines) >= 3  # header + separator + at least 1 data row
+        assert lines[0].startswith("|")
+        assert "---" in lines[1]
+
+    def test_empty_results(self, tmp_path: Path) -> None:
+        m = MultiEndpointResult()
+        content = format_multi_markdown(m)
+        assert "No results" in content
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestMultiCliArgs:
+    def _make_parser(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--endpoints", type=str, nargs="+", required=True)
+        parser.add_argument("--threshold", type=float, default=5.0)
+        parser.add_argument("--json-output", type=str, default=None)
+        parser.add_argument("--markdown-output", type=str, default=None)
+        _add_vllm_compat_args(parser)
+        return parser
+
+    def test_endpoints_parsed(self) -> None:
+        parser = self._make_parser()
+        args = parser.parse_args(
+            ["--endpoints", "http://a", "http://b", "--model", "m"]
+        )
+        assert args.endpoints == ["http://a", "http://b"]
+
+    def test_threshold_default(self) -> None:
+        parser = self._make_parser()
+        args = parser.parse_args(["--endpoints", "http://a", "http://b"])
+        assert args.threshold == 5.0
+
+    def test_json_output(self) -> None:
+        parser = self._make_parser()
+        args = parser.parse_args(
+            ["--endpoints", "http://a", "http://b", "--json-output", "/tmp/o.json"]
+        )
+        assert args.json_output == "/tmp/o.json"
+
+    def test_markdown_output(self) -> None:
+        parser = self._make_parser()
+        args = parser.parse_args(
+            ["--endpoints", "http://a", "http://b", "--markdown-output", "/tmp/o.md"]
+        )
+        assert args.markdown_output == "/tmp/o.md"


### PR DESCRIPTION
## Summary
Add `xpyd-bench-multi` CLI entry point for benchmarking multiple endpoints with the same workload.

### Features
- `--endpoints url1 url2 ...` to benchmark multiple endpoints sequentially
- Same prompts, parameters, and ordering for fair comparison
- Side-by-side summary table printed to stdout
- Pairwise regression detection (first endpoint = baseline)
- `--json-output` and `--markdown-output` export support
- Exit code 1 when regression detected (CI-friendly)

### Implementation
- New module: `src/xpyd_bench/multi.py`
- New tests: `tests/test_multi_endpoint.py` (16 tests)
- Entry point registered in `pyproject.toml`

Closes #48