### PR TITLE
fix: non-streaming TPOT no longer includes prefill time

### DIFF
--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -147,8 +147,10 @@ async def _send_request(
                 usage = body.get("usage", {})
                 result.prompt_tokens = usage.get("prompt_tokens", 0)
                 result.completion_tokens = usage.get("completion_tokens", 0)
-                if result.completion_tokens > 0:
-                    result.tpot_ms = result.latency_ms / result.completion_tokens
+                # Non-streaming: TPOT cannot be accurately measured because
+                # latency includes prefill time. Leave as None for consistency
+                # with streaming TPOT which correctly excludes TTFT/prefill.
+                # result.tpot_ms remains None
 
         except Exception as exc:  # noqa: BLE001
             end = time.perf_counter()

--- a/tests/test_non_streaming_tpot.py
+++ b/tests/test_non_streaming_tpot.py
@@ -1,0 +1,50 @@
+"""Test that non-streaming requests do not compute TPOT (issue #93).
+
+Non-streaming latency includes prefill time, so dividing by token count
+would inflate TPOT compared to streaming (which correctly excludes TTFT).
+The fix sets tpot_ms = None for non-streaming requests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from xpyd_bench.bench.runner import _send_request
+
+
+class TestNonStreamingTpotIsNone:
+    """Non-streaming requests should NOT compute tpot_ms."""
+
+    @pytest.mark.asyncio
+    async def test_completions_non_streaming_tpot_is_none(self):
+        """Non-streaming /v1/completions should leave tpot_ms as None."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"text": "hello world"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_resp
+
+        result = await _send_request(
+            client=mock_client,
+            url="http://localhost:8000/v1/completions",
+            payload={"prompt": "test", "max_tokens": 10},
+            is_streaming=False,
+            request_timeout=30.0,
+            retries=0,
+            retry_delay=0.0,
+        )
+
+        assert result.success is True
+        assert result.completion_tokens == 5
+        assert result.tpot_ms is None, (
+            "Non-streaming TPOT should be None because latency includes prefill"
+        )
+        assert result.latency_ms is not None
+        assert result.latency_ms > 0


### PR DESCRIPTION
## Problem

Non-streaming TPOT was computed as `latency_ms / completion_tokens`, which includes prefill time and inflates TPOT by ~50% compared to streaming mode (which correctly uses only decode-phase duration).

## Fix

Set `tpot_ms = None` for non-streaming requests since TTFT is not observable in non-streaming mode. This makes the metric consistent: TPOT always reflects decode-only time, or is absent when it cannot be accurately measured.

## Tests

Added `tests/test_non_streaming_tpot.py` — verifies non-streaming requests produce `tpot_ms=None`.

All 511 tests pass. Lint clean.

Closes #93