### PR TITLE
feat: unified CLI subcommand interface (M24)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -178,6 +178,14 @@
 - Tests covering log file creation and content
 
 ## M23: Configuration Dump & Validation ✅
+
+## M24: Unified CLI Subcommand Interface
+- Single `xpyd-bench <subcommand>` entry point with subcommand routing
+- Subcommands: `run`, `compare`, `multi`, `profile`, `replay`, `config dump`, `config validate`
+- `xpyd-bench` with no subcommand defaults to `run` for backward compatibility
+- `--version` flag prints package version
+- Legacy standalone entry points still work but print deprecation warning
+- Tests covering subcommand routing, backward compat, version flag, deprecation warnings
 - `xpyd-bench config dump` subcommand to print resolved configuration (CLI + YAML merged)
 - `xpyd-bench config validate --config <path>` to validate YAML config without running
 - Print warnings for deprecated or conflicting options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,13 @@ dev = [
 ]
 
 [project.scripts]
-xpyd-bench = "xpyd_bench.cli:bench_main"
-xpyd-bench-compare = "xpyd_bench.cli:compare_main"
-xpyd-bench-multi = "xpyd_bench.cli:multi_main"
-xpyd-bench-profile = "xpyd_bench.cli:profile_main"
-xpyd-bench-replay = "xpyd_bench.cli:replay_main"
-xpyd-bench-config-dump = "xpyd_bench.config_cmd:config_dump_main"
-xpyd-bench-config-validate = "xpyd_bench.config_cmd:config_validate_main"
+xpyd-bench = "xpyd_bench.main:main"
+xpyd-bench-compare = "xpyd_bench.main:deprecated_compare_main"
+xpyd-bench-multi = "xpyd_bench.main:deprecated_multi_main"
+xpyd-bench-profile = "xpyd_bench.main:deprecated_profile_main"
+xpyd-bench-replay = "xpyd_bench.main:deprecated_replay_main"
+xpyd-bench-config-dump = "xpyd_bench.main:deprecated_config_dump_main"
+xpyd-bench-config-validate = "xpyd_bench.main:deprecated_config_validate_main"
 xpyd-dummy = "xpyd_bench.dummy.cli:dummy_main"
 
 # Reserved for future xpyd CLI subcommand discovery

--- a/src/xpyd_bench/main.py
+++ b/src/xpyd_bench/main.py
@@ -1,0 +1,143 @@
+"""Unified CLI entry point for xpyd-bench (M24).
+
+Usage:
+    xpyd-bench run [args...]          # benchmark (default if no subcommand)
+    xpyd-bench compare [args...]      # compare results
+    xpyd-bench multi [args...]        # multi-endpoint mode
+    xpyd-bench profile [args...]      # profile recording
+    xpyd-bench replay [args...]       # replay traces
+    xpyd-bench config dump [args...]  # dump resolved config
+    xpyd-bench config validate [args...]  # validate config
+    xpyd-bench --version              # show version
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import sys
+import warnings
+
+
+def _get_version() -> str:
+    """Return the installed package version."""
+    try:
+        return importlib.metadata.version("xpyd-bench")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _deprecation_wrapper(func_path: str, legacy_name: str):
+    """Return a wrapper that prints a deprecation warning then calls the real function."""
+
+    def wrapper() -> None:
+        subcmd = legacy_name.replace("xpyd-bench-", "").replace("-", " ")
+        warnings.warn(
+            f"'{legacy_name}' is deprecated, use 'xpyd-bench {subcmd}' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        module_path, func_name = func_path.rsplit(":", 1)
+        mod = __import__(module_path, fromlist=[func_name])
+        getattr(mod, func_name)()
+
+    return wrapper
+
+
+# Legacy entry point wrappers
+deprecated_compare_main = _deprecation_wrapper(
+    "xpyd_bench.cli:compare_main", "xpyd-bench-compare"
+)
+deprecated_multi_main = _deprecation_wrapper(
+    "xpyd_bench.cli:multi_main", "xpyd-bench-multi"
+)
+deprecated_profile_main = _deprecation_wrapper(
+    "xpyd_bench.cli:profile_main", "xpyd-bench-profile"
+)
+deprecated_replay_main = _deprecation_wrapper(
+    "xpyd_bench.cli:replay_main", "xpyd-bench-replay"
+)
+deprecated_config_dump_main = _deprecation_wrapper(
+    "xpyd_bench.config_cmd:config_dump_main", "xpyd-bench-config-dump"
+)
+deprecated_config_validate_main = _deprecation_wrapper(
+    "xpyd_bench.config_cmd:config_validate_main", "xpyd-bench-config-validate"
+)
+
+
+_SUBCOMMANDS = {
+    "run",
+    "compare",
+    "multi",
+    "profile",
+    "replay",
+    "config",
+}
+
+
+def main() -> None:
+    """Unified CLI entry point."""
+    argv = sys.argv[1:]
+
+    # Handle --version anywhere
+    if "--version" in argv:
+        print(f"xpyd-bench {_get_version()}")
+        sys.exit(0)
+
+    # Determine subcommand
+    if not argv or argv[0] not in _SUBCOMMANDS:
+        # Default to 'run' — pass all args through
+        from xpyd_bench.cli import bench_main
+
+        bench_main(argv)
+        return
+
+    subcmd = argv[0]
+    rest = argv[1:]
+
+    if subcmd == "run":
+        from xpyd_bench.cli import bench_main
+
+        bench_main(rest)
+    elif subcmd == "compare":
+        from xpyd_bench.cli import compare_main
+
+        compare_main(rest)
+    elif subcmd == "multi":
+        from xpyd_bench.cli import multi_main
+
+        multi_main(rest)
+    elif subcmd == "profile":
+        from xpyd_bench.cli import profile_main
+
+        profile_main(rest)
+    elif subcmd == "replay":
+        from xpyd_bench.cli import replay_main
+
+        replay_main(rest)
+    elif subcmd == "config":
+        _config_subcommand(rest)
+
+
+def _config_subcommand(argv: list[str]) -> None:
+    """Handle 'xpyd-bench config <dump|validate>' subcommand."""
+    if not argv:
+        print("Usage: xpyd-bench config <dump|validate> [options]", file=sys.stderr)
+        sys.exit(1)
+
+    sub = argv[0]
+    rest = argv[1:]
+
+    if sub == "dump":
+        from xpyd_bench.config_cmd import config_dump_main
+
+        config_dump_main(rest)
+    elif sub == "validate":
+        from xpyd_bench.config_cmd import config_validate_main
+
+        config_validate_main(rest)
+    else:
+        print(
+            f"Unknown config subcommand '{sub}'. Use 'dump' or 'validate'.",
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/tests/test_unified_cli.py
+++ b/tests/test_unified_cli.py
@@ -1,0 +1,182 @@
+"""Tests for M24: Unified CLI Subcommand Interface."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+import yaml
+
+from xpyd_bench.main import (
+    _get_version,
+    deprecated_compare_main,
+    deprecated_config_dump_main,
+    deprecated_config_validate_main,
+    deprecated_multi_main,
+    deprecated_profile_main,
+    deprecated_replay_main,
+    main,
+)
+
+
+class TestVersionFlag:
+    """Test --version flag."""
+
+    def test_version_prints_and_exits(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench", "--version"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "xpyd-bench" in out
+
+    def test_get_version_returns_string(self):
+        v = _get_version()
+        assert isinstance(v, str)
+        assert len(v) > 0
+
+
+class TestSubcommandRouting:
+    """Test that subcommands route correctly."""
+
+    def test_run_subcommand(self, monkeypatch):
+        """'xpyd-bench run --help' should trigger bench_main."""
+        monkeypatch.setattr("sys.argv", ["xpyd-bench", "run", "--help"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+    def test_compare_subcommand(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench", "compare", "--help"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+    def test_multi_subcommand(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench", "multi", "--help"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+    def test_profile_subcommand(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench", "profile", "--help"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+    def test_replay_subcommand(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench", "replay", "--help"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+    def test_config_dump_subcommand(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench", "config", "dump"])
+        main()
+        out = capsys.readouterr().out
+        parsed = yaml.safe_load(out)
+        assert isinstance(parsed, dict)
+        assert "model" in parsed
+
+    def test_config_validate_subcommand(self, monkeypatch, tmp_path, capsys):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(yaml.dump({"model": "gpt-4"}))
+        monkeypatch.setattr(
+            "sys.argv", ["xpyd-bench", "config", "validate", "--config", str(cfg)]
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+        assert "Validation OK" in capsys.readouterr().out
+
+    def test_config_no_sub(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench", "config"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 1
+
+    def test_config_unknown_sub(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench", "config", "bogus"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 1
+
+
+class TestBackwardCompat:
+    """Test that no subcommand defaults to 'run'."""
+
+    def test_no_subcommand_defaults_to_run(self, monkeypatch):
+        """'xpyd-bench --help' should trigger bench_main (run)."""
+        monkeypatch.setattr("sys.argv", ["xpyd-bench", "--help"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+    def test_unknown_arg_goes_to_run(self, monkeypatch):
+        """Unknown first arg (not a subcommand) passes to run."""
+        monkeypatch.setattr("sys.argv", ["xpyd-bench", "--model", "gpt-4", "--help"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+
+class TestDeprecationWarnings:
+    """Test legacy entry points emit deprecation warnings."""
+
+    def test_deprecated_compare(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench-compare", "--help"])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with pytest.raises(SystemExit):
+                deprecated_compare_main()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "deprecated" in str(w[0].message).lower()
+
+    def test_deprecated_multi(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench-multi", "--help"])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with pytest.raises(SystemExit):
+                deprecated_multi_main()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+    def test_deprecated_profile(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench-profile", "--help"])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with pytest.raises(SystemExit):
+                deprecated_profile_main()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+    def test_deprecated_replay(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench-replay", "--help"])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with pytest.raises(SystemExit):
+                deprecated_replay_main()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+    def test_deprecated_config_dump(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench-config-dump"])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            deprecated_config_dump_main()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+    def test_deprecated_config_validate(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(yaml.dump({"model": "x"}))
+        monkeypatch.setattr(
+            "sys.argv", ["xpyd-bench-config-validate", "--config", str(cfg)]
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with pytest.raises(SystemExit):
+                deprecated_config_validate_main()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)


### PR DESCRIPTION
## Summary
Implement a unified `xpyd-bench <subcommand>` CLI entry point (M24).

### Changes
- **New:** `src/xpyd_bench/main.py` — unified entry point with subcommand routing
- **Subcommands:** `run`, `compare`, `multi`, `profile`, `replay`, `config dump`, `config validate`
- No subcommand defaults to `run` for backward compatibility
- `--version` flag prints package version
- Legacy entry points (`xpyd-bench-compare`, etc.) still work but emit `DeprecationWarning`
- Updated `pyproject.toml` entry points
- Added M24 to ROADMAP.md
- **19 new tests** in `test_unified_cli.py`, all 471 tests pass

Closes #66