### PR TITLE
fix: use None instead of 0.0 for unmeasured latency percentiles

### DIFF
--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -48,31 +48,31 @@ class BenchmarkResult:
     output_throughput: float = 0.0  # output tok/s
     total_token_throughput: float = 0.0  # (input+output) tok/s
 
-    # Latency percentiles
-    mean_ttft_ms: float = 0.0
-    median_ttft_ms: float = 0.0
-    p50_ttft_ms: float = 0.0
-    p90_ttft_ms: float = 0.0
-    p95_ttft_ms: float = 0.0
-    p99_ttft_ms: float = 0.0
-    mean_tpot_ms: float = 0.0
-    median_tpot_ms: float = 0.0
-    p50_tpot_ms: float = 0.0
-    p90_tpot_ms: float = 0.0
-    p95_tpot_ms: float = 0.0
-    p99_tpot_ms: float = 0.0
-    mean_itl_ms: float = 0.0
-    median_itl_ms: float = 0.0
-    p50_itl_ms: float = 0.0
-    p90_itl_ms: float = 0.0
-    p95_itl_ms: float = 0.0
-    p99_itl_ms: float = 0.0
-    mean_e2el_ms: float = 0.0
-    median_e2el_ms: float = 0.0
-    p50_e2el_ms: float = 0.0
-    p90_e2el_ms: float = 0.0
-    p95_e2el_ms: float = 0.0
-    p99_e2el_ms: float = 0.0
+    # Latency percentiles (None = metric not measured)
+    mean_ttft_ms: float | None = None
+    median_ttft_ms: float | None = None
+    p50_ttft_ms: float | None = None
+    p90_ttft_ms: float | None = None
+    p95_ttft_ms: float | None = None
+    p99_ttft_ms: float | None = None
+    mean_tpot_ms: float | None = None
+    median_tpot_ms: float | None = None
+    p50_tpot_ms: float | None = None
+    p90_tpot_ms: float | None = None
+    p95_tpot_ms: float | None = None
+    p99_tpot_ms: float | None = None
+    mean_itl_ms: float | None = None
+    median_itl_ms: float | None = None
+    p50_itl_ms: float | None = None
+    p90_itl_ms: float | None = None
+    p95_itl_ms: float | None = None
+    p99_itl_ms: float | None = None
+    mean_e2el_ms: float | None = None
+    median_e2el_ms: float | None = None
+    p50_e2el_ms: float | None = None
+    p90_e2el_ms: float | None = None
+    p95_e2el_ms: float | None = None
+    p99_e2el_ms: float | None = None
 
     # Partial result flag (set when benchmark was interrupted)
     partial: bool = False

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -670,10 +670,13 @@ def _print_summary(r: BenchmarkResult) -> None:
         p90 = getattr(r, f"p90_{prefix}_ms")
         p95 = getattr(r, f"p95_{prefix}_ms")
         p99 = getattr(r, f"p99_{prefix}_ms")
-        print(
-            f"  {label:5s}  mean={mean:8.2f}  P50={p50:8.2f}  "
-            f"P90={p90:8.2f}  P95={p95:8.2f}  P99={p99:8.2f} ms"
-        )
+        if mean is None:
+            print(f"  {label:5s}  N/A (not measured)")
+        else:
+            print(
+                f"  {label:5s}  mean={mean:8.2f}  P50={p50:8.2f}  "
+                f"P90={p90:8.2f}  P95={p95:8.2f}  P99={p99:8.2f} ms"
+            )
     print("=" * 60)
 
 
@@ -779,7 +782,8 @@ def _to_dict(r: BenchmarkResult) -> dict:
     for prefix in ("ttft", "tpot", "itl", "e2el"):
         for stat in ("mean", "median", "p50", "p90", "p95", "p99"):
             key = f"{stat}_{prefix}_ms"
-            d[key] = getattr(r, key)
+            val = getattr(r, key)
+            d[key] = val  # None serializes as JSON null
     if r.environment:
         d["environment"] = r.environment
     if r.partial:

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -1060,9 +1060,9 @@ def replay_main(argv: list[str] | None = None) -> None:
     print(f"Replay complete: {bench_result.completed}/{bench_result.num_prompts} succeeded")
     print(f"Total duration:  {bench_result.total_duration_s:.2f}s")
     print(f"Throughput:      {bench_result.request_throughput:.2f} req/s")
-    if bench_result.mean_ttft_ms > 0:
+    if bench_result.mean_ttft_ms is not None:
         print(f"Mean TTFT:       {bench_result.mean_ttft_ms:.2f}ms")
-    if bench_result.mean_e2el_ms > 0:
+    if bench_result.mean_e2el_ms is not None:
         print(f"Mean E2E:        {bench_result.mean_e2el_ms:.2f}ms")
 
     if args.save_result:

--- a/src/xpyd_bench/multi.py
+++ b/src/xpyd_bench/multi.py
@@ -125,8 +125,10 @@ def format_multi_summary(multi: MultiEndpointResult) -> str:
     for label, attr in display_metrics:
         row = [f"{label:<28s}"]
         for r in multi.results:
-            val = getattr(r, attr, 0)
-            if isinstance(val, float):
+            val = getattr(r, attr, None)
+            if val is None:
+                row.append(f"{'N/A':>20s}")
+            elif isinstance(val, float):
                 row.append(f"{val:>20.2f}")
             else:
                 row.append(f"{val!s:>20s}")
@@ -193,8 +195,10 @@ def format_multi_markdown(multi: MultiEndpointResult) -> str:
     for metric in display_metrics:
         cells = [metric]
         for r in multi.results:
-            val = getattr(r, metric, 0)
-            if isinstance(val, float):
+            val = getattr(r, metric, None)
+            if val is None:
+                cells.append("N/A")
+            elif isinstance(val, float):
                 cells.append(f"{val:.2f}")
             else:
                 cells.append(str(val))

--- a/src/xpyd_bench/reporting/formats.py
+++ b/src/xpyd_bench/reporting/formats.py
@@ -87,6 +87,9 @@ def format_text_report(result: BenchmarkResult) -> str:
     header = f"  {'Metric':6s} {'Mean':>8s} {'P50':>8s} {'P90':>8s} {'P95':>8s} {'P99':>8s}"
     lines.append(header)
     lines.append("  " + "-" * 66)
+    def _fmt(v: float | None) -> str:
+        return f"{v:8.2f}" if v is not None else "     N/A"
+
     for label, prefix in [("TTFT", "ttft"), ("TPOT", "tpot"), ("ITL", "itl"), ("E2EL", "e2el")]:
         mean = getattr(result, f"mean_{prefix}_ms")
         p50 = getattr(result, f"p50_{prefix}_ms")
@@ -94,7 +97,7 @@ def format_text_report(result: BenchmarkResult) -> str:
         p95 = getattr(result, f"p95_{prefix}_ms")
         p99 = getattr(result, f"p99_{prefix}_ms")
         lines.append(
-            f"  {label:6s} {mean:8.2f} {p50:8.2f} {p90:8.2f} {p95:8.2f} {p99:8.2f}"
+            f"  {label:6s} {_fmt(mean)} {_fmt(p50)} {_fmt(p90)} {_fmt(p95)} {_fmt(p99)}"
         )
     lines.append("  " + "-" * 66)
     lines.append("=" * 70)
@@ -104,6 +107,11 @@ def format_text_report(result: BenchmarkResult) -> str:
 # ---------------------------------------------------------------------------
 # Summary column definitions (shared by CSV and Markdown)
 # ---------------------------------------------------------------------------
+
+def _fmt_or_na(v: float | None) -> str:
+    """Format a float or return N/A for None."""
+    return f"{v:.2f}" if v is not None else "N/A"
+
 
 _SUMMARY_COLUMNS = [
     ("backend", lambda r: r.backend),
@@ -115,26 +123,26 @@ _SUMMARY_COLUMNS = [
     ("request_throughput", lambda r: f"{r.request_throughput:.2f}"),
     ("output_throughput", lambda r: f"{r.output_throughput:.2f}"),
     ("total_token_throughput", lambda r: f"{r.total_token_throughput:.2f}"),
-    ("mean_ttft_ms", lambda r: f"{r.mean_ttft_ms:.2f}"),
-    ("p50_ttft_ms", lambda r: f"{r.p50_ttft_ms:.2f}"),
-    ("p90_ttft_ms", lambda r: f"{r.p90_ttft_ms:.2f}"),
-    ("p95_ttft_ms", lambda r: f"{r.p95_ttft_ms:.2f}"),
-    ("p99_ttft_ms", lambda r: f"{r.p99_ttft_ms:.2f}"),
-    ("mean_tpot_ms", lambda r: f"{r.mean_tpot_ms:.2f}"),
-    ("p50_tpot_ms", lambda r: f"{r.p50_tpot_ms:.2f}"),
-    ("p90_tpot_ms", lambda r: f"{r.p90_tpot_ms:.2f}"),
-    ("p95_tpot_ms", lambda r: f"{r.p95_tpot_ms:.2f}"),
-    ("p99_tpot_ms", lambda r: f"{r.p99_tpot_ms:.2f}"),
-    ("mean_itl_ms", lambda r: f"{r.mean_itl_ms:.2f}"),
-    ("p50_itl_ms", lambda r: f"{r.p50_itl_ms:.2f}"),
-    ("p90_itl_ms", lambda r: f"{r.p90_itl_ms:.2f}"),
-    ("p95_itl_ms", lambda r: f"{r.p95_itl_ms:.2f}"),
-    ("p99_itl_ms", lambda r: f"{r.p99_itl_ms:.2f}"),
-    ("mean_e2el_ms", lambda r: f"{r.mean_e2el_ms:.2f}"),
-    ("p50_e2el_ms", lambda r: f"{r.p50_e2el_ms:.2f}"),
-    ("p90_e2el_ms", lambda r: f"{r.p90_e2el_ms:.2f}"),
-    ("p95_e2el_ms", lambda r: f"{r.p95_e2el_ms:.2f}"),
-    ("p99_e2el_ms", lambda r: f"{r.p99_e2el_ms:.2f}"),
+    ("mean_ttft_ms", lambda r: _fmt_or_na(r.mean_ttft_ms)),
+    ("p50_ttft_ms", lambda r: _fmt_or_na(r.p50_ttft_ms)),
+    ("p90_ttft_ms", lambda r: _fmt_or_na(r.p90_ttft_ms)),
+    ("p95_ttft_ms", lambda r: _fmt_or_na(r.p95_ttft_ms)),
+    ("p99_ttft_ms", lambda r: _fmt_or_na(r.p99_ttft_ms)),
+    ("mean_tpot_ms", lambda r: _fmt_or_na(r.mean_tpot_ms)),
+    ("p50_tpot_ms", lambda r: _fmt_or_na(r.p50_tpot_ms)),
+    ("p90_tpot_ms", lambda r: _fmt_or_na(r.p90_tpot_ms)),
+    ("p95_tpot_ms", lambda r: _fmt_or_na(r.p95_tpot_ms)),
+    ("p99_tpot_ms", lambda r: _fmt_or_na(r.p99_tpot_ms)),
+    ("mean_itl_ms", lambda r: _fmt_or_na(r.mean_itl_ms)),
+    ("p50_itl_ms", lambda r: _fmt_or_na(r.p50_itl_ms)),
+    ("p90_itl_ms", lambda r: _fmt_or_na(r.p90_itl_ms)),
+    ("p95_itl_ms", lambda r: _fmt_or_na(r.p95_itl_ms)),
+    ("p99_itl_ms", lambda r: _fmt_or_na(r.p99_itl_ms)),
+    ("mean_e2el_ms", lambda r: _fmt_or_na(r.mean_e2el_ms)),
+    ("p50_e2el_ms", lambda r: _fmt_or_na(r.p50_e2el_ms)),
+    ("p90_e2el_ms", lambda r: _fmt_or_na(r.p90_e2el_ms)),
+    ("p95_e2el_ms", lambda r: _fmt_or_na(r.p95_e2el_ms)),
+    ("p99_e2el_ms", lambda r: _fmt_or_na(r.p99_e2el_ms)),
 ]
 
 _PER_REQUEST_COLUMNS = [

--- a/src/xpyd_bench/reporting/html_report.py
+++ b/src/xpyd_bench/reporting/html_report.py
@@ -54,6 +54,10 @@ def _build_summary_rows(result: BenchmarkResult) -> str:
 def _build_percentile_rows(result: BenchmarkResult) -> str:
     """Build HTML table rows for latency percentiles."""
     rows = []
+
+    def _fh(v: float | None) -> str:
+        return f"{v:.2f}" if v is not None else "N/A"
+
     for label, prefix in [("TTFT", "ttft"), ("TPOT", "tpot"),
                            ("ITL", "itl"), ("E2E Latency", "e2el")]:
         mean = getattr(result, f"mean_{prefix}_ms")
@@ -63,9 +67,9 @@ def _build_percentile_rows(result: BenchmarkResult) -> str:
         p99 = getattr(result, f"p99_{prefix}_ms")
         rows.append(
             f"<tr><td>{_safe(label)}</td>"
-            f"<td>{mean:.2f}</td><td>{p50:.2f}</td>"
-            f"<td>{p90:.2f}</td><td>{p95:.2f}</td>"
-            f"<td class='p99'>{p99:.2f}</td></tr>"
+            f"<td>{_fh(mean)}</td><td>{_fh(p50)}</td>"
+            f"<td>{_fh(p90)}</td><td>{_fh(p95)}</td>"
+            f"<td class='p99'>{_fh(p99)}</td></tr>"
         )
     return "\n".join(rows)
 

--- a/tests/test_unmeasured_percentiles.py
+++ b/tests/test_unmeasured_percentiles.py
@@ -1,0 +1,43 @@
+"""Tests for issue #78: unmeasured latency percentiles should be None, not 0.0."""
+
+from __future__ import annotations
+
+from xpyd_bench.bench.models import BenchmarkResult, RequestResult
+from xpyd_bench.bench.runner import _compute_metrics, _to_dict
+
+
+class TestUnmeasuredPercentiles:
+    """Percentiles for unmeasured metrics must be None."""
+
+    def test_non_streaming_ttft_is_none(self):
+        """Non-streaming requests have no TTFT; percentiles should be None."""
+        result = BenchmarkResult()
+        result.requests = [
+            RequestResult(prompt_tokens=10, completion_tokens=5, latency_ms=100.0),
+            RequestResult(prompt_tokens=10, completion_tokens=5, latency_ms=120.0),
+        ]
+        result.total_duration_s = 1.0
+        _compute_metrics(result)
+        assert result.mean_ttft_ms is None
+        assert result.p50_ttft_ms is None
+        assert result.p99_ttft_ms is None
+        # E2E latency should be measured
+        assert result.mean_e2el_ms is not None
+
+    def test_to_dict_none_serialization(self):
+        """_to_dict should include None values (serialized as null in JSON)."""
+        result = BenchmarkResult()
+        result.requests = [
+            RequestResult(prompt_tokens=10, completion_tokens=5, latency_ms=100.0),
+        ]
+        result.total_duration_s = 1.0
+        _compute_metrics(result)
+        d = _to_dict(result)
+        assert d["mean_ttft_ms"] is None
+        assert d["mean_e2el_ms"] is not None
+
+    def test_default_benchmark_result_is_none(self):
+        """Fresh BenchmarkResult should have None percentiles, not 0.0."""
+        r = BenchmarkResult()
+        assert r.mean_ttft_ms is None
+        assert r.p99_e2el_ms is None


### PR DESCRIPTION
Change BenchmarkResult percentile fields from `float=0.0` to `float|None=None`. Update all formatting code (runner, reporting, multi, html_report, cli) to handle None values gracefully, displaying 'N/A' instead of misleading 0.0.

Closes #78