### PR TITLE
feat: M19 — Dry Run Mode (--dry-run)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -140,3 +140,14 @@
 - Trace format captures: timestamps, prompt lengths, endpoint, inter-request delays
 - Deterministic replay for reproducible benchmarks across different servers
 - Tests covering profile recording, replay accuracy, and trace format validation
+
+## M19: Dry Run Mode
+- `--dry-run` CLI flag to validate configuration and dataset without sending HTTP requests
+- Print execution plan: resolved base URL, endpoint, model, dataset stats, rate config
+- Load and validate dataset (file or synthetic), report stats
+- Validate YAML config if provided
+- Print estimated benchmark duration based on num_prompts and request_rate
+- Exit with code 0 on success, non-zero on validation errors
+- YAML config support (`dry_run: true`)
+- Works with all existing CLI flags (scenarios, custom headers, auth, etc.)
+- Tests covering dry-run output, validation errors, and CLI integration

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -361,6 +361,15 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Initial concurrency for adaptive mode (default: 16).",
     )
 
+    # Dry run
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=None,
+        help="Validate configuration and dataset without sending requests. "
+        "Prints execution plan and exits.",
+    )
+
     # Extended config
     parser.add_argument(
         "--config",
@@ -451,6 +460,97 @@ def _resolve_base_url(args: argparse.Namespace) -> str:
     if args.base_url:
         return args.base_url.rstrip("/")
     return f"http://{args.host}:{args.port}"
+
+
+def _dry_run(args: argparse.Namespace, base_url: str) -> None:
+    """Validate configuration and dataset, print execution plan, then exit."""
+    from xpyd_bench import __version__
+    from xpyd_bench.datasets.loader import load_dataset, validate_and_report
+
+    print(f"xpyd-bench v{__version__} — DRY RUN")
+    print(f"{'='*60}")
+    print()
+
+    # Execution plan
+    print("Execution Plan:")
+    print(f"  Base URL:        {base_url}")
+    print(f"  Endpoint:        {args.endpoint}")
+    print(f"  Backend:         {args.backend}")
+    print(f"  Model:           {args.model or '(auto-detect)'}")
+    print(f"  Num prompts:     {args.num_prompts}")
+    print(f"  Request rate:    {args.request_rate}")
+    print(f"  Max concurrency: {args.max_concurrency or 'unlimited'}")
+    print(f"  Input len:       {args.input_len}")
+    print(f"  Output len:      {args.output_len}")
+    print(f"  Seed:            {args.seed}")
+    print(f"  Rate algorithm:  {args.rate_algorithm}")
+
+    # Auth
+    api_key_source = "none"
+    if args.api_key:
+        api_key_source = "CLI/config (set)"
+    print(f"  API key:         {api_key_source}")
+
+    # Custom headers
+    if args.custom_headers:
+        print(f"  Custom headers:  {len(args.custom_headers)} header(s)")
+        for k, v in args.custom_headers.items():
+            print(f"    {k}: {v}")
+    else:
+        print("  Custom headers:  none")
+
+    # Warmup
+    warmup = getattr(args, "warmup", None) or 0
+    print(f"  Warmup requests: {warmup}")
+
+    # Timeout / retry
+    print(f"  Timeout:         {args.timeout}s")
+    print(f"  Retries:         {args.retries}")
+    if args.retries > 0:
+        print(f"  Retry delay:     {args.retry_delay}s (exponential backoff)")
+
+    # Scenario
+    scenario = getattr(args, "scenario", None)
+    if scenario:
+        print(f"  Scenario:        {scenario}")
+
+    print()
+
+    # Dataset validation
+    print("Dataset Validation:")
+    try:
+        entries = load_dataset(
+            path=args.dataset_path,
+            name=args.dataset_name,
+            num_prompts=args.num_prompts,
+            input_len=args.input_len,
+            output_len=args.output_len,
+            input_len_dist=getattr(args, "synthetic_input_len_dist", "fixed"),
+            output_len_dist=getattr(args, "synthetic_output_len_dist", "fixed"),
+            seed=args.seed,
+        )
+        source = args.dataset_path or f"synthetic ({args.dataset_name})"
+        validate_and_report(entries, source)
+    except (ValueError, FileNotFoundError) as exc:
+        print(f"  ERROR: {exc}")
+        raise SystemExit(1) from exc
+
+    print()
+
+    # Estimated duration
+    rate = args.request_rate
+    if rate != float("inf") and rate > 0:
+        est_seconds = args.num_prompts / rate
+        if est_seconds >= 60:
+            print(f"Estimated duration: {est_seconds / 60:.1f} min ({est_seconds:.0f}s)")
+        else:
+            print(f"Estimated duration: {est_seconds:.1f}s")
+    else:
+        print("Estimated duration: all requests sent at once (rate=inf)")
+
+    print()
+    print("Dry run complete. Configuration is valid.")
+    print(f"{'='*60}")
 
 
 def _parse_header(raw: str) -> tuple[str, str]:
@@ -545,6 +645,11 @@ def bench_main(argv: list[str] | None = None) -> None:
 
     from xpyd_bench import __version__
     from xpyd_bench.bench.runner import run_benchmark
+
+    # Dry run: validate config and dataset, print plan, exit
+    if getattr(args, "dry_run", False):
+        _dry_run(args, base_url)
+        return
 
     print(f"xpyd-bench v{__version__}")
     print(f"  Base URL:       {base_url}")

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,169 @@
+"""Tests for M19: Dry Run Mode (--dry-run)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+
+import pytest
+
+from xpyd_bench.cli import bench_main
+
+
+class TestDryRunBasic:
+    """Test basic dry-run execution and output."""
+
+    def test_dry_run_exits_cleanly(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """--dry-run should exit without error on valid config."""
+        bench_main(["--dry-run", "--num-prompts", "10"])
+        captured = capsys.readouterr()
+        assert "DRY RUN" in captured.out
+        assert "Dry run complete" in captured.out
+        assert "Configuration is valid" in captured.out
+
+    def test_dry_run_prints_execution_plan(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Dry run should print all key config values."""
+        bench_main([
+            "--dry-run",
+            "--base-url", "http://test:9999",
+            "--endpoint", "/v1/chat/completions",
+            "--model", "test-model",
+            "--num-prompts", "50",
+            "--request-rate", "10",
+            "--max-concurrency", "5",
+            "--input-len", "128",
+            "--output-len", "64",
+        ])
+        out = capsys.readouterr().out
+        assert "http://test:9999" in out
+        assert "/v1/chat/completions" in out
+        assert "test-model" in out
+        assert "50" in out
+        assert "10" in out
+
+    def test_dry_run_estimated_duration_finite_rate(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Estimated duration shown for finite request rate."""
+        bench_main(["--dry-run", "--num-prompts", "100", "--request-rate", "10"])
+        out = capsys.readouterr().out
+        assert "Estimated duration:" in out
+        assert "10.0s" in out
+
+    def test_dry_run_estimated_duration_inf_rate(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Infinite rate shows 'all at once' message."""
+        bench_main(["--dry-run", "--num-prompts", "10"])
+        out = capsys.readouterr().out
+        assert "all requests sent at once" in out
+
+    def test_dry_run_no_http_requests(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Dry run should NOT import or call run_benchmark."""
+        # If it tried to connect, it would fail since no server is running
+        bench_main(["--dry-run", "--base-url", "http://nowhere:1", "--num-prompts", "5"])
+        out = capsys.readouterr().out
+        assert "DRY RUN" in out
+        assert "Dry run complete" in out
+
+
+class TestDryRunDataset:
+    """Test dry-run with various dataset configurations."""
+
+    def test_dry_run_synthetic_dataset(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Dry run with synthetic dataset prints stats."""
+        bench_main(["--dry-run", "--dataset-name", "synthetic", "--num-prompts", "20"])
+        out = capsys.readouterr().out
+        assert "Dataset:" in out
+        assert "Entries:" in out
+
+    def test_dry_run_jsonl_dataset(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Dry run with JSONL dataset file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            for i in range(5):
+                f.write(json.dumps({"prompt": f"test prompt {i}"}) + "\n")
+            f.flush()
+            bench_main(["--dry-run", "--dataset-path", f.name, "--num-prompts", "5"])
+        out = capsys.readouterr().out
+        assert "Entries:" in out
+        assert "5" in out
+
+    def test_dry_run_invalid_dataset_path(self) -> None:
+        """Dry run exits with error for missing dataset file."""
+        with pytest.raises(SystemExit) as exc_info:
+            bench_main(["--dry-run", "--dataset-path", "/nonexistent/file.jsonl"])
+        assert exc_info.value.code == 1
+
+    def test_dry_run_empty_jsonl(self) -> None:
+        """Dry run exits with error for empty dataset."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write("")
+            f.flush()
+            with pytest.raises(SystemExit) as exc_info:
+                bench_main(["--dry-run", "--dataset-path", f.name])
+            assert exc_info.value.code == 1
+
+
+class TestDryRunYamlConfig:
+    """Test dry-run with YAML config files."""
+
+    def test_dry_run_from_yaml(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Dry run reads dry_run from YAML config."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("dry_run: true\nnum_prompts: 15\nrequest_rate: 5\n")
+            f.flush()
+            bench_main(["--config", f.name])
+        out = capsys.readouterr().out
+        assert "DRY RUN" in out
+        assert "Dry run complete" in out
+
+    def test_dry_run_cli_overrides_yaml(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """CLI --dry-run works even without YAML."""
+        bench_main(["--dry-run", "--num-prompts", "3"])
+        out = capsys.readouterr().out
+        assert "DRY RUN" in out
+
+
+class TestDryRunScenario:
+    """Test dry-run with scenario presets."""
+
+    def test_dry_run_with_scenario(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Dry run works with --scenario flag."""
+        bench_main(["--dry-run", "--scenario", "short"])
+        out = capsys.readouterr().out
+        assert "DRY RUN" in out
+        assert "Scenario:" in out or "short" in out.lower() or "Dry run complete" in out
+
+
+class TestDryRunAuth:
+    """Test dry-run auth display."""
+
+    def test_dry_run_shows_api_key_status(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Dry run shows API key status."""
+        bench_main(["--dry-run", "--api-key", "sk-test", "--num-prompts", "5"])
+        out = capsys.readouterr().out
+        assert "API key:" in out
+        assert "set" in out.lower()
+
+    def test_dry_run_no_api_key(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Dry run shows no API key when not set."""
+        bench_main(["--dry-run", "--num-prompts", "5"])
+        out = capsys.readouterr().out
+        assert "API key:" in out
+
+
+class TestDryRunHeaders:
+    """Test dry-run custom headers display."""
+
+    def test_dry_run_shows_custom_headers(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Dry run displays custom headers."""
+        bench_main([
+            "--dry-run",
+            "--header", "X-Test: hello",
+            "--header", "X-Other: world",
+            "--num-prompts", "5",
+        ])
+        out = capsys.readouterr().out
+        assert "2 header(s)" in out
+        assert "X-Test" in out
+        assert "X-Other" in out


### PR DESCRIPTION
## Summary
Add `--dry-run` CLI flag that validates configuration and dataset without sending HTTP requests.

## Changes
- **CLI**: `--dry-run` flag added to argument parser (default: None, compatible with YAML `dry_run: true`)
- **Execution plan**: Prints resolved base URL, endpoint, model, dataset stats, rate config, auth status, custom headers, warmup, timeout/retry settings
- **Dataset validation**: Loads and validates dataset (file-based or synthetic), reports stats via `validate_and_report`
- **Estimated duration**: Calculates and prints estimated benchmark duration based on num_prompts / request_rate
- **Error handling**: Exits with code 1 on validation errors (missing dataset, empty dataset, etc.)
- **YAML support**: `dry_run: true` in YAML config triggers dry-run mode
- **Tests**: 15 tests covering all dry-run functionality

## Test Results
All 15 new tests pass. Lint clean (ruff + isort).

Closes #56