### PR TITLE
feat: add environment info capture to benchmark results (M21)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -161,3 +161,24 @@
 - JSON output includes `sla_results` section with per-target pass/fail
 - YAML config support (`sla: <path>`)
 - Tests covering SLA pass, SLA fail, partial SLA, missing metrics
+
+## M21: Environment Info Capture
+- `collect_env_info()` utility in `src/xpyd_bench/bench/env.py`
+- Captures: Python version, OS, platform, CPU architecture, hostname, xpyd-bench version, ISO 8601 timestamp
+- `BenchmarkResult` includes `environment` dict field (auto-populated)
+- All saved JSON results include `environment` section
+- `--dry-run` output shows environment info
+- Tests covering environment info structure and presence
+
+## M22: Request Logging & Debug Mode
+- `--debug-log <path>` CLI flag to write per-request debug logs
+- Each log entry: timestamp, URL, payload (truncated), status code, latency, error
+- Useful for diagnosing failures in long benchmark runs
+- YAML config support (`debug_log`)
+- Tests covering log file creation and content
+
+## M23: Configuration Dump & Validation
+- `xpyd-bench config dump` subcommand to print resolved configuration (CLI + YAML merged)
+- `xpyd-bench config validate --config <path>` to validate YAML config without running
+- Print warnings for deprecated or conflicting options
+- Tests covering dump output and validation errors

--- a/src/xpyd_bench/bench/env.py
+++ b/src/xpyd_bench/bench/env.py
@@ -1,0 +1,28 @@
+"""Environment info collection for benchmark reproducibility."""
+
+from __future__ import annotations
+
+import platform
+import socket
+import sys
+from datetime import datetime, timezone
+
+
+def collect_env_info() -> dict[str, str]:
+    """Collect environment metadata for embedding in benchmark results.
+
+    Returns a dict with keys:
+        python_version, os, platform, architecture, hostname,
+        xpyd_bench_version, timestamp
+    """
+    from xpyd_bench import __version__
+
+    return {
+        "python_version": sys.version,
+        "os": platform.system(),
+        "platform": platform.platform(),
+        "architecture": platform.machine(),
+        "hostname": socket.gethostname(),
+        "xpyd_bench_version": __version__,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -76,3 +76,6 @@ class BenchmarkResult:
 
     # Partial result flag (set when benchmark was interrupted)
     partial: bool = False
+
+    # Environment metadata for reproducibility
+    environment: dict[str, str] = field(default_factory=dict)

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -13,6 +13,7 @@ from typing import Any
 import httpx
 import numpy as np
 
+from xpyd_bench.bench.env import collect_env_info
 from xpyd_bench.bench.models import BenchmarkResult, RequestResult
 
 # ---------------------------------------------------------------------------
@@ -477,6 +478,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         max_concurrency=args.max_concurrency,
         input_len=args.input_len,
         output_len=args.output_len,
+        environment=collect_env_info(),
     )
 
     # Timeout & retry settings
@@ -694,6 +696,7 @@ async def replay_trace(
         base_url=base_url,
         model=model,
         num_prompts=len(trace.entries),
+        environment=collect_env_info(),
     )
 
     async with httpx.AsyncClient(headers=headers) as client:

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -558,6 +558,16 @@ def _dry_run(args: argparse.Namespace, base_url: str) -> None:
 
     print()
     print("Dry run complete. Configuration is valid.")
+
+    # Environment info
+    from xpyd_bench.bench.env import collect_env_info
+
+    env = collect_env_info()
+    print()
+    print("Environment:")
+    for k, v in env.items():
+        print(f"  {k}: {v}")
+
     print(f"{'='*60}")
 
 

--- a/tests/test_env_info.py
+++ b/tests/test_env_info.py
@@ -1,0 +1,96 @@
+"""Tests for M21: Environment Info Capture."""
+
+from __future__ import annotations
+
+import json
+import platform
+import socket
+import sys
+from dataclasses import asdict
+
+from xpyd_bench.bench.env import collect_env_info
+from xpyd_bench.bench.models import BenchmarkResult
+
+
+class TestCollectEnvInfo:
+    """Tests for collect_env_info()."""
+
+    def test_returns_dict(self):
+        info = collect_env_info()
+        assert isinstance(info, dict)
+
+    def test_required_keys(self):
+        info = collect_env_info()
+        expected_keys = {
+            "python_version",
+            "os",
+            "platform",
+            "architecture",
+            "hostname",
+            "xpyd_bench_version",
+            "timestamp",
+        }
+        assert expected_keys <= set(info.keys())
+
+    def test_all_values_are_strings(self):
+        info = collect_env_info()
+        for k, v in info.items():
+            assert isinstance(v, str), f"{k} should be str, got {type(v)}"
+
+    def test_python_version(self):
+        info = collect_env_info()
+        assert sys.version in info["python_version"]
+
+    def test_os(self):
+        info = collect_env_info()
+        assert info["os"] == platform.system()
+
+    def test_architecture(self):
+        info = collect_env_info()
+        assert info["architecture"] == platform.machine()
+
+    def test_hostname(self):
+        info = collect_env_info()
+        assert info["hostname"] == socket.gethostname()
+
+    def test_version(self):
+        from xpyd_bench import __version__
+
+        info = collect_env_info()
+        assert info["xpyd_bench_version"] == __version__
+
+    def test_timestamp_iso_format(self):
+        from datetime import datetime
+
+        info = collect_env_info()
+        # Should parse without error
+        datetime.fromisoformat(info["timestamp"])
+
+
+class TestBenchmarkResultEnvironment:
+    """Tests that BenchmarkResult includes environment field."""
+
+    def test_default_empty(self):
+        r = BenchmarkResult()
+        assert r.environment == {}
+
+    def test_with_env_info(self):
+        env = collect_env_info()
+        r = BenchmarkResult(environment=env)
+        assert r.environment == env
+        assert "python_version" in r.environment
+
+    def test_serialization(self):
+        env = collect_env_info()
+        r = BenchmarkResult(environment=env)
+        data = asdict(r)
+        assert "environment" in data
+        assert data["environment"]["os"] == platform.system()
+
+    def test_json_roundtrip(self):
+        env = collect_env_info()
+        r = BenchmarkResult(environment=env)
+        data = asdict(r)
+        raw = json.dumps(data, default=str)
+        loaded = json.loads(raw)
+        assert loaded["environment"]["hostname"] == socket.gethostname()


### PR DESCRIPTION
## Summary
Add environment metadata (Python version, OS, platform, CPU architecture, hostname, xpyd-bench version, timestamp) to every benchmark result for reproducibility.

## Changes
- New `collect_env_info()` utility in `src/xpyd_bench/bench/env.py`
- `BenchmarkResult` dataclass now includes `environment` dict field
- Runner and replay mode auto-populate environment info
- `--dry-run` output shows environment section
- Added M21-M23 milestones to ROADMAP.md
- 13 new tests

## Tests
All 426 tests pass. Lint clean.

Closes #60