### PR TITLE
fix: include environment field in _to_dict() output

### DIFF
--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -780,6 +780,8 @@ def _to_dict(r: BenchmarkResult) -> dict:
         for stat in ("mean", "median", "p50", "p90", "p95", "p99"):
             key = f"{stat}_{prefix}_ms"
             d[key] = getattr(r, key)
+    if r.environment:
+        d["environment"] = r.environment
     if r.partial:
         d["partial"] = True
     return d

--- a/tests/test_env_info.py
+++ b/tests/test_env_info.py
@@ -10,6 +10,7 @@ from dataclasses import asdict
 
 from xpyd_bench.bench.env import collect_env_info
 from xpyd_bench.bench.models import BenchmarkResult
+from xpyd_bench.bench.runner import _to_dict
 
 
 class TestCollectEnvInfo:
@@ -94,3 +95,19 @@ class TestBenchmarkResultEnvironment:
         raw = json.dumps(data, default=str)
         loaded = json.loads(raw)
         assert loaded["environment"]["hostname"] == socket.gethostname()
+
+
+class TestToDictEnvironment:
+    """Tests that _to_dict() includes environment in output."""
+
+    def test_to_dict_includes_environment(self):
+        env = collect_env_info()
+        r = BenchmarkResult(environment=env)
+        d = _to_dict(r)
+        assert "environment" in d
+        assert d["environment"]["os"] == platform.system()
+
+    def test_to_dict_omits_empty_environment(self):
+        r = BenchmarkResult()
+        d = _to_dict(r)
+        assert "environment" not in d


### PR DESCRIPTION
## Summary

`_to_dict()` in `runner.py` was omitting the `environment` metadata from serialized `BenchmarkResult` dicts. This caused all saved JSON results to miss the M21 requirement that environment info be included.

### Changes
- Add `d["environment"] = r.environment` in `_to_dict()` when environment is populated
- Add tests verifying `_to_dict` includes environment when present and omits it when empty

Closes #80
Closes #72