### PR TITLE
fix: echo=True completion_tokens inconsistency in dummy server

### DIFF
--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -299,8 +299,11 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
         if stopped:
             finish_reason = "stop"
 
+        # Track generated token count before echo prepend
+        gen_token_count = actual_tokens
+
         if echo:
-            generated_text = prompt_text + generated_text
+            generated_text = prompt_text + " " + generated_text if generated_text else prompt_text
 
         choice: dict = {
             "index": i,
@@ -319,13 +322,6 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
                 ],
                 "text_offset": list(range(0, len(generated_text), max(1, len(generated_text) // max(len(tokens), 1)))),  # noqa: E501
             }
-
-        # Count completion tokens based on generated token count (not echo)
-        gen_token_count = len(generated_text.split()) if generated_text else 0
-        if echo and prompt_text:
-            # Subtract prompt tokens from word count
-            prompt_word_count = len(prompt_text.split()) if prompt_text else 0
-            gen_token_count = max(0, gen_token_count - prompt_word_count)
         total_completion_tokens += gen_token_count
         choices.append(choice)
 

--- a/tests/test_issue85_echo_tokens.py
+++ b/tests/test_issue85_echo_tokens.py
@@ -1,0 +1,60 @@
+"""Tests for issue #85: echo=True completion_tokens consistency."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from xpyd_bench.dummy.server import ServerConfig, create_app
+
+
+@pytest.fixture
+def client():
+    config = ServerConfig(prefill_ms=0, decode_ms=0, model_name="test-model", eos_min_ratio=1.0)
+    app = create_app(config)
+    return TestClient(app)
+
+
+class TestEchoCompletionTokens:
+    """Verify completion_tokens is consistent with and without echo."""
+
+    def test_echo_does_not_change_completion_tokens(self, client):
+        """completion_tokens must be the same regardless of echo flag."""
+        payload = {"prompt": "one two three four five", "max_tokens": 10}
+
+        r1 = client.post("/v1/completions", json=payload).json()
+        r2 = client.post("/v1/completions", json={**payload, "echo": True}).json()
+
+        assert r1["usage"]["completion_tokens"] == 10
+        assert r2["usage"]["completion_tokens"] == 10
+
+    def test_echo_prepends_prompt_text(self, client):
+        """echo=True should prepend the prompt to the generated text."""
+        prompt = "hello world"
+        r = client.post(
+            "/v1/completions",
+            json={"prompt": prompt, "max_tokens": 5, "echo": True},
+        ).json()
+
+        text = r["choices"][0]["text"]
+        assert text.startswith(prompt)
+
+    def test_echo_false_no_prompt_in_text(self, client):
+        """echo=False should not include prompt in text."""
+        prompt = "hello world"
+        r = client.post(
+            "/v1/completions",
+            json={"prompt": prompt, "max_tokens": 5, "echo": False},
+        ).json()
+
+        text = r["choices"][0]["text"]
+        assert not text.startswith(prompt)
+
+    def test_echo_with_n_greater_than_1(self, client):
+        """completion_tokens consistent with echo and n>1."""
+        payload = {"prompt": "a b c", "max_tokens": 5, "n": 2}
+
+        r1 = client.post("/v1/completions", json=payload).json()
+        r2 = client.post("/v1/completions", json={**payload, "echo": True}).json()
+
+        assert r1["usage"]["completion_tokens"] == r2["usage"]["completion_tokens"]


### PR DESCRIPTION
## Summary

Fix inconsistent `completion_tokens` count when `echo=True` in non-streaming `/v1/completions` responses.

## Root Cause

When echo prepends prompt text to generated text, the concatenation lacked a space separator, causing word-merge. The token count was then derived from word-splitting the combined text and subtracting prompt words — inherently unreliable.

## Fix

- Track `gen_token_count = actual_tokens` **before** prepending the prompt (uses the known count directly)
- Add space separator when prepending: `prompt_text + " " + generated_text`
- Remove the fragile word-split-and-subtract logic

## Tests

Added `tests/test_issue85_echo_tokens.py` with 4 tests:
- `completion_tokens` consistency with/without echo
- Echo prepends prompt text correctly
- No prompt in text when echo=False
- Consistency with `n > 1`

Closes #85