### PR TITLE
feat: profile & replay mode (M18)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,7 +134,7 @@
 - YAML config support (`html_report`)
 - Tests covering HTML generation, file content validation, and CLI integration
 
-## M18: Profile & Replay Mode
+## M18: Profile & Replay Mode ✅
 - `xpyd-bench profile --output trace.json` to record request timing patterns from a live endpoint
 - `xpyd-bench replay --trace trace.json --base-url <url>` to replay recorded patterns
 - Trace format captures: timestamps, prompt lengths, endpoint, inter-request delays

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dev = [
 xpyd-bench = "xpyd_bench.cli:bench_main"
 xpyd-bench-compare = "xpyd_bench.cli:compare_main"
 xpyd-bench-multi = "xpyd_bench.cli:multi_main"
+xpyd-bench-profile = "xpyd_bench.cli:profile_main"
+xpyd-bench-replay = "xpyd_bench.cli:replay_main"
 xpyd-dummy = "xpyd_bench.dummy.cli:dummy_main"
 
 # Reserved for future xpyd CLI subcommand discovery

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -662,6 +662,83 @@ def _print_summary(r: BenchmarkResult) -> None:
     print("=" * 60)
 
 
+async def replay_trace(
+    trace: Any,
+    delays: list[float],
+    base_url: str,
+    model: str = "",
+    api_key: str | None = None,
+    timeout: float = 300.0,
+) -> BenchmarkResult:
+    """Replay a recorded trace against a target server.
+
+    Sends requests with the same inter-request timing as the original trace.
+
+    Args:
+        trace: TraceData object with recorded entries.
+        delays: Pre-computed inter-request delays in seconds.
+        base_url: Target server base URL.
+        model: Model name override.
+        api_key: Optional API key for authentication.
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        BenchmarkResult with metrics from the replay run.
+    """
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    result = BenchmarkResult(
+        backend="openai",
+        base_url=base_url,
+        model=model,
+        num_prompts=len(trace.entries),
+    )
+
+    async with httpx.AsyncClient(headers=headers) as client:
+        start_time = time.perf_counter()
+
+        for i, entry in enumerate(trace.entries):
+            if i < len(delays) and delays[i] > 0:
+                await asyncio.sleep(delays[i])
+
+            url = base_url.rstrip("/") + entry.endpoint
+            is_chat = "chat" in entry.endpoint
+
+            if is_chat:
+                payload: dict[str, Any] = {
+                    "model": model or entry.model,
+                    "messages": [{"role": "user", "content": entry.prompt or "hello"}],
+                    "max_tokens": entry.max_tokens,
+                    "temperature": entry.temperature,
+                    "stream": entry.stream,
+                }
+            else:
+                payload = {
+                    "model": model or entry.model,
+                    "prompt": entry.prompt or "hello",
+                    "max_tokens": entry.max_tokens,
+                    "temperature": entry.temperature,
+                    "stream": entry.stream,
+                }
+
+            req_result = await _send_request(
+                client,
+                url,
+                payload,
+                is_streaming=entry.stream,
+                request_timeout=timeout,
+            )
+            result.requests.append(req_result)
+
+        end_time = time.perf_counter()
+        result.total_duration_s = end_time - start_time
+
+    _compute_metrics(result)
+    return result
+
+
 def _to_dict(r: BenchmarkResult) -> dict:
     """Convert BenchmarkResult to a JSON-serializable dict."""
     d: dict[str, Any] = {

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -742,6 +742,190 @@ def multi_main(argv: list[str] | None = None) -> None:
         raise SystemExit(1)
 
 
+def profile_main(argv: list[str] | None = None) -> None:
+    """Entry point for ``xpyd-bench-profile`` command.
+
+    Runs a benchmark and records a request timing trace to a JSON file.
+    """
+    from xpyd_bench.profile import TraceRecorder, save_trace
+
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench-profile",
+        description="Run a benchmark and record request timing trace",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        metavar="PATH",
+        help="Output path for the trace JSON file.",
+    )
+    _add_vllm_compat_args(parser)
+    args = parser.parse_args(argv)
+
+    # Merge YAML config if provided
+    if args.config:
+        args = _load_yaml_config(args.config, args)
+
+    import os
+
+    if args.api_key is None:
+        args.api_key = os.environ.get("OPENAI_API_KEY")
+    args.custom_headers = _resolve_custom_headers(args)
+
+    base_url = _resolve_base_url(args)
+    args.base_url = base_url
+
+    from xpyd_bench import __version__
+    from xpyd_bench.bench.runner import run_benchmark
+    from xpyd_bench.datasets.loader import load_dataset
+
+    print(f"xpyd-bench-profile v{__version__}")
+    print(f"  Base URL: {base_url}")
+    print(f"  Output:   {args.output}")
+    print()
+
+    # Create recorder
+    recorder = TraceRecorder(base_url=base_url)
+
+    # Load dataset
+    prompts = load_dataset(args)
+
+    # Record each prompt into the trace as we dispatch
+    recorder.start()
+    for p in prompts:
+        prompt_len = p.get("prompt_len", len(str(p.get("prompt", ""))))
+        recorder.record(
+            prompt_len=prompt_len,
+            output_len=getattr(args, "output_len", 128),
+            endpoint=args.endpoint,
+            model=args.model or "",
+            prompt=str(p.get("prompt", ""))[:200],  # truncate for trace
+            temperature=getattr(args, "temperature", 1.0),
+            max_tokens=getattr(args, "max_tokens", 128),
+            stream=getattr(args, "stream", True),
+        )
+
+    # Run the actual benchmark
+    bench_result, result = asyncio.run(run_benchmark(args))
+
+    # Finalize trace
+    trace = recorder.finish()
+    trace_path = save_trace(trace, args.output)
+    print(f"\nTrace saved to {trace_path} ({trace.num_entries} entries)")
+
+
+def replay_main(argv: list[str] | None = None) -> None:
+    """Entry point for ``xpyd-bench-replay`` command.
+
+    Replays a recorded trace against a target server.
+    """
+    import os
+
+    from xpyd_bench.profile import compute_delays, load_trace
+
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench-replay",
+        description="Replay a recorded request timing trace against a server",
+    )
+    parser.add_argument(
+        "--trace",
+        type=str,
+        required=True,
+        metavar="PATH",
+        help="Path to the trace JSON file.",
+    )
+    parser.add_argument(
+        "--base-url",
+        type=str,
+        required=True,
+        help="Target server base URL.",
+    )
+    parser.add_argument(
+        "--speed",
+        type=float,
+        default=1.0,
+        help="Replay speed multiplier (default: 1.0). "
+        "2.0 = 2x faster, 0.5 = half speed.",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="Override model name from trace.",
+    )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="API key for authentication.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=300.0,
+        help="Per-request timeout in seconds (default: 300).",
+    )
+    parser.add_argument(
+        "--save-result",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Save benchmark result JSON to this path.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.api_key is None:
+        args.api_key = os.environ.get("OPENAI_API_KEY")
+
+    from xpyd_bench import __version__
+
+    print(f"xpyd-bench-replay v{__version__}")
+
+    trace = load_trace(args.trace)
+    print(f"  Trace:    {args.trace} ({trace.num_entries} entries)")
+    print(f"  Original: {trace.base_url} ({trace.total_duration_s:.1f}s)")
+    print(f"  Target:   {args.base_url}")
+    print(f"  Speed:    {args.speed}x")
+    print()
+
+    delays = compute_delays(trace, speed=args.speed)
+    model = args.model or (trace.entries[0].model if trace.entries else "")
+
+    # Build requests and replay with timing
+    from xpyd_bench.bench.runner import replay_trace
+
+    bench_result = asyncio.run(
+        replay_trace(
+            trace=trace,
+            delays=delays,
+            base_url=args.base_url,
+            model=model,
+            api_key=args.api_key,
+            timeout=args.timeout,
+        )
+    )
+
+    # Print summary
+    print(f"\n{'='*60}")
+    print(f"Replay complete: {bench_result.completed}/{bench_result.num_prompts} succeeded")
+    print(f"Total duration:  {bench_result.total_duration_s:.2f}s")
+    print(f"Throughput:      {bench_result.request_throughput:.2f} req/s")
+    if bench_result.mean_ttft_ms > 0:
+        print(f"Mean TTFT:       {bench_result.mean_ttft_ms:.2f}ms")
+    if bench_result.mean_e2el_ms > 0:
+        print(f"Mean E2E:        {bench_result.mean_e2el_ms:.2f}ms")
+
+    if args.save_result:
+        from dataclasses import asdict
+
+        p = Path(args.save_result)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "w") as f:
+            json.dump(asdict(bench_result), f, indent=2, default=str)
+        print(f"\nResult saved to {p}")
+
+
 def _save_result(args: argparse.Namespace, result: dict) -> None:
     """Save benchmark result to JSON."""
     from datetime import datetime

--- a/src/xpyd_bench/profile.py
+++ b/src/xpyd_bench/profile.py
@@ -1,0 +1,147 @@
+"""Profile & Replay: capture and replay request timing patterns.
+
+Profile mode records a trace of request timings during a benchmark run.
+Replay mode replays a recorded trace against a target server with
+deterministic inter-request delays for reproducible benchmarks.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class TraceEntry:
+    """A single recorded request in the trace."""
+
+    offset_s: float  # seconds from trace start
+    prompt_len: int  # prompt token count
+    output_len: int  # requested max output tokens
+    endpoint: str = "/v1/completions"
+    model: str = ""
+    prompt: str = ""  # actual prompt text (optional, may be empty)
+    temperature: float = 1.0
+    max_tokens: int = 128
+    stream: bool = True
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TraceData:
+    """Complete recorded trace."""
+
+    version: int = 1
+    base_url: str = ""
+    total_duration_s: float = 0.0
+    num_entries: int = 0
+    entries: list[TraceEntry] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> TraceData:
+        entries = [TraceEntry(**e) for e in data.get("entries", [])]
+        return cls(
+            version=data.get("version", 1),
+            base_url=data.get("base_url", ""),
+            total_duration_s=data.get("total_duration_s", 0.0),
+            num_entries=data.get("num_entries", len(entries)),
+            entries=entries,
+        )
+
+
+def save_trace(trace: TraceData, path: str | Path) -> Path:
+    """Save trace data to a JSON file."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "w") as f:
+        json.dump(trace.to_dict(), f, indent=2)
+    return p
+
+
+def load_trace(path: str | Path) -> TraceData:
+    """Load trace data from a JSON file."""
+    with open(path) as f:
+        data = json.load(f)
+    return TraceData.from_dict(data)
+
+
+class TraceRecorder:
+    """Records request timings during a benchmark run."""
+
+    def __init__(self, base_url: str = "") -> None:
+        self._base_url = base_url
+        self._start: float | None = None
+        self._entries: list[TraceEntry] = []
+
+    def start(self) -> None:
+        self._start = time.monotonic()
+
+    def record(
+        self,
+        prompt_len: int,
+        output_len: int,
+        endpoint: str = "/v1/completions",
+        model: str = "",
+        prompt: str = "",
+        temperature: float = 1.0,
+        max_tokens: int = 128,
+        stream: bool = True,
+        **extra: Any,
+    ) -> None:
+        if self._start is None:
+            self.start()
+        offset = time.monotonic() - self._start  # type: ignore[operator]
+        self._entries.append(
+            TraceEntry(
+                offset_s=offset,
+                prompt_len=prompt_len,
+                output_len=output_len,
+                endpoint=endpoint,
+                model=model,
+                prompt=prompt,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                stream=stream,
+                extra=extra if extra else {},
+            )
+        )
+
+    def finish(self) -> TraceData:
+        duration = time.monotonic() - self._start if self._start else 0.0
+        return TraceData(
+            version=1,
+            base_url=self._base_url,
+            total_duration_s=duration,
+            num_entries=len(self._entries),
+            entries=list(self._entries),
+        )
+
+
+def compute_delays(trace: TraceData, speed: float = 1.0) -> list[float]:
+    """Compute inter-request delays from trace offsets.
+
+    Args:
+        trace: The recorded trace data.
+        speed: Speed multiplier (2.0 = replay at 2x speed, 0.5 = half speed).
+
+    Returns:
+        List of delays in seconds. First entry delay is from time 0.
+    """
+    if not trace.entries:
+        return []
+    if speed <= 0:
+        raise ValueError("speed must be positive")
+
+    delays = []
+    prev_offset = 0.0
+    for entry in trace.entries:
+        delay = max(0.0, (entry.offset_s - prev_offset) / speed)
+        delays.append(delay)
+        prev_offset = entry.offset_s
+    return delays

--- a/tests/test_profile_replay.py
+++ b/tests/test_profile_replay.py
@@ -1,0 +1,252 @@
+"""Tests for M18: Profile & Replay Mode."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from xpyd_bench.profile import (
+    TraceData,
+    TraceEntry,
+    TraceRecorder,
+    compute_delays,
+    load_trace,
+    save_trace,
+)
+
+# ---------------------------------------------------------------------------
+# TraceEntry & TraceData
+# ---------------------------------------------------------------------------
+
+
+class TestTraceData:
+    def test_to_dict_roundtrip(self):
+        entry = TraceEntry(
+            offset_s=1.5,
+            prompt_len=100,
+            output_len=50,
+            endpoint="/v1/completions",
+            model="gpt-4",
+            prompt="hello world",
+            temperature=0.7,
+            max_tokens=256,
+            stream=True,
+        )
+        trace = TraceData(
+            version=1,
+            base_url="http://localhost:8000",
+            total_duration_s=10.0,
+            num_entries=1,
+            entries=[entry],
+        )
+        d = trace.to_dict()
+        restored = TraceData.from_dict(d)
+        assert restored.version == 1
+        assert restored.base_url == "http://localhost:8000"
+        assert restored.total_duration_s == 10.0
+        assert len(restored.entries) == 1
+        assert restored.entries[0].offset_s == 1.5
+        assert restored.entries[0].prompt == "hello world"
+        assert restored.entries[0].model == "gpt-4"
+
+    def test_from_dict_defaults(self):
+        trace = TraceData.from_dict({})
+        assert trace.version == 1
+        assert trace.entries == []
+        assert trace.num_entries == 0
+
+    def test_from_dict_computes_num_entries(self):
+        data = {
+            "entries": [
+                {"offset_s": 0.0, "prompt_len": 10, "output_len": 5},
+                {"offset_s": 1.0, "prompt_len": 20, "output_len": 10},
+            ]
+        }
+        trace = TraceData.from_dict(data)
+        assert trace.num_entries == 2
+
+
+# ---------------------------------------------------------------------------
+# Save / Load
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoad:
+    def test_save_and_load(self, tmp_path: Path):
+        entry = TraceEntry(offset_s=0.5, prompt_len=50, output_len=30)
+        trace = TraceData(
+            base_url="http://example.com",
+            total_duration_s=5.0,
+            num_entries=1,
+            entries=[entry],
+        )
+        out = tmp_path / "trace.json"
+        save_trace(trace, out)
+
+        loaded = load_trace(out)
+        assert loaded.base_url == "http://example.com"
+        assert loaded.total_duration_s == 5.0
+        assert len(loaded.entries) == 1
+        assert loaded.entries[0].offset_s == 0.5
+
+    def test_save_creates_parent_dirs(self, tmp_path: Path):
+        out = tmp_path / "sub" / "dir" / "trace.json"
+        trace = TraceData(num_entries=0)
+        save_trace(trace, out)
+        assert out.exists()
+
+    def test_save_produces_valid_json(self, tmp_path: Path):
+        trace = TraceData(
+            entries=[TraceEntry(offset_s=0, prompt_len=10, output_len=5)]
+        )
+        out = tmp_path / "t.json"
+        save_trace(trace, out)
+        data = json.loads(out.read_text())
+        assert data["version"] == 1
+        assert len(data["entries"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# TraceRecorder
+# ---------------------------------------------------------------------------
+
+
+class TestTraceRecorder:
+    def test_basic_recording(self):
+        rec = TraceRecorder(base_url="http://localhost:8000")
+        rec.start()
+        time.sleep(0.01)
+        rec.record(prompt_len=100, output_len=50)
+        time.sleep(0.01)
+        rec.record(prompt_len=200, output_len=100)
+        trace = rec.finish()
+
+        assert trace.base_url == "http://localhost:8000"
+        assert trace.num_entries == 2
+        assert trace.total_duration_s > 0
+        assert trace.entries[0].offset_s < trace.entries[1].offset_s
+
+    def test_auto_start(self):
+        rec = TraceRecorder()
+        rec.record(prompt_len=10, output_len=5)
+        trace = rec.finish()
+        assert trace.num_entries == 1
+        assert trace.entries[0].offset_s >= 0
+
+    def test_record_all_fields(self):
+        rec = TraceRecorder()
+        rec.record(
+            prompt_len=100,
+            output_len=50,
+            endpoint="/v1/chat/completions",
+            model="gpt-4",
+            prompt="test prompt",
+            temperature=0.5,
+            max_tokens=512,
+            stream=False,
+        )
+        trace = rec.finish()
+        e = trace.entries[0]
+        assert e.endpoint == "/v1/chat/completions"
+        assert e.model == "gpt-4"
+        assert e.temperature == 0.5
+        assert e.max_tokens == 512
+        assert e.stream is False
+
+
+# ---------------------------------------------------------------------------
+# compute_delays
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDelays:
+    def test_empty_trace(self):
+        trace = TraceData(entries=[])
+        assert compute_delays(trace) == []
+
+    def test_single_entry(self):
+        trace = TraceData(entries=[
+            TraceEntry(offset_s=2.0, prompt_len=10, output_len=5)
+        ])
+        delays = compute_delays(trace)
+        assert len(delays) == 1
+        assert delays[0] == pytest.approx(2.0)
+
+    def test_multiple_entries(self):
+        trace = TraceData(entries=[
+            TraceEntry(offset_s=0.0, prompt_len=10, output_len=5),
+            TraceEntry(offset_s=1.0, prompt_len=20, output_len=10),
+            TraceEntry(offset_s=3.0, prompt_len=30, output_len=15),
+        ])
+        delays = compute_delays(trace)
+        assert delays == [pytest.approx(0.0), pytest.approx(1.0), pytest.approx(2.0)]
+
+    def test_speed_multiplier(self):
+        trace = TraceData(entries=[
+            TraceEntry(offset_s=0.0, prompt_len=10, output_len=5),
+            TraceEntry(offset_s=2.0, prompt_len=20, output_len=10),
+        ])
+        delays = compute_delays(trace, speed=2.0)
+        assert delays == [pytest.approx(0.0), pytest.approx(1.0)]
+
+    def test_speed_slow(self):
+        trace = TraceData(entries=[
+            TraceEntry(offset_s=0.0, prompt_len=10, output_len=5),
+            TraceEntry(offset_s=1.0, prompt_len=20, output_len=10),
+        ])
+        delays = compute_delays(trace, speed=0.5)
+        assert delays == [pytest.approx(0.0), pytest.approx(2.0)]
+
+    def test_invalid_speed(self):
+        trace = TraceData(entries=[
+            TraceEntry(offset_s=0.0, prompt_len=10, output_len=5)
+        ])
+        with pytest.raises(ValueError, match="speed must be positive"):
+            compute_delays(trace, speed=0)
+        with pytest.raises(ValueError, match="speed must be positive"):
+            compute_delays(trace, speed=-1)
+
+    def test_negative_offset_clamped(self):
+        """If offsets go backwards (shouldn't happen), delays clamp to 0."""
+        trace = TraceData(entries=[
+            TraceEntry(offset_s=5.0, prompt_len=10, output_len=5),
+            TraceEntry(offset_s=3.0, prompt_len=20, output_len=10),
+        ])
+        delays = compute_delays(trace)
+        assert delays[1] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# CLI integration (argument parsing only)
+# ---------------------------------------------------------------------------
+
+
+class TestCLIParsing:
+    def test_profile_help(self):
+        """profile_main accepts --output."""
+        from xpyd_bench.cli import profile_main
+
+        with pytest.raises(SystemExit):
+            profile_main(["--help"])
+
+    def test_replay_help(self):
+        """replay_main accepts --trace and --base-url."""
+        from xpyd_bench.cli import replay_main
+
+        with pytest.raises(SystemExit):
+            replay_main(["--help"])
+
+    def test_replay_requires_trace(self):
+        from xpyd_bench.cli import replay_main
+
+        with pytest.raises(SystemExit):
+            replay_main(["--base-url", "http://localhost:8000"])
+
+    def test_replay_requires_base_url(self):
+        from xpyd_bench.cli import replay_main
+
+        with pytest.raises(SystemExit):
+            replay_main(["--trace", "trace.json"])


### PR DESCRIPTION
## Summary

Implement M18: Profile & Replay Mode for capturing and replaying request timing patterns.

### Changes
- New `src/xpyd_bench/profile.py`: TraceData/TraceEntry models, TraceRecorder, save/load, compute_delays
- New `src/xpyd_bench/bench/runner.py`: `replay_trace()` async function
- New CLI entry points: `xpyd-bench-profile` and `xpyd-bench-replay`
- 20 new tests in `tests/test_profile_replay.py`
- ROADMAP.md: M18 marked ✅

### Features
- Profile mode records request timing trace to JSON
- Replay mode replays trace with deterministic inter-request delays
- Speed multiplier (`--speed`) for faster/slower replay
- Standard BenchmarkResult output from replay for comparison

Closes #54