### PR TITLE
fix: YAML config now overrides CLI default values

### DIFF
--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -606,15 +606,53 @@ def _resolve_custom_headers(args: argparse.Namespace) -> dict[str, str]:
     return headers
 
 
-def _load_yaml_config(path: str, args: argparse.Namespace) -> argparse.Namespace:
-    """Merge YAML config into args (CLI takes precedence)."""
+def _get_explicit_keys(
+    parser: argparse.ArgumentParser,
+    args: argparse.Namespace,
+) -> set[str]:
+    """Return the set of attribute names explicitly provided on the CLI.
+
+    Compares *args* against the parser defaults — any attribute whose value
+    differs from the default is considered explicitly provided.
+    """
+    defaults = vars(parser.parse_args([]))
+    return {k for k, v in vars(args).items() if v != defaults.get(k)}
+
+
+def _load_yaml_config(
+    path: str,
+    args: argparse.Namespace,
+    explicit_keys: set[str] | None = None,
+) -> argparse.Namespace:
+    """Merge YAML config into args (explicitly-provided CLI flags take precedence).
+
+    Parameters
+    ----------
+    path:
+        Path to the YAML configuration file.
+    args:
+        Parsed CLI namespace.
+    explicit_keys:
+        Set of attribute names that were explicitly provided on the command
+        line.  When given, only those keys are protected from YAML overrides.
+        When *None* (legacy call-sites), the function falls back to the
+        previous behaviour of skipping keys whose current value is not
+        ``None``.
+    """
     with open(path) as f:
         cfg = yaml.safe_load(f) or {}
     for key, value in cfg.items():
         attr = key.replace("-", "_")
-        # Only set if not explicitly provided on CLI
-        if getattr(args, attr, None) is None:
-            setattr(args, attr, value)
+        if explicit_keys is not None:
+            # Only skip keys the user explicitly typed on the CLI
+            if attr in explicit_keys:
+                continue
+            if hasattr(args, attr):
+                setattr(args, attr, value)
+        else:
+            # Legacy fallback: only set if current value is None
+            if getattr(args, attr, None) is None:
+                setattr(args, attr, value)
     return args
 
 
@@ -655,7 +693,8 @@ def bench_main(argv: list[str] | None = None) -> None:
 
     # Merge YAML config if provided
     if args.config:
-        args = _load_yaml_config(args.config, args)
+        explicit = _get_explicit_keys(parser, args)
+        args = _load_yaml_config(args.config, args, explicit_keys=explicit)
 
     base_url = _resolve_base_url(args)
 
@@ -848,7 +887,8 @@ def multi_main(argv: list[str] | None = None) -> None:
 
     # Merge YAML config if provided
     if args.config:
-        args = _load_yaml_config(args.config, args)
+        explicit = _get_explicit_keys(parser, args)
+        args = _load_yaml_config(args.config, args, explicit_keys=explicit)
 
     # Resolve API key
     import os
@@ -914,7 +954,8 @@ def profile_main(argv: list[str] | None = None) -> None:
 
     # Merge YAML config if provided
     if args.config:
-        args = _load_yaml_config(args.config, args)
+        explicit = _get_explicit_keys(parser, args)
+        args = _load_yaml_config(args.config, args, explicit_keys=explicit)
 
     import os
 

--- a/tests/test_yaml_override.py
+++ b/tests/test_yaml_override.py
@@ -1,0 +1,79 @@
+"""Tests for YAML config overriding CLI defaults (issue #82)."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+
+from xpyd_bench.cli import (
+    _add_vllm_compat_args,
+    _get_explicit_keys,
+    _load_yaml_config,
+)
+
+
+def _make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    _add_vllm_compat_args(parser)
+    return parser
+
+
+def _write_yaml(content: str) -> str:
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+    f.write(content)
+    f.close()
+    return f.name
+
+
+class TestGetExplicitKeys:
+    def test_no_args_yields_empty(self):
+        parser = _make_parser()
+        args = parser.parse_args([])
+        assert _get_explicit_keys(parser, args) == set()
+
+    def test_explicit_flags_detected(self):
+        parser = _make_parser()
+        args = parser.parse_args(["--num-prompts", "42", "--base-url", "http://x"])
+        explicit = _get_explicit_keys(parser, args)
+        assert "num_prompts" in explicit
+        assert "base_url" in explicit
+        assert "request_rate" not in explicit
+
+
+class TestYamlOverride:
+    def test_yaml_overrides_defaults(self):
+        parser = _make_parser()
+        args = parser.parse_args([])
+        explicit = _get_explicit_keys(parser, args)
+        path = _write_yaml("num_prompts: 500\nrequest_rate: 10.0\n")
+        try:
+            args = _load_yaml_config(path, args, explicit_keys=explicit)
+            assert args.num_prompts == 500
+            assert args.request_rate == 10.0
+        finally:
+            os.unlink(path)
+
+    def test_cli_explicit_wins_over_yaml(self):
+        parser = _make_parser()
+        args = parser.parse_args(["--num-prompts", "200"])
+        explicit = _get_explicit_keys(parser, args)
+        path = _write_yaml("num_prompts: 500\nrequest_rate: 10.0\n")
+        try:
+            args = _load_yaml_config(path, args, explicit_keys=explicit)
+            assert args.num_prompts == 200  # CLI wins
+            assert args.request_rate == 10.0  # YAML applied
+        finally:
+            os.unlink(path)
+
+    def test_legacy_none_fallback(self):
+        """Without explicit_keys, legacy behaviour: only None attrs are set."""
+        parser = _make_parser()
+        args = parser.parse_args([])
+        path = _write_yaml("num_prompts: 500\n")
+        try:
+            args = _load_yaml_config(path, args, explicit_keys=None)
+            # Legacy: num_prompts has default 1000 (not None), so YAML is ignored
+            assert args.num_prompts == 1000
+        finally:
+            os.unlink(path)


### PR DESCRIPTION
## Problem

`_load_yaml_config()` only set YAML values when the CLI attribute was `None`, but argparse always populates defaults (e.g. `num_prompts=1000`, `request_rate=inf`). This meant **YAML config was silently ignored** for any field with a CLI default — making YAML nearly useless for most parameters.

## Fix

- Add `_get_explicit_keys()` helper that compares parsed args against parser defaults to detect which flags the user actually typed on the CLI
- Update `_load_yaml_config()` to accept an optional `explicit_keys` set — only those keys are protected from YAML overrides
- Update all 3 call sites (`bench_main`, `multi_main`, `profile_main`) to pass explicit keys
- Legacy call-sites without `explicit_keys` retain old behavior

## Tests

- 5 new tests in `test_yaml_override.py` covering:
  - Explicit key detection
  - YAML overriding defaults
  - CLI explicit values winning over YAML
  - Legacy fallback behavior

All 500 tests pass.

Closes #82