### PR TITLE
fix: rate=0 in custom schedule now skips idle seconds without sending requests

### DIFF
--- a/src/xpyd_bench/bench/rate_patterns.py
+++ b/src/xpyd_bench/bench/rate_patterns.py
@@ -192,19 +192,25 @@ def _custom_intervals(
     rng = np.random.RandomState(seed)
     intervals: list[float] = []
     idx = 0
+    idle_carry = 0.0  # accumulated idle time to prepend to next request
 
     while len(intervals) < num:
         rate = schedule[idx % len(schedule)]
         idx += 1
         if rate <= 0:
-            # Idle second — emit one request after 1s pause
-            intervals.append(1.0)
+            # Idle second — skip without scheduling any request.
+            # Accumulate the idle time onto the next real request's delay.
+            idle_carry += 1.0
             continue
         # Generate ~rate requests within this 1-second window
         n_in_sec = max(1, round(rate))
         n_in_sec = min(n_in_sec, num - len(intervals))
         gap = 1.0 / rate
         gaps = rng.exponential(gap, size=n_in_sec).tolist()
+        # Add accumulated idle time to the first request after idle period
+        if idle_carry > 0 and gaps:
+            gaps[0] += idle_carry
+            idle_carry = 0.0
         intervals.extend(gaps)
 
     return intervals[:num]

--- a/tests/test_rate_patterns.py
+++ b/tests/test_rate_patterns.py
@@ -102,8 +102,9 @@ class TestCustomPattern:
         cfg = {"type": "custom", "schedule": [0.0, 10.0]}
         intervals = generate_pattern_intervals(20, cfg, seed=0)
         assert len(intervals) == 20
-        # First interval should be 1.0 (idle second)
-        assert intervals[0] == 1.0
+        # First interval should include ~1s idle carry added to the
+        # exponential gap from the rate=10 second
+        assert intervals[0] > 0.8
 
     def test_deterministic(self):
         cfg = {"type": "custom", "schedule": [5.0, 10.0]}

--- a/tests/test_rate_zero_idle.py
+++ b/tests/test_rate_zero_idle.py
@@ -1,0 +1,55 @@
+"""Tests for rate=0 idle behavior in custom rate patterns (issue #95)."""
+
+from __future__ import annotations
+
+from xpyd_bench.bench.rate_patterns import generate_pattern_intervals
+
+
+class TestCustomRateZeroIdle:
+    """Verify rate=0 entries produce no requests."""
+
+    def test_zero_rate_does_not_emit_request(self):
+        """A zero-rate slot followed by active slot works correctly."""
+        # Schedule: [0, 5] — first second idle, second second active
+        cfg = {"type": "custom", "schedule": [0, 5]}
+        intervals = generate_pattern_intervals(5, cfg, seed=42)
+        assert len(intervals) == 5
+        # First request should have ~1s idle carry added
+        assert intervals[0] > 0.8
+
+    def test_zero_rate_no_requests_in_idle_slots(self):
+        """rate=0 slots should not contribute any requests."""
+        # Schedule: [10, 0, 0, 10] — only seconds 0 and 3 produce requests
+        cfg = {"type": "custom", "schedule": [10, 0, 0, 10]}
+        intervals = generate_pattern_intervals(10, cfg, seed=42)
+        assert len(intervals) == 10
+        # All intervals should be positive (no zero-length gaps from idle)
+        assert all(i > 0 for i in intervals)
+
+    def test_idle_time_accumulated_to_next_request(self):
+        """Idle seconds should add delay to the first request after idle."""
+        # Schedule: [10, 0, 0, 10] — 2 idle seconds between bursts
+        cfg = {"type": "custom", "schedule": [10, 0, 0, 10]}
+        intervals = generate_pattern_intervals(20, cfg, seed=42)
+        assert len(intervals) == 20
+        # The first 10 requests come from rate=10 in second 0
+        # Then 2 idle seconds, then next requests from rate=10 in second 3
+        # Request 11 (index 10) should have ~2s extra delay from idle
+        assert intervals[10] > 1.5  # Should include ~2s idle carry
+
+    def test_single_zero_between_active(self):
+        """Single idle second adds ~1s to next request delay."""
+        cfg = {"type": "custom", "schedule": [5, 0, 5]}
+        intervals = generate_pattern_intervals(10, cfg, seed=0)
+        assert len(intervals) == 10
+        # First 5 from rate=5, then 1 idle second, then 5 from rate=5
+        assert intervals[5] > 0.8  # Should include ~1s idle carry
+
+    def test_no_idle_carry_when_no_zeros(self):
+        """Without zeros, intervals behave normally."""
+        cfg = {"type": "custom", "schedule": [10]}
+        intervals = generate_pattern_intervals(10, cfg, seed=0)
+        assert len(intervals) == 10
+        # Mean should be ~0.1s (1/10)
+        mean_gap = sum(intervals) / len(intervals)
+        assert 0.01 < mean_gap < 0.5


### PR DESCRIPTION
## Summary

Custom rate pattern schedule entries with `rate=0` previously emitted a request with 1.0s delay, contradicting the idle semantics. Now `rate=0` entries accumulate idle time and add it to the first request of the next active period, so no requests are scheduled during idle slots.

## Changes

- **`_custom_intervals()`**: `rate<=0` now accumulates idle time via `idle_carry` instead of appending an interval
- **Idle carry**: Accumulated idle time is added to the first request's delay after the idle period
- **Updated test**: `test_idle_seconds` in `test_rate_patterns.py` updated to match new behavior
- **New tests**: `test_rate_zero_idle.py` with 5 tests covering zero-rate idle behavior

## Backward Compatibility

This is a bug fix — the previous behavior was incorrect (rate=0 was effectively rate=1). No API changes.

Closes #95