### PR TITLE
feat: Connection Pool & HTTP/2 Configuration (M28)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
 tokenizer = [
     "tiktoken>=0.5.0",
 ]
+http2 = [
+    "h2>=4.0.0",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
@@ -31,6 +34,7 @@ dev = [
     "pre-commit>=3.6.0",
     "httpx>=0.27.0",
     "tiktoken>=0.5.0",
+    "h2>=4.0.0",
 ]
 
 [project.scripts]

--- a/src/xpyd_bench/bench/debug_log.py
+++ b/src/xpyd_bench/bench/debug_log.py
@@ -51,6 +51,23 @@ class DebugLogger:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._file = open(self._path, "w")  # noqa: SIM115
 
+    def log_connection_config(
+        self,
+        http2: bool = False,
+        max_connections: int = 100,
+        max_keepalive: int = 20,
+    ) -> None:
+        """Write connection pool configuration as the first log entry."""
+        entry = {
+            "type": "connection_config",
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "http2": http2,
+            "max_connections": max_connections,
+            "max_keepalive": max_keepalive,
+        }
+        self._file.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        self._file.flush()
+
     def log(
         self,
         url: str,

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -18,6 +18,35 @@ from xpyd_bench.bench.env import collect_env_info
 from xpyd_bench.bench.models import BenchmarkResult, RequestResult
 
 # ---------------------------------------------------------------------------
+# HTTP client helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_client_kwargs(
+    args: Namespace, headers: dict[str, str] | None = None
+) -> dict[str, Any]:
+    """Build kwargs dict for ``httpx.AsyncClient`` from CLI/config args."""
+    kwargs: dict[str, Any] = {}
+    if headers:
+        kwargs["headers"] = headers
+    if getattr(args, "http2", False):
+        try:
+            import h2  # noqa: F401
+        except ImportError:
+            raise SystemExit(
+                "ERROR: --http2 requires the 'h2' package. "
+                "Install it with: pip install h2"
+            )
+        kwargs["http2"] = True
+    max_connections = getattr(args, "max_connections", 100) or 100
+    max_keepalive = getattr(args, "max_keepalive", 20) or 20
+    kwargs["limits"] = httpx.Limits(
+        max_connections=max_connections,
+        max_keepalive_connections=max_keepalive,
+    )
+    return kwargs
+
+# ---------------------------------------------------------------------------
 # Prompt generation
 # ---------------------------------------------------------------------------
 
@@ -588,7 +617,8 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         warmup_prompts = prompts[:warmup_count] if len(prompts) >= warmup_count else (
             prompts * ((warmup_count // len(prompts)) + 1)
         )[:warmup_count]
-        async with httpx.AsyncClient(headers=headers) as warmup_client:
+        warmup_kw = _build_client_kwargs(args, headers=headers)
+        async with httpx.AsyncClient(**warmup_kw) as warmup_client:
             for wi, wp in enumerate(warmup_prompts):
                 payload = _build_payload(args, wp, is_chat, is_embeddings)
                 wr = await _send_request(warmup_client, url, payload, is_streaming)
@@ -603,6 +633,11 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     debug_logger: DebugLogger | None = None
     if debug_log_path:
         debug_logger = DebugLogger(debug_log_path)
+        debug_logger.log_connection_config(
+            http2=getattr(args, "http2", False),
+            max_connections=getattr(args, "max_connections", 100),
+            max_keepalive=getattr(args, "max_keepalive", 20),
+        )
 
     if reporter:
         reporter.start()
@@ -623,7 +658,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
 
     grace_period = getattr(args, "shutdown_grace_period", 5.0) or 5.0
 
-    async with httpx.AsyncClient(headers=headers) as client:
+    async with httpx.AsyncClient(**_build_client_kwargs(args, headers=headers)) as client:
         # Install signal handler for graceful shutdown
         loop = asyncio.get_running_loop()
 
@@ -744,6 +779,9 @@ async def replay_trace(
     model: str = "",
     api_key: str | None = None,
     timeout: float = 300.0,
+    http2: bool = False,
+    max_connections: int = 100,
+    max_keepalive: int = 20,
 ) -> BenchmarkResult:
     """Replay a recorded trace against a target server.
 
@@ -772,7 +810,16 @@ async def replay_trace(
         environment=collect_env_info(),
     )
 
-    async with httpx.AsyncClient(headers=headers) as client:
+    replay_kwargs: dict[str, Any] = {
+        "headers": headers,
+        "limits": httpx.Limits(
+            max_connections=max_connections,
+            max_keepalive_connections=max_keepalive,
+        ),
+    }
+    if http2:
+        replay_kwargs["http2"] = True
+    async with httpx.AsyncClient(**replay_kwargs) as client:
         start_time = time.perf_counter()
 
         for i, entry in enumerate(trace.entries):

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -404,6 +404,26 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         "is not installed. (default: None = word-split)",
     )
 
+    # Connection pool & HTTP/2 (M28)
+    parser.add_argument(
+        "--http2",
+        action="store_true",
+        default=False,
+        help="Enable HTTP/2 multiplexing (requires h2 package).",
+    )
+    parser.add_argument(
+        "--max-connections",
+        type=int,
+        default=100,
+        help="Maximum number of connections in the pool (default: 100).",
+    )
+    parser.add_argument(
+        "--max-keepalive",
+        type=int,
+        default=20,
+        help="Maximum number of keepalive connections (default: 20).",
+    )
+
     # Extended config
     parser.add_argument(
         "--config",
@@ -531,6 +551,14 @@ def _dry_run(args: argparse.Namespace, base_url: str) -> None:
     # Tokenizer
     tokenizer = getattr(args, "tokenizer", None)
     print(f"  Tokenizer:       {tokenizer or '(word-split)'}")
+
+    # Connection pool (M28)
+    http2 = getattr(args, "http2", False)
+    max_conn = getattr(args, "max_connections", 100)
+    max_ka = getattr(args, "max_keepalive", 20)
+    print(f"  HTTP/2:          {http2}")
+    print(f"  Max connections: {max_conn}")
+    print(f"  Max keepalive:   {max_ka}")
 
     # Auth
     api_key_source = "none"
@@ -1126,6 +1154,9 @@ def replay_main(argv: list[str] | None = None) -> None:
             model=model,
             api_key=args.api_key,
             timeout=args.timeout,
+            http2=getattr(args, "http2", False),
+            max_connections=getattr(args, "max_connections", 100),
+            max_keepalive=getattr(args, "max_keepalive", 20),
         )
     )
 

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,0 +1,214 @@
+"""Tests for M28: Connection Pool & HTTP/2 Configuration."""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from xpyd_bench.bench.debug_log import DebugLogger
+from xpyd_bench.bench.runner import _build_client_kwargs
+
+# ---------------------------------------------------------------------------
+# _build_client_kwargs tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildClientKwargs:
+    """Tests for the HTTP client factory helper."""
+
+    def test_defaults(self):
+        """Default args produce correct limits."""
+        args = Namespace(http2=False, max_connections=100, max_keepalive=20)
+        kwargs = _build_client_kwargs(args)
+        assert "http2" not in kwargs
+        limits = kwargs["limits"]
+        assert limits.max_connections == 100
+        assert limits.max_keepalive_connections == 20
+
+    def test_http2_enabled(self):
+        """--http2 sets http2=True when h2 is available."""
+        args = Namespace(http2=True, max_connections=100, max_keepalive=20)
+        kwargs = _build_client_kwargs(args)
+        assert kwargs["http2"] is True
+
+    def test_http2_missing_h2(self):
+        """--http2 without h2 package raises SystemExit."""
+        args = Namespace(http2=True, max_connections=100, max_keepalive=20)
+        with patch.dict("sys.modules", {"h2": None}):
+            with pytest.raises(SystemExit, match="h2"):
+                _build_client_kwargs(args)
+
+    def test_custom_pool_sizes(self):
+        """Custom max-connections and max-keepalive are applied."""
+        args = Namespace(http2=False, max_connections=50, max_keepalive=10)
+        kwargs = _build_client_kwargs(args)
+        limits = kwargs["limits"]
+        assert limits.max_connections == 50
+        assert limits.max_keepalive_connections == 10
+
+    def test_headers_passed(self):
+        """Headers are included in kwargs."""
+        args = Namespace(http2=False, max_connections=100, max_keepalive=20)
+        kwargs = _build_client_kwargs(args, headers={"X-Test": "1"})
+        assert kwargs["headers"] == {"X-Test": "1"}
+
+    def test_none_pool_values_fallback(self):
+        """None pool values fall back to defaults."""
+        args = Namespace(http2=False, max_connections=None, max_keepalive=None)
+        kwargs = _build_client_kwargs(args)
+        limits = kwargs["limits"]
+        assert limits.max_connections == 100
+        assert limits.max_keepalive_connections == 20
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLIArgs:
+    """Test that CLI args are parsed correctly."""
+
+    def test_http2_flag(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--http2"])
+        assert args.http2 is True
+
+    def test_max_connections_flag(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--max-connections", "50"])
+        assert args.max_connections == 50
+
+    def test_max_keepalive_flag(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--max-keepalive", "10"])
+        assert args.max_keepalive == 10
+
+    def test_defaults(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        assert args.http2 is False
+        assert args.max_connections == 100
+        assert args.max_keepalive == 20
+
+
+# ---------------------------------------------------------------------------
+# YAML config tests
+# ---------------------------------------------------------------------------
+
+
+class TestYAMLConfig:
+    """Test YAML config support for connection parameters."""
+
+    def test_yaml_connection_config(self, tmp_path: Path):
+        import argparse
+
+        import yaml
+
+        from xpyd_bench.cli import _add_vllm_compat_args, _load_yaml_config
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+
+        config = {"http2": True, "max_connections": 200, "max_keepalive": 50}
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(yaml.dump(config))
+
+        args = _load_yaml_config(str(cfg_path), args, explicit_keys=set())
+        assert args.http2 is True
+        assert args.max_connections == 200
+        assert args.max_keepalive == 50
+
+    def test_cli_overrides_yaml(self, tmp_path: Path):
+        import argparse
+
+        import yaml
+
+        from xpyd_bench.cli import _add_vllm_compat_args, _load_yaml_config
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--max-connections", "75"])
+
+        config = {"max_connections": 200}
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(yaml.dump(config))
+
+        args = _load_yaml_config(
+            str(cfg_path), args, explicit_keys={"max_connections"}
+        )
+        assert args.max_connections == 75
+
+
+# ---------------------------------------------------------------------------
+# Dry run output tests
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunOutput:
+    """Test that dry-run shows connection config."""
+
+    def test_dry_run_shows_connection_info(self, capsys):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args, _dry_run
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--http2", "--max-connections", "50"])
+        # Ensure custom_headers is resolved
+        args.custom_headers = {}
+
+        _dry_run(args, "http://localhost:8000")
+
+        captured = capsys.readouterr().out
+        assert "HTTP/2:          True" in captured
+        assert "Max connections: 50" in captured
+        assert "Max keepalive:   20" in captured
+
+
+# ---------------------------------------------------------------------------
+# Debug log connection config tests
+# ---------------------------------------------------------------------------
+
+
+class TestDebugLogConnectionConfig:
+    """Test that debug log includes connection pool info."""
+
+    def test_log_connection_config(self, tmp_path: Path):
+        log_path = tmp_path / "debug.jsonl"
+        logger = DebugLogger(str(log_path))
+        logger.log_connection_config(http2=True, max_connections=50, max_keepalive=10)
+        logger.close()
+
+        lines = log_path.read_text().strip().split("\n")
+        entry = json.loads(lines[0])
+        assert entry["type"] == "connection_config"
+        assert entry["http2"] is True
+        assert entry["max_connections"] == 50
+        assert entry["max_keepalive"] == 10


### PR DESCRIPTION
## Summary
Add configurable connection pool sizing and HTTP/2 support for the benchmark HTTP client.

## Changes
- **`--http2` flag**: Enable HTTP/2 multiplexing (requires `h2` package, added as optional dep)
- **`--max-connections N`**: Configure connection pool size (default: 100)
- **`--max-keepalive N`**: Configure keepalive connection limit (default: 20)
- **YAML config**: `http2`, `max_connections`, `max_keepalive` keys supported
- **`--dry-run`**: Shows connection pool configuration in execution plan
- **All `httpx.AsyncClient` instantiations** updated (warmup, benchmark, replay)
- **`_build_client_kwargs()`** helper centralizes client configuration
- **14 tests** covering helper, CLI flags, YAML config, and client instantiation

Closes #112