### PR TITLE
feat: Configuration Dump & Validation (M23)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ xpyd-bench-compare = "xpyd_bench.cli:compare_main"
 xpyd-bench-multi = "xpyd_bench.cli:multi_main"
 xpyd-bench-profile = "xpyd_bench.cli:profile_main"
 xpyd-bench-replay = "xpyd_bench.cli:replay_main"
+xpyd-bench-config-dump = "xpyd_bench.config_cmd:config_dump_main"
+xpyd-bench-config-validate = "xpyd_bench.config_cmd:config_validate_main"
 xpyd-dummy = "xpyd_bench.dummy.cli:dummy_main"
 
 # Reserved for future xpyd CLI subcommand discovery

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -1,0 +1,204 @@
+"""Configuration dump and validation subcommands (M23)."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Known YAML config keys (matching CLI argument names with underscores)
+_KNOWN_KEYS: set[str] = {
+    "adaptive_concurrency",
+    "adaptive_initial_concurrency",
+    "adaptive_max_concurrency",
+    "adaptive_min_concurrency",
+    "adaptive_target_latency",
+    "api_key",
+    "api_seed",
+    "backend",
+    "base_url",
+    "best_of",
+    "burstiness",
+    "csv_report",
+    "dataset_name",
+    "dataset_path",
+    "debug_log",
+    "disable_tqdm",
+    "dry_run",
+    "echo",
+    "endpoint",
+    "export_requests",
+    "export_requests_csv",
+    "frequency_penalty",
+    "header",
+    "headers",
+    "host",
+    "html_report",
+    "ignore_eos",
+    "input_len",
+    "json_report",
+    "logit_bias",
+    "logprobs",
+    "markdown_report",
+    "max_completion_tokens",
+    "max_concurrency",
+    "metadata",
+    "model",
+    "n",
+    "num_prompts",
+    "output_len",
+    "parallel_tool_calls",
+    "port",
+    "presence_penalty",
+    "rate_algorithm",
+    "request_rate",
+    "response_format",
+    "result_dir",
+    "result_filename",
+    "retries",
+    "retry_delay",
+    "rich_progress",
+    "save_result",
+    "scenario",
+    "seed",
+    "service_tier",
+    "sla",
+    "stop",
+    "stream_options_include_usage",
+    "suffix",
+    "synthetic_input_len_dist",
+    "synthetic_output_len_dist",
+    "temperature",
+    "text_report",
+    "time_series_window",
+    "timeout",
+    "token_bucket_burst",
+    "tool_choice",
+    "tools",
+    "top_k",
+    "top_logprobs",
+    "top_p",
+    "use_beam_search",
+    "user",
+    "warmup",
+}
+
+# Deprecated keys (currently none, placeholder for future use)
+_DEPRECATED_KEYS: dict[str, str] = {}
+
+
+def _load_and_check_yaml(path: str) -> tuple[dict[str, Any], list[str], list[str]]:
+    """Load YAML config and return (config, warnings, errors)."""
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    config_path = Path(path)
+    if not config_path.exists():
+        errors.append(f"Config file not found: {path}")
+        return {}, warnings, errors
+
+    try:
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        errors.append(f"Invalid YAML syntax: {e}")
+        return {}, warnings, errors
+
+    if cfg is None:
+        warnings.append("Config file is empty")
+        return {}, warnings, errors
+
+    if not isinstance(cfg, dict):
+        errors.append(f"Config must be a YAML mapping, got {type(cfg).__name__}")
+        return {}, warnings, errors
+
+    for key in cfg:
+        normalized = str(key).replace("-", "_")
+        if normalized in _DEPRECATED_KEYS:
+            warnings.append(
+                f"Deprecated key '{key}': {_DEPRECATED_KEYS[normalized]}"
+            )
+        elif normalized not in _KNOWN_KEYS:
+            warnings.append(f"Unknown key '{key}' (will be ignored)")
+
+    return cfg, warnings, errors
+
+
+def config_dump_main(argv: list[str] | None = None) -> None:
+    """Entry point for ``xpyd-bench-config dump``."""
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench-config dump",
+        description="Print resolved configuration (CLI defaults + YAML merged).",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Path to YAML config file to merge with defaults.",
+    )
+    args = parser.parse_args(argv)
+
+    # Get CLI defaults from bench parser
+    from xpyd_bench.cli import _add_vllm_compat_args
+
+    bench_parser = argparse.ArgumentParser()
+    _add_vllm_compat_args(bench_parser)
+    defaults = vars(bench_parser.parse_args([]))
+
+    # Remove internal-only keys
+    for k in ("list_scenarios",):
+        defaults.pop(k, None)
+
+    # Merge YAML if provided
+    if args.config:
+        cfg, warnings, errors = _load_and_check_yaml(args.config)
+        if errors:
+            for e in errors:
+                print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(1)
+        for w in warnings:
+            print(f"WARNING: {w}", file=sys.stderr)
+        for key, value in cfg.items():
+            attr = str(key).replace("-", "_")
+            defaults[attr] = value
+
+    # Clean up for display: convert inf to string
+    for k, v in defaults.items():
+        if isinstance(v, float) and v == float("inf"):
+            defaults[k] = "inf"
+
+    print(yaml.dump(defaults, default_flow_style=False, sort_keys=True), end="")
+
+
+def config_validate_main(argv: list[str] | None = None) -> None:
+    """Entry point for ``xpyd-bench-config validate``."""
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench-config validate",
+        description="Validate a YAML config file without running a benchmark.",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        metavar="PATH",
+        help="Path to YAML config file to validate.",
+    )
+    args = parser.parse_args(argv)
+
+    cfg, warnings, errors = _load_and_check_yaml(args.config)
+
+    for w in warnings:
+        print(f"WARNING: {w}", file=sys.stderr)
+    for e in errors:
+        print(f"ERROR: {e}", file=sys.stderr)
+
+    if errors:
+        print("Validation FAILED.")
+        sys.exit(1)
+    else:
+        print("Validation OK.")
+        sys.exit(0)

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -1,0 +1,146 @@
+"""Tests for M23: Configuration Dump & Validation."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from xpyd_bench.config_cmd import (
+    _load_and_check_yaml,
+    config_dump_main,
+    config_validate_main,
+)
+
+
+class TestLoadAndCheckYaml:
+    """Test the YAML loading and validation helper."""
+
+    def test_valid_config(self, tmp_path):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(yaml.dump({"model": "gpt-4", "num_prompts": 100}))
+        cfg, warnings, errors = _load_and_check_yaml(str(cfg_path))
+        assert cfg == {"model": "gpt-4", "num_prompts": 100}
+        assert not warnings
+        assert not errors
+
+    def test_unknown_key_warning(self, tmp_path):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(yaml.dump({"model": "gpt-4", "bogus_key": 42}))
+        cfg, warnings, errors = _load_and_check_yaml(str(cfg_path))
+        assert len(warnings) == 1
+        assert "Unknown key 'bogus_key'" in warnings[0]
+        assert not errors
+
+    def test_file_not_found(self):
+        cfg, warnings, errors = _load_and_check_yaml("/nonexistent/path.yaml")
+        assert len(errors) == 1
+        assert "not found" in errors[0]
+
+    def test_invalid_yaml_syntax(self, tmp_path):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text("{{invalid: yaml: [")
+        cfg, warnings, errors = _load_and_check_yaml(str(cfg_path))
+        assert len(errors) == 1
+        assert "Invalid YAML syntax" in errors[0]
+
+    def test_empty_config(self, tmp_path):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text("")
+        cfg, warnings, errors = _load_and_check_yaml(str(cfg_path))
+        assert len(warnings) == 1
+        assert "empty" in warnings[0].lower()
+        assert not errors
+
+    def test_non_dict_config(self, tmp_path):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text("- item1\n- item2\n")
+        cfg, warnings, errors = _load_and_check_yaml(str(cfg_path))
+        assert len(errors) == 1
+        assert "mapping" in errors[0].lower()
+
+    def test_hyphenated_keys_normalized(self, tmp_path):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(yaml.dump({"request-rate": 10, "input-len": 128}))
+        cfg, warnings, errors = _load_and_check_yaml(str(cfg_path))
+        assert not warnings
+        assert not errors
+
+
+class TestConfigDump:
+    """Test config dump subcommand."""
+
+    def test_dump_defaults(self, capsys):
+        config_dump_main([])
+        output = capsys.readouterr().out
+        parsed = yaml.safe_load(output)
+        assert isinstance(parsed, dict)
+        assert "model" in parsed
+        assert "num_prompts" in parsed
+        assert parsed["num_prompts"] == 1000
+
+    def test_dump_with_yaml(self, tmp_path, capsys):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(yaml.dump({"model": "my-model", "num_prompts": 50}))
+        config_dump_main(["--config", str(cfg_path)])
+        output = capsys.readouterr().out
+        parsed = yaml.safe_load(output)
+        assert parsed["model"] == "my-model"
+        assert parsed["num_prompts"] == 50
+
+    def test_dump_with_invalid_config(self, tmp_path):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text("{{bad yaml")
+        with pytest.raises(SystemExit) as exc_info:
+            config_dump_main(["--config", str(cfg_path)])
+        assert exc_info.value.code == 1
+
+    def test_dump_unknown_key_warning(self, tmp_path, capsys):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(yaml.dump({"model": "x", "fake_option": True}))
+        config_dump_main(["--config", str(cfg_path)])
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "fake_option" in err
+
+
+class TestConfigValidate:
+    """Test config validate subcommand."""
+
+    def test_valid_config(self, tmp_path, capsys):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(yaml.dump({"model": "gpt-4", "num_prompts": 100}))
+        with pytest.raises(SystemExit) as exc_info:
+            config_validate_main(["--config", str(cfg_path)])
+        assert exc_info.value.code == 0
+        assert "Validation OK" in capsys.readouterr().out
+
+    def test_invalid_yaml(self, tmp_path, capsys):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text("{{bad")
+        with pytest.raises(SystemExit) as exc_info:
+            config_validate_main(["--config", str(cfg_path)])
+        assert exc_info.value.code == 1
+        assert "FAILED" in capsys.readouterr().out
+
+    def test_missing_file(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            config_validate_main(["--config", "/no/such/file.yaml"])
+        assert exc_info.value.code == 1
+
+    def test_unknown_keys_still_pass(self, tmp_path, capsys):
+        """Unknown keys produce warnings but validation still passes."""
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(yaml.dump({"model": "x", "unknown_key": 1}))
+        with pytest.raises(SystemExit) as exc_info:
+            config_validate_main(["--config", str(cfg_path)])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "Validation OK" in captured.out
+
+    def test_non_dict_fails(self, tmp_path, capsys):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text("[1, 2, 3]")
+        with pytest.raises(SystemExit) as exc_info:
+            config_validate_main(["--config", str(cfg_path)])
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary
Add `xpyd-bench-config-dump` and `xpyd-bench-config-validate` CLI subcommands for inspecting and validating configuration without running benchmarks.

## Changes
- New `src/xpyd_bench/config_cmd.py`: dump and validate subcommands with YAML key validation
- Entry points registered in `pyproject.toml`
- 16 new tests covering dump output, YAML merge, validation pass/fail, unknown keys, edge cases

## Testing
All 452 tests pass. Lint clean (`ruff check` + `isort --check`).

Closes #64