### PR TITLE
feat: Request Logging & Debug Mode (M22)

### DIFF
--- a/src/xpyd_bench/bench/debug_log.py
+++ b/src/xpyd_bench/bench/debug_log.py
@@ -1,0 +1,83 @@
+"""Per-request debug logging for long benchmark runs."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from xpyd_bench.bench.models import RequestResult
+
+# Maximum characters for payload in log entries
+_MAX_PAYLOAD_LEN = 512
+
+
+@dataclass
+class DebugLogEntry:
+    """A single debug log entry for one request."""
+
+    timestamp: str
+    url: str
+    payload: str
+    status: str
+    latency_ms: float
+    success: bool
+    error: str | None = None
+    retries: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "timestamp": self.timestamp,
+            "url": self.url,
+            "payload": self.payload,
+            "status": self.status,
+            "latency_ms": round(self.latency_ms, 3),
+            "success": self.success,
+        }
+        if self.error is not None:
+            d["error"] = self.error
+        if self.retries > 0:
+            d["retries"] = self.retries
+        return d
+
+
+class DebugLogger:
+    """Writes per-request debug log entries as JSON lines to a file."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = open(self._path, "w")  # noqa: SIM115
+
+    def log(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        result: RequestResult,
+    ) -> None:
+        """Write one log entry for a completed request."""
+        # Truncate payload
+        payload_str = json.dumps(payload, ensure_ascii=False)
+        if len(payload_str) > _MAX_PAYLOAD_LEN:
+            payload_str = payload_str[:_MAX_PAYLOAD_LEN] + "...(truncated)"
+
+        status = "ok" if result.success else "error"
+
+        entry = DebugLogEntry(
+            timestamp=time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            url=url,
+            payload=payload_str,
+            status=status,
+            latency_ms=result.latency_ms,
+            success=result.success,
+            error=result.error,
+            retries=result.retries,
+        )
+        self._file.write(json.dumps(entry.to_dict(), ensure_ascii=False) + "\n")
+        self._file.flush()
+
+    def close(self) -> None:
+        """Close the log file."""
+        self._file.close()

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -13,6 +13,7 @@ from typing import Any
 import httpx
 import numpy as np
 
+from xpyd_bench.bench.debug_log import DebugLogger
 from xpyd_bench.bench.env import collect_env_info
 from xpyd_bench.bench.models import BenchmarkResult, RequestResult
 
@@ -541,6 +542,12 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         if not args.disable_tqdm:
             print("Warmup complete. Starting benchmark...")
 
+    # Debug logger (M22)
+    debug_log_path = getattr(args, "debug_log", None)
+    debug_logger: DebugLogger | None = None
+    if debug_log_path:
+        debug_logger = DebugLogger(debug_log_path)
+
     if reporter:
         reporter.start()
 
@@ -549,7 +556,10 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     shutdown_requested = False
 
     async def _tracked_task(client: httpx.AsyncClient, prompt: str) -> RequestResult:
+        payload = _build_payload(args, prompt, is_chat)
         r = await _task(client, prompt)
+        if debug_logger:
+            debug_logger.log(url, payload, r)
         if reporter:
             reporter.advance(success=r.success)
         return r
@@ -621,6 +631,9 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     result.total_duration_s = overall_end - overall_start
     result.requests = results_list
     result.partial = shutdown_requested
+
+    if debug_logger:
+        debug_logger.close()
 
     _compute_metrics(result)
 

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -457,6 +457,13 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Export an interactive HTML report dashboard.",
     )
     reporting.add_argument(
+        "--debug-log",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Write per-request debug logs (JSONL) for diagnosing failures.",
+    )
+    reporting.add_argument(
         "--rich-progress",
         action="store_true",
         help="Use rich progress bar and summary table.",
@@ -729,6 +736,10 @@ def bench_main(argv: list[str] | None = None) -> None:
 
         p = export_html_report(bench_result, args.html_report)
         print(f"\nHTML report saved to {p}")
+
+    # Debug log notification (M22)
+    if getattr(args, "debug_log", None):
+        print(f"\nDebug log saved to {args.debug_log}")
 
     # Save results if requested
     if args.save_result:

--- a/tests/test_debug_log.py
+++ b/tests/test_debug_log.py
@@ -1,0 +1,178 @@
+"""Tests for M22: Request Logging & Debug Mode."""
+
+from __future__ import annotations
+
+import json
+
+from xpyd_bench.bench.debug_log import DebugLogEntry, DebugLogger
+from xpyd_bench.bench.models import RequestResult
+
+
+class TestDebugLogEntry:
+    """Test DebugLogEntry dataclass."""
+
+    def test_to_dict_success(self):
+        entry = DebugLogEntry(
+            timestamp="2026-04-04T19:00:00+0800",
+            url="http://localhost:8000/v1/completions",
+            payload='{"prompt": "hello", "max_tokens": 128}',
+            status="ok",
+            latency_ms=42.123456,
+            success=True,
+        )
+        d = entry.to_dict()
+        assert d["timestamp"] == "2026-04-04T19:00:00+0800"
+        assert d["url"] == "http://localhost:8000/v1/completions"
+        assert d["success"] is True
+        assert d["latency_ms"] == 42.123
+        assert "error" not in d
+        assert "retries" not in d
+
+    def test_to_dict_error(self):
+        entry = DebugLogEntry(
+            timestamp="2026-04-04T19:00:00+0800",
+            url="http://localhost:8000/v1/completions",
+            payload="{}",
+            status="error",
+            latency_ms=100.0,
+            success=False,
+            error="Connection refused",
+            retries=2,
+        )
+        d = entry.to_dict()
+        assert d["success"] is False
+        assert d["error"] == "Connection refused"
+        assert d["retries"] == 2
+
+
+class TestDebugLogger:
+    """Test DebugLogger file output."""
+
+    def test_log_creates_file(self, tmp_path):
+        log_path = tmp_path / "debug.jsonl"
+        logger = DebugLogger(log_path)
+        result = RequestResult(latency_ms=50.0, success=True)
+        logger.log(
+            url="http://localhost:8000/v1/completions",
+            payload={"prompt": "hello", "max_tokens": 128},
+            result=result,
+        )
+        logger.close()
+
+        assert log_path.exists()
+        lines = log_path.read_text().strip().split("\n")
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["url"] == "http://localhost:8000/v1/completions"
+        assert entry["success"] is True
+        assert entry["latency_ms"] == 50.0
+        assert "timestamp" in entry
+        assert "payload" in entry
+
+    def test_log_multiple_entries(self, tmp_path):
+        log_path = tmp_path / "debug.jsonl"
+        logger = DebugLogger(log_path)
+        for i in range(5):
+            result = RequestResult(latency_ms=float(i * 10), success=True)
+            logger.log(
+                url="http://localhost:8000/v1/completions",
+                payload={"prompt": f"prompt {i}"},
+                result=result,
+            )
+        logger.close()
+
+        lines = log_path.read_text().strip().split("\n")
+        assert len(lines) == 5
+        for i, line in enumerate(lines):
+            entry = json.loads(line)
+            assert entry["latency_ms"] == float(i * 10)
+
+    def test_log_error_entry(self, tmp_path):
+        log_path = tmp_path / "debug.jsonl"
+        logger = DebugLogger(log_path)
+        result = RequestResult(
+            latency_ms=200.0, success=False, error="timeout", retries=3
+        )
+        logger.log(
+            url="http://localhost:8000/v1/completions",
+            payload={"prompt": "test"},
+            result=result,
+        )
+        logger.close()
+
+        entry = json.loads(log_path.read_text().strip())
+        assert entry["success"] is False
+        assert entry["error"] == "timeout"
+        assert entry["retries"] == 3
+        assert entry["status"] == "error"
+
+    def test_payload_truncation(self, tmp_path):
+        log_path = tmp_path / "debug.jsonl"
+        logger = DebugLogger(log_path)
+        # Create a very large payload
+        long_prompt = "x" * 2000
+        result = RequestResult(latency_ms=10.0, success=True)
+        logger.log(
+            url="http://localhost:8000/v1/completions",
+            payload={"prompt": long_prompt},
+            result=result,
+        )
+        logger.close()
+
+        entry = json.loads(log_path.read_text().strip())
+        assert entry["payload"].endswith("...(truncated)")
+        assert len(entry["payload"]) < 600  # 512 + truncation marker
+
+    def test_creates_parent_dirs(self, tmp_path):
+        log_path = tmp_path / "subdir" / "deep" / "debug.jsonl"
+        logger = DebugLogger(log_path)
+        result = RequestResult(latency_ms=1.0, success=True)
+        logger.log(url="http://x", payload={}, result=result)
+        logger.close()
+        assert log_path.exists()
+
+
+class TestDebugLogCLI:
+    """Test --debug-log CLI argument parsing."""
+
+    def test_cli_arg_parsed(self):
+        """Verify --debug-log is recognized by the argument parser."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--debug-log", "/tmp/test.jsonl"])
+        assert args.debug_log == "/tmp/test.jsonl"
+
+    def test_cli_arg_default_none(self):
+        """Verify --debug-log defaults to None."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        assert args.debug_log is None
+
+
+class TestDebugLogYAMLConfig:
+    """Test YAML config support for debug_log."""
+
+    def test_yaml_config_sets_debug_log(self, tmp_path):
+        import argparse
+
+        import yaml
+
+        from xpyd_bench.cli import _add_vllm_compat_args, _load_yaml_config
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.dump({"debug_log": "/tmp/debug.jsonl"}))
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        args = _load_yaml_config(str(config_path), args)
+        assert args.debug_log == "/tmp/debug.jsonl"


### PR DESCRIPTION
## Summary
Add `--debug-log <path>` CLI flag to write per-request debug logs as JSONL for diagnosing failures in long benchmark runs.

## Changes
- New `src/xpyd_bench/bench/debug_log.py`: `DebugLogger` class with payload truncation
- CLI: `--debug-log <path>` argument in reporting group
- Runner integration: logs each request after completion
- YAML config support (`debug_log`)
- 10 new tests covering log creation, content, errors, truncation, CLI, and YAML

## Testing
All 436 tests pass. Lint clean (`ruff check` + `isort --check`).

Closes #62