### PR TITLE
feat: result aggregation across multiple runs (M25)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -179,13 +179,23 @@
 
 ## M23: Configuration Dump & Validation ✅
 
-## M24: Unified CLI Subcommand Interface
+## M24: Unified CLI Subcommand Interface ✅
 - Single `xpyd-bench <subcommand>` entry point with subcommand routing
 - Subcommands: `run`, `compare`, `multi`, `profile`, `replay`, `config dump`, `config validate`
 - `xpyd-bench` with no subcommand defaults to `run` for backward compatibility
 - `--version` flag prints package version
 - Legacy standalone entry points still work but print deprecation warning
 - Tests covering subcommand routing, backward compat, version flag, deprecation warnings
+
+## M25: Result Aggregation Across Multiple Runs
+- `xpyd-bench aggregate <result1.json> <result2.json> ...` CLI subcommand
+- Compute mean, stddev, min, max across runs for key metrics (TTFT, TPOT, throughput, latency percentiles)
+- Coefficient of variation (CV) per metric to flag unstable benchmarks
+- `--output <path>` to save aggregated summary as JSON
+- `--min-runs N` to enforce minimum number of runs (default 2)
+- Detect and warn about outlier runs (>2 stddev from mean)
+- Human-readable table output with statistical summary
+- Tests covering aggregation math, outlier detection, CLI integration, edge cases
 - `xpyd-bench config dump` subcommand to print resolved configuration (CLI + YAML merged)
 - `xpyd-bench config validate --config <path>` to validate YAML config without running
 - Print warnings for deprecated or conflicting options

--- a/src/xpyd_bench/aggregate.py
+++ b/src/xpyd_bench/aggregate.py
@@ -1,0 +1,192 @@
+"""Result aggregation across multiple benchmark runs (M25).
+
+Usage:
+    xpyd-bench aggregate result1.json result2.json [--output agg.json] [--min-runs N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+# Metrics to aggregate from BenchmarkResult JSON
+_METRIC_KEYS: list[str] = [
+    "mean_ttft_ms",
+    "p50_ttft_ms",
+    "p90_ttft_ms",
+    "p95_ttft_ms",
+    "p99_ttft_ms",
+    "mean_tpot_ms",
+    "p50_tpot_ms",
+    "p90_tpot_ms",
+    "p95_tpot_ms",
+    "p99_tpot_ms",
+    "mean_e2el_ms",
+    "p50_e2el_ms",
+    "p90_e2el_ms",
+    "p95_e2el_ms",
+    "p99_e2el_ms",
+    "request_throughput",
+    "output_throughput",
+    "total_token_throughput",
+]
+
+
+@dataclass
+class MetricStats:
+    """Statistical summary for a single metric across runs."""
+
+    mean: float = 0.0
+    stddev: float = 0.0
+    min: float = 0.0
+    max: float = 0.0
+    cv: float = 0.0  # coefficient of variation
+
+
+@dataclass
+class AggregateResult:
+    """Aggregated statistics across multiple benchmark runs."""
+
+    num_runs: int = 0
+    metrics: dict[str, MetricStats] = field(default_factory=dict)
+    outlier_runs: list[int] = field(default_factory=list)  # 0-based indices
+
+    def to_dict(self) -> dict:
+        """Serialize to plain dict for JSON output."""
+        return {
+            "num_runs": self.num_runs,
+            "outlier_run_indices": self.outlier_runs,
+            "metrics": {
+                k: {
+                    "mean": round(v.mean, 4),
+                    "stddev": round(v.stddev, 4),
+                    "min": round(v.min, 4),
+                    "max": round(v.max, 4),
+                    "cv": round(v.cv, 4),
+                }
+                for k, v in self.metrics.items()
+            },
+        }
+
+
+def _compute_stats(values: list[float]) -> MetricStats:
+    """Compute statistical summary for a list of values."""
+    arr = np.array(values, dtype=np.float64)
+    mean = float(np.mean(arr))
+    stddev = float(np.std(arr, ddof=1)) if len(arr) > 1 else 0.0
+    cv = stddev / mean if mean != 0 else 0.0
+    return MetricStats(
+        mean=mean,
+        stddev=stddev,
+        min=float(np.min(arr)),
+        max=float(np.max(arr)),
+        cv=cv,
+    )
+
+
+def _detect_outliers(values: list[float]) -> list[int]:
+    """Return indices of values >2 stddev from mean."""
+    if len(values) < 3:
+        return []
+    arr = np.array(values, dtype=np.float64)
+    mean = float(np.mean(arr))
+    std = float(np.std(arr, ddof=1))
+    if std == 0:
+        return []
+    return [i for i, v in enumerate(values) if abs(v - mean) > 2 * std]
+
+
+def aggregate_results(results: list[dict]) -> AggregateResult:
+    """Aggregate multiple BenchmarkResult dicts into statistical summary."""
+    agg = AggregateResult(num_runs=len(results))
+
+    for key in _METRIC_KEYS:
+        values = [r.get(key, 0.0) for r in results]
+        # Skip metrics that are all zero
+        if all(v == 0.0 for v in values):
+            continue
+        agg.metrics[key] = _compute_stats(values)
+
+    # Detect outlier runs based on request_throughput
+    tp_values = [r.get("request_throughput", 0.0) for r in results]
+    if not all(v == 0.0 for v in tp_values):
+        agg.outlier_runs = _detect_outliers(tp_values)
+
+    return agg
+
+
+def _print_table(agg: AggregateResult) -> None:
+    """Print human-readable summary table."""
+    print(f"\n{'='*80}")
+    print(f"Aggregate Summary ({agg.num_runs} runs)")
+    print(f"{'='*80}")
+    header = f"{'Metric':<30} {'Mean':>10} {'Stddev':>10} {'Min':>10} {'Max':>10} {'CV':>8}"
+    print(header)
+    print("-" * 80)
+    for key, stats in agg.metrics.items():
+        cv_flag = " ⚠" if stats.cv > 0.15 else ""
+        print(
+            f"{key:<30} {stats.mean:>10.2f} {stats.stddev:>10.2f} "
+            f"{stats.min:>10.2f} {stats.max:>10.2f} {stats.cv:>7.2%}{cv_flag}"
+        )
+    if agg.outlier_runs:
+        print(f"\n⚠ Outlier runs detected (indices): {agg.outlier_runs}")
+    print()
+
+
+def aggregate_main(argv: list[str] | None = None) -> None:
+    """CLI entry point for aggregate subcommand."""
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench aggregate",
+        description="Aggregate metrics across multiple benchmark result files.",
+    )
+    parser.add_argument(
+        "results",
+        nargs="+",
+        help="Paths to benchmark result JSON files",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        default=None,
+        help="Save aggregated summary to JSON file",
+    )
+    parser.add_argument(
+        "--min-runs",
+        type=int,
+        default=2,
+        help="Minimum number of runs required (default: 2)",
+    )
+
+    args = parser.parse_args(argv)
+
+    if len(args.results) < args.min_runs:
+        print(
+            f"Error: need at least {args.min_runs} result files, got {len(args.results)}.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    results: list[dict] = []
+    for path_str in args.results:
+        path = Path(path_str)
+        if not path.exists():
+            print(f"Error: file not found: {path}", file=sys.stderr)
+            sys.exit(1)
+        with open(path) as f:
+            results.append(json.load(f))
+
+    agg = aggregate_results(results)
+    _print_table(agg)
+
+    if args.output:
+        out_path = Path(args.output)
+        with open(out_path, "w") as f:
+            json.dump(agg.to_dict(), f, indent=2)
+        print(f"Saved aggregated summary to {out_path}")

--- a/src/xpyd_bench/main.py
+++ b/src/xpyd_bench/main.py
@@ -71,6 +71,7 @@ _SUBCOMMANDS = {
     "profile",
     "replay",
     "config",
+    "aggregate",
 }
 
 
@@ -116,6 +117,10 @@ def main() -> None:
         replay_main(rest)
     elif subcmd == "config":
         _config_subcommand(rest)
+    elif subcmd == "aggregate":
+        from xpyd_bench.aggregate import aggregate_main
+
+        aggregate_main(rest)
 
 
 def _config_subcommand(argv: list[str]) -> None:

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,0 +1,171 @@
+"""Tests for M25: Result Aggregation Across Multiple Runs."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xpyd_bench.aggregate import (
+    _compute_stats,
+    _detect_outliers,
+    aggregate_main,
+    aggregate_results,
+)
+
+
+def _make_result(
+    throughput: float = 10.0,
+    mean_ttft: float = 50.0,
+    p99_ttft: float = 100.0,
+    mean_tpot: float = 20.0,
+) -> dict:
+    """Create a minimal BenchmarkResult-like dict."""
+    return {
+        "request_throughput": throughput,
+        "output_throughput": throughput * 10,
+        "total_token_throughput": throughput * 15,
+        "mean_ttft_ms": mean_ttft,
+        "p50_ttft_ms": mean_ttft * 0.9,
+        "p90_ttft_ms": mean_ttft * 1.5,
+        "p95_ttft_ms": mean_ttft * 1.8,
+        "p99_ttft_ms": p99_ttft,
+        "mean_tpot_ms": mean_tpot,
+        "p50_tpot_ms": mean_tpot * 0.9,
+        "p90_tpot_ms": mean_tpot * 1.5,
+        "p95_tpot_ms": mean_tpot * 1.8,
+        "p99_tpot_ms": mean_tpot * 2.0,
+        "mean_e2el_ms": 200.0,
+        "p50_e2el_ms": 180.0,
+        "p90_e2el_ms": 250.0,
+        "p95_e2el_ms": 280.0,
+        "p99_e2el_ms": 300.0,
+    }
+
+
+class TestComputeStats:
+    """Test statistical computation."""
+
+    def test_basic_stats(self):
+        stats = _compute_stats([10.0, 20.0, 30.0])
+        assert abs(stats.mean - 20.0) < 0.01
+        assert stats.min == 10.0
+        assert stats.max == 30.0
+        assert stats.stddev > 0
+
+    def test_single_value(self):
+        stats = _compute_stats([5.0])
+        assert stats.mean == 5.0
+        assert stats.stddev == 0.0
+        assert stats.cv == 0.0
+
+    def test_identical_values(self):
+        stats = _compute_stats([7.0, 7.0, 7.0])
+        assert stats.cv == 0.0
+
+    def test_cv_calculation(self):
+        stats = _compute_stats([100.0, 100.0])
+        assert stats.cv == 0.0
+
+
+class TestDetectOutliers:
+    """Test outlier detection."""
+
+    def test_no_outliers(self):
+        assert _detect_outliers([10.0, 10.1, 9.9, 10.0]) == []
+
+    def test_outlier_detected(self):
+        values = [10.0, 10.0, 10.0, 10.0, 10.0, 50.0]
+        outliers = _detect_outliers(values)
+        assert 5 in outliers
+
+    def test_too_few_values(self):
+        assert _detect_outliers([1.0, 2.0]) == []
+
+    def test_all_same(self):
+        assert _detect_outliers([5.0, 5.0, 5.0, 5.0]) == []
+
+
+class TestAggregateResults:
+    """Test the main aggregation logic."""
+
+    def test_two_runs(self):
+        r1 = _make_result(throughput=10.0, mean_ttft=50.0)
+        r2 = _make_result(throughput=12.0, mean_ttft=60.0)
+        agg = aggregate_results([r1, r2])
+        assert agg.num_runs == 2
+        assert "request_throughput" in agg.metrics
+        assert abs(agg.metrics["request_throughput"].mean - 11.0) < 0.01
+
+    def test_to_dict(self):
+        r1 = _make_result()
+        r2 = _make_result()
+        agg = aggregate_results([r1, r2])
+        d = agg.to_dict()
+        assert d["num_runs"] == 2
+        assert isinstance(d["metrics"], dict)
+        for v in d["metrics"].values():
+            assert "mean" in v
+            assert "stddev" in v
+
+    def test_outlier_in_results(self):
+        runs = [_make_result(throughput=10.0) for _ in range(5)]
+        runs.append(_make_result(throughput=100.0))  # outlier
+        agg = aggregate_results(runs)
+        assert 5 in agg.outlier_runs
+
+
+class TestAggregateCLI:
+    """Test CLI integration."""
+
+    def test_aggregate_two_files(self, tmp_path):
+        f1 = tmp_path / "r1.json"
+        f2 = tmp_path / "r2.json"
+        f1.write_text(json.dumps(_make_result(throughput=10.0)))
+        f2.write_text(json.dumps(_make_result(throughput=12.0)))
+        aggregate_main([str(f1), str(f2)])
+
+    def test_aggregate_with_output(self, tmp_path):
+        f1 = tmp_path / "r1.json"
+        f2 = tmp_path / "r2.json"
+        out = tmp_path / "agg.json"
+        f1.write_text(json.dumps(_make_result()))
+        f2.write_text(json.dumps(_make_result()))
+        aggregate_main([str(f1), str(f2), "--output", str(out)])
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert data["num_runs"] == 2
+
+    def test_min_runs_error(self, tmp_path):
+        f1 = tmp_path / "r1.json"
+        f1.write_text(json.dumps(_make_result()))
+        with pytest.raises(SystemExit) as exc_info:
+            aggregate_main([str(f1)])
+        assert exc_info.value.code == 1
+
+    def test_min_runs_override(self, tmp_path):
+        f1 = tmp_path / "r1.json"
+        f1.write_text(json.dumps(_make_result()))
+        aggregate_main([str(f1), "--min-runs", "1"])
+
+    def test_file_not_found(self, tmp_path):
+        with pytest.raises(SystemExit) as exc_info:
+            aggregate_main([str(tmp_path / "nope.json"), str(tmp_path / "nope2.json")])
+        assert exc_info.value.code == 1
+
+    def test_help(self):
+        with pytest.raises(SystemExit) as exc_info:
+            aggregate_main(["--help"])
+        assert exc_info.value.code == 0
+
+
+class TestUnifiedCLIAggregate:
+    """Test aggregate routing through unified CLI."""
+
+    def test_aggregate_subcommand_help(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["xpyd-bench", "aggregate", "--help"])
+        from xpyd_bench.main import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0


### PR DESCRIPTION
## Summary
Add `xpyd-bench aggregate` subcommand for statistical aggregation across multiple benchmark runs.

## Changes
- New `src/xpyd_bench/aggregate.py`: aggregation logic with mean/stddev/min/max/CV computation, outlier detection, CLI entry point
- Wired into unified CLI (`main.py`) as `aggregate` subcommand
- 18 new tests in `tests/test_aggregate.py`
- ROADMAP.md: M24 marked ✅, M25 added

## Features
- `xpyd-bench aggregate r1.json r2.json ...` — compute stats across runs
- `--output agg.json` — save aggregated summary as JSON
- `--min-runs N` — enforce minimum run count (default 2)
- CV > 15% warning for unstable metrics
- Outlier run detection (>2σ from mean throughput)

Closes #70