### PR TITLE
fix: use actual request timestamps for time-series bucketing

### DIFF
--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -15,6 +15,7 @@ class RequestResult:
     tpot_ms: float | None = None  # Time per output token
     itl_ms: list[float] = field(default_factory=list)  # Inter-token latencies
     latency_ms: float = 0.0  # End-to-end latency
+    start_time: float | None = None  # perf_counter timestamp when request started
     retries: int = 0
     success: bool = True
     error: str | None = None
@@ -76,6 +77,9 @@ class BenchmarkResult:
 
     # Partial result flag (set when benchmark was interrupted)
     partial: bool = False
+
+    # Benchmark start time (perf_counter) for relative timestamp computation
+    bench_start_time: float = 0.0
 
     # Environment metadata for reproducibility
     environment: dict[str, str] = field(default_factory=dict)

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -130,6 +130,7 @@ async def _send_request(
         attempts = attempt
         result = RequestResult()
         start = time.perf_counter()
+        result.start_time = start
 
         try:
             if is_streaming:
@@ -178,6 +179,7 @@ async def _send_streaming(
 ) -> RequestResult:
     """Send a streaming request, measure TTFT / ITL."""
     result = RequestResult()
+    result.start_time = start
     payload["stream"] = True
     first_token_time: float | None = None
     last_token_time: float = start
@@ -553,6 +555,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
 
     tasks: list[asyncio.Task] = []
     overall_start = time.perf_counter()
+    result.bench_start_time = overall_start
     shutdown_requested = False
 
     async def _tracked_task(client: httpx.AsyncClient, prompt: str) -> RequestResult:

--- a/src/xpyd_bench/reporting/metrics.py
+++ b/src/xpyd_bench/reporting/metrics.py
@@ -22,14 +22,23 @@ def compute_time_series(
 
     num_windows = max(1, int(result.total_duration_s / window_s) + 1)
 
-    # We don't have absolute timestamps per request, so approximate by order.
-    # Distribute requests evenly across duration for bucketing.
+    # Use actual start_time timestamps when available; fall back to index-based
+    # approximation for backward compatibility with older result data.
+    has_timestamps = (
+        result.bench_start_time > 0
+        and all(r.start_time is not None for r in successful)
+    )
+
     buckets: list[list[RequestResult]] = [[] for _ in range(num_windows)]
     for idx, req in enumerate(successful):
-        # Estimate request finish time proportionally
-        frac = idx / max(len(successful) - 1, 1)
-        t = frac * result.total_duration_s
+        if has_timestamps:
+            t = req.start_time - result.bench_start_time  # type: ignore[operator]
+        else:
+            # Legacy fallback: distribute evenly by index
+            frac = idx / max(len(successful) - 1, 1)
+            t = frac * result.total_duration_s
         bucket_idx = min(int(t / window_s), num_windows - 1)
+        bucket_idx = max(0, bucket_idx)  # clamp negative
         buckets[bucket_idx].append(req)
 
     series = []

--- a/tests/test_time_series_timestamps.py
+++ b/tests/test_time_series_timestamps.py
@@ -1,0 +1,87 @@
+"""Tests for time-series bucketing using actual request timestamps (issue #96)."""
+
+from __future__ import annotations
+
+from xpyd_bench.bench.models import BenchmarkResult, RequestResult
+from xpyd_bench.reporting.metrics import compute_time_series
+
+
+class TestTimeSeriesWithTimestamps:
+    """Verify compute_time_series uses start_time when available."""
+
+    def test_bursty_requests_bucketed_correctly(self):
+        """All requests in first second should land in bucket 0."""
+        bench_start = 1000.0
+        result = BenchmarkResult(
+            total_duration_s=10.0,
+            bench_start_time=bench_start,
+        )
+        # 50 requests all starting within the first second
+        result.requests = [
+            RequestResult(
+                completion_tokens=10,
+                success=True,
+                start_time=bench_start + i * 0.02,  # 0.00 to 0.98s
+            )
+            for i in range(50)
+        ]
+        result.completed = 50
+
+        ts = compute_time_series(result, window_s=1.0)
+        assert len(ts) > 0
+        # All 50 requests should be in the first bucket
+        assert ts[0]["requests"] == 50
+        # Remaining buckets should be empty
+        for bucket in ts[1:]:
+            assert bucket["requests"] == 0
+
+    def test_evenly_spread_requests(self):
+        """Requests spread across time should be distributed across buckets."""
+        bench_start = 1000.0
+        result = BenchmarkResult(
+            total_duration_s=5.0,
+            bench_start_time=bench_start,
+        )
+        # 5 requests, one per second
+        result.requests = [
+            RequestResult(
+                completion_tokens=10,
+                success=True,
+                start_time=bench_start + i,
+            )
+            for i in range(5)
+        ]
+        result.completed = 5
+
+        ts = compute_time_series(result, window_s=1.0)
+        # First 5 buckets should each have 1 request
+        for i in range(5):
+            assert ts[i]["requests"] == 1
+
+    def test_fallback_without_timestamps(self):
+        """Without start_time, falls back to index-based distribution."""
+        result = BenchmarkResult(
+            total_duration_s=10.0,
+            bench_start_time=0.0,  # No bench start time
+        )
+        result.requests = [
+            RequestResult(completion_tokens=10, success=True)
+            for _ in range(10)
+        ]
+        result.completed = 10
+
+        ts = compute_time_series(result, window_s=1.0)
+        assert len(ts) > 0
+        # Should still work (legacy uniform distribution)
+        total_reqs = sum(b["requests"] for b in ts)
+        assert total_reqs == 10
+
+    def test_start_time_set_on_request_result(self):
+        """RequestResult has start_time field."""
+        r = RequestResult(start_time=42.0)
+        assert r.start_time == 42.0
+
+    def test_bench_start_time_on_result(self):
+        """BenchmarkResult has bench_start_time field."""
+        r = BenchmarkResult(bench_start_time=100.0)
+        assert r.bench_start_time == 100.0


### PR DESCRIPTION
## Summary

`compute_time_series()` previously distributed requests uniformly by index, producing fake flat data regardless of actual traffic pattern (bursty, ramped, etc.). This defeated the purpose of M6's "throughput over time" requirement.

## Changes

- **`RequestResult.start_time`**: New field recording `time.perf_counter()` at request dispatch
- **`BenchmarkResult.bench_start_time`**: Records benchmark start for relative offset computation
- **`compute_time_series()`**: Uses actual timestamps when available, falls back to legacy index-based distribution for backward compatibility with older result data
- **Tests**: 5 new tests covering bursty bucketing, even spread, fallback behavior, and field presence

## Backward Compatibility

Results without `start_time` (e.g., loaded from older JSON) gracefully fall back to the previous uniform distribution.

Closes #96