### PR TITLE
feat: add embeddings endpoint benchmarking support (M26)

### DIFF
--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -260,9 +260,19 @@ def _build_payload(
     args: Namespace,
     prompt: str,
     is_chat: bool,
+    is_embeddings: bool = False,
 ) -> dict[str, Any]:
     """Build the JSON body for a single request."""
-    payload: dict[str, Any] = {"max_tokens": args.output_len}
+    if is_embeddings:
+        payload: dict[str, Any] = {"input": prompt}
+        if args.model:
+            payload["model"] = args.model
+        encoding_format = getattr(args, "encoding_format", None)
+        if encoding_format is not None:
+            payload["encoding_format"] = encoding_format
+        return payload
+
+    payload = {"max_tokens": args.output_len}
 
     if args.model:
         payload["model"] = args.model
@@ -408,10 +418,15 @@ def _compute_metrics(result: BenchmarkResult) -> None:
 async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, BenchmarkResult]:
     """Execute the benchmark and return (result_dict, BenchmarkResult)."""
     is_chat = "chat" in args.endpoint
+    is_embeddings = "embeddings" in args.endpoint
     # Use explicit --stream/--no-stream if provided; default to endpoint type for
     # backward compatibility (chat=streaming, completions=non-streaming).
+    # Embeddings are always non-streaming.
     stream_flag = getattr(args, "stream", None)
-    is_streaming = stream_flag if stream_flag is not None else is_chat
+    if is_embeddings:
+        is_streaming = False
+    else:
+        is_streaming = stream_flag if stream_flag is not None else is_chat
     url = f"{base_url}{args.endpoint}"
 
     # Build default headers (authentication + custom)
@@ -528,7 +543,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
             await adaptive_limiter.acquire()
             try:
                 r = await _send_request(
-                    client, url, _build_payload(args, prompt, is_chat), is_streaming,
+                    client, url, _build_payload(args, prompt, is_chat, is_embeddings), is_streaming,
                     request_timeout=request_timeout,
                     retries=req_retries,
                     retry_delay=req_retry_delay,
@@ -540,13 +555,13 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         if semaphore:
             async with semaphore:
                 return await _send_request(
-                    client, url, _build_payload(args, prompt, is_chat), is_streaming,
+                    client, url, _build_payload(args, prompt, is_chat, is_embeddings), is_streaming,
                     request_timeout=request_timeout,
                     retries=req_retries,
                     retry_delay=req_retry_delay,
                 )
         return await _send_request(
-            client, url, _build_payload(args, prompt, is_chat), is_streaming,
+            client, url, _build_payload(args, prompt, is_chat, is_embeddings), is_streaming,
             request_timeout=request_timeout,
             retries=req_retries,
             retry_delay=req_retry_delay,
@@ -570,7 +585,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         )[:warmup_count]
         async with httpx.AsyncClient(headers=headers) as warmup_client:
             for wi, wp in enumerate(warmup_prompts):
-                payload = _build_payload(args, wp, is_chat)
+                payload = _build_payload(args, wp, is_chat, is_embeddings)
                 wr = await _send_request(warmup_client, url, payload, is_streaming)
                 if not args.disable_tqdm:
                     status = "ok" if wr.success else f"FAIL: {wr.error}"
@@ -593,7 +608,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     shutdown_requested = False
 
     async def _tracked_task(client: httpx.AsyncClient, prompt: str) -> RequestResult:
-        payload = _build_payload(args, prompt, is_chat)
+        payload = _build_payload(args, prompt, is_chat, is_embeddings)
         r = await _task(client, prompt)
         if debug_logger:
             debug_logger.log(url, payload, r)

--- a/src/xpyd_bench/dummy/cli.py
+++ b/src/xpyd_bench/dummy/cli.py
@@ -51,6 +51,12 @@ def dummy_main(argv: list[str] | None = None) -> None:
         default=None,
         help="Require this API key for authentication. Returns 401 for missing/wrong key.",
     )
+    parser.add_argument(
+        "--embedding-dim",
+        type=int,
+        default=1536,
+        help="Dimensionality of embedding vectors (default: 1536).",
+    )
     args = parser.parse_args(argv)
 
     import uvicorn
@@ -64,6 +70,7 @@ def dummy_main(argv: list[str] | None = None) -> None:
         max_tokens_default=args.max_tokens_default,
         eos_min_ratio=args.eos_min_ratio,
         require_api_key=args.require_api_key,
+        embedding_dim=args.embedding_dim,
     )
     app = create_app(config)
 

--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -25,6 +25,7 @@ class ServerConfig:
     max_tokens_default: int = 128
     eos_min_ratio: float = 0.5  # EOS won't fire before this fraction of max_tokens
     require_api_key: str | None = None  # If set, require this API key for auth
+    embedding_dim: int = 1536  # Dimensionality for embedding vectors
 
 
 # Global config — set before starting the server
@@ -746,6 +747,67 @@ async def _handle_models(request: Request) -> JSONResponse:
 # ---------------------------------------------------------------------------
 
 
+async def _handle_embeddings(request: Request) -> JSONResponse:
+    """Handle POST /v1/embeddings — return random embedding vectors."""
+    cfg = _config
+    body = await request.json()
+
+    model = body.get("model", cfg.model_name)
+    raw_input = body.get("input", "")
+    encoding_format = body.get("encoding_format", "float")
+
+    # Normalize input to list of strings
+    if isinstance(raw_input, str):
+        inputs = [raw_input]
+    elif isinstance(raw_input, list):
+        inputs = [str(item) for item in raw_input]
+    else:
+        inputs = [str(raw_input)]
+
+    # Simulate prefill latency per input
+    if cfg.prefill_ms > 0:
+        await asyncio.sleep(cfg.prefill_ms * len(inputs) / 1000.0)
+
+    # Count tokens (simple word-split approximation)
+    total_tokens = sum(len(text.split()) for text in inputs)
+
+    data = []
+    for i, text in enumerate(inputs):
+        # Deterministic pseudo-random vector based on input text
+        rng = random.Random(hash(text) & 0xFFFFFFFF)
+        vector = [rng.gauss(0, 1) for _ in range(cfg.embedding_dim)]
+
+        if encoding_format == "base64":
+            import base64
+            import struct
+
+            raw_bytes = struct.pack(f"{len(vector)}f", *vector)
+            embedding_value = base64.b64encode(raw_bytes).decode("ascii")
+        else:
+            embedding_value = vector
+
+        data.append({
+            "object": "embedding",
+            "index": i,
+            "embedding": embedding_value,
+        })
+
+    custom = _extract_custom_headers(request)
+    response_body: dict = {
+        "object": "list",
+        "data": data,
+        "model": model,
+        "usage": {
+            "prompt_tokens": total_tokens,
+            "total_tokens": total_tokens,
+        },
+    }
+    if custom:
+        response_body["_echoed_headers"] = custom
+
+    return JSONResponse(response_body)
+
+
 async def _handle_health(request: Request) -> JSONResponse:
     return JSONResponse({"status": "ok"})
 
@@ -781,6 +843,7 @@ def create_app(config: ServerConfig | None = None) -> Starlette:
     routes = [
         Route("/v1/completions", _handle_completions, methods=["POST"]),
         Route("/v1/chat/completions", _handle_chat_completions, methods=["POST"]),
+        Route("/v1/embeddings", _handle_embeddings, methods=["POST"]),
         Route("/v1/models", _handle_models, methods=["GET"]),
         Route("/health", _handle_health, methods=["GET"]),
     ]

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,116 @@
+"""Tests for embeddings endpoint benchmarking (M26, issue #108)."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from xpyd_bench.dummy.server import ServerConfig, create_app
+
+
+@pytest.fixture
+def client():
+    config = ServerConfig(prefill_ms=0, decode_ms=0, model_name="test-model", embedding_dim=128)
+    app = create_app(config)
+    return TestClient(app)
+
+
+class TestDummyEmbeddings:
+    """Verify dummy server /v1/embeddings endpoint."""
+
+    def test_single_string_input(self, client):
+        """Single string input returns one embedding."""
+        r = client.post("/v1/embeddings", json={"input": "hello world", "model": "test"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["object"] == "list"
+        assert len(body["data"]) == 1
+        assert body["data"][0]["object"] == "embedding"
+        assert body["data"][0]["index"] == 0
+        assert len(body["data"][0]["embedding"]) == 128
+        assert body["usage"]["prompt_tokens"] > 0
+        assert body["usage"]["total_tokens"] == body["usage"]["prompt_tokens"]
+
+    def test_list_input(self, client):
+        """List of strings returns multiple embeddings."""
+        r = client.post(
+            "/v1/embeddings",
+            json={"input": ["hello", "world", "foo"], "model": "test"},
+        )
+        body = r.json()
+        assert len(body["data"]) == 3
+        for i, item in enumerate(body["data"]):
+            assert item["index"] == i
+            assert len(item["embedding"]) == 128
+
+    def test_model_echo(self, client):
+        """Response echoes the requested model name."""
+        r = client.post("/v1/embeddings", json={"input": "x", "model": "my-model"}).json()
+        assert r["model"] == "my-model"
+
+    def test_default_model(self, client):
+        """When model not specified, uses server config model."""
+        r = client.post("/v1/embeddings", json={"input": "x"}).json()
+        assert r["model"] == "test-model"
+
+    def test_deterministic_vectors(self, client):
+        """Same input produces same embedding vector."""
+        r1 = client.post("/v1/embeddings", json={"input": "hello"}).json()
+        r2 = client.post("/v1/embeddings", json={"input": "hello"}).json()
+        assert r1["data"][0]["embedding"] == r2["data"][0]["embedding"]
+
+    def test_different_inputs_different_vectors(self, client):
+        """Different inputs produce different vectors."""
+        r1 = client.post("/v1/embeddings", json={"input": "hello"}).json()
+        r2 = client.post("/v1/embeddings", json={"input": "world"}).json()
+        assert r1["data"][0]["embedding"] != r2["data"][0]["embedding"]
+
+    def test_custom_headers_echo(self, client):
+        """Custom headers are echoed in response."""
+        r = client.post(
+            "/v1/embeddings",
+            json={"input": "x"},
+            headers={"X-Custom": "test-val"},
+        ).json()
+        assert r.get("_echoed_headers", {}).get("x-custom") == "test-val"
+
+
+class TestEmbeddingsPayloadBuilder:
+    """Verify _build_payload generates correct embeddings payloads."""
+
+    def test_embeddings_payload(self):
+        from argparse import Namespace
+
+        from xpyd_bench.bench.runner import _build_payload
+
+        args = Namespace(model="emb-model", output_len=128)
+        payload = _build_payload(args, "test prompt", is_chat=False, is_embeddings=True)
+        assert payload == {"input": "test prompt", "model": "emb-model"}
+        # No max_tokens for embeddings
+        assert "max_tokens" not in payload
+
+    def test_embeddings_payload_no_model(self):
+        from argparse import Namespace
+
+        from xpyd_bench.bench.runner import _build_payload
+
+        args = Namespace(model="", output_len=128)
+        payload = _build_payload(args, "test", is_chat=False, is_embeddings=True)
+        assert "model" not in payload
+        assert payload == {"input": "test"}
+
+
+class TestEmbeddingsStreamingDisabled:
+    """Embeddings should always be non-streaming."""
+
+    def test_is_streaming_false_for_embeddings(self):
+        """run_benchmark sets is_streaming=False for embeddings endpoint."""
+        # We test the logic inline since we can't easily call run_benchmark
+        endpoint = "/v1/embeddings"
+        is_embeddings = "embeddings" in endpoint
+        stream_flag = True  # Even if user passes --stream
+        if is_embeddings:
+            is_streaming = False
+        else:
+            is_streaming = stream_flag
+        assert is_streaming is False


### PR DESCRIPTION
## Summary
Add `/v1/embeddings` endpoint support for both the benchmark runner and dummy server.

## Changes
- **Dummy server**: New `/v1/embeddings` handler with configurable `--embedding-dim` (default 1536). Supports single string and list inputs, deterministic vectors, base64 encoding format, custom header echo.
- **Runner**: Detects embeddings endpoint, forces non-streaming mode, builds embeddings-specific payload (input field, no max_tokens/sampling params).
- **CLI**: `--embedding-dim` flag for dummy server.
- **Tests**: 10 new tests covering dummy server responses, payload building, and streaming override.

## Validation
- All 554 tests pass (0 regressions)
- Lint clean (`ruff check` + `isort --check`)

Closes #108