### PR TITLE
feat: M29 — Live Progress Dashboard (Terminal UI)

### DIFF
--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -601,13 +601,22 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
             retry_delay=req_retry_delay,
         )
 
-    # Rich progress bar
-    use_rich = getattr(args, "rich_progress", False) and not args.disable_tqdm
+    # Live dashboard (M29) — use LiveDashboard when not explicitly disabled
+    no_live = getattr(args, "no_live", False)
+    use_live = not args.disable_tqdm and not no_live
     reporter = None
-    if use_rich:
-        from xpyd_bench.reporting.rich_output import RichProgressReporter
+    _LiveDashboardType: type = type(None)  # sentinel for isinstance check
+    if use_live:
+        from xpyd_bench.reporting.rich_output import LiveDashboard
 
-        reporter = RichProgressReporter(total=args.num_prompts)
+        _LiveDashboardType = LiveDashboard
+        reporter = LiveDashboard(total=args.num_prompts)
+    elif not args.disable_tqdm and not no_live:
+        use_rich = getattr(args, "rich_progress", False)
+        if use_rich:
+            from xpyd_bench.reporting.rich_output import RichProgressReporter
+
+            reporter = RichProgressReporter(total=args.num_prompts)
 
     # --- Warmup phase ---
     warmup_count = getattr(args, "warmup", 0) or 0
@@ -653,7 +662,11 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         if debug_logger:
             debug_logger.log(url, payload, r)
         if reporter:
-            reporter.advance(success=r.success)
+            latency = r.latency * 1000 if r.latency is not None else None
+            if isinstance(reporter, _LiveDashboardType):
+                reporter.advance(success=r.success, latency_ms=latency)
+            else:
+                reporter.advance(success=r.success)
         return r
 
     grace_period = getattr(args, "shutdown_grace_period", 5.0) or 5.0
@@ -687,7 +700,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
             task = asyncio.create_task(_tracked_task(client, prompt))
             tasks.append(task)
 
-            if not use_rich and not args.disable_tqdm and (i + 1) % 100 == 0:
+            if not reporter and not args.disable_tqdm and (i + 1) % 100 == 0:
                 print(f"  Launched {i + 1}/{args.num_prompts} requests...")
 
         # Wait for all launched tasks to complete (with grace period if shutting down)

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -274,6 +274,12 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Disable progress bar.",
     )
+    parser.add_argument(
+        "--no-live",
+        action="store_true",
+        default=False,
+        help="Disable live progress dashboard (auto-disabled for non-TTY).",
+    )
     vllm_ext.add_argument(
         "--ignore-eos",
         action="store_true",

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -48,6 +48,7 @@ _KNOWN_KEYS: set[str] = {
     "metadata",
     "model",
     "n",
+    "no_live",
     "num_prompts",
     "output_len",
     "parallel_tool_calls",

--- a/src/xpyd_bench/reporting/rich_output.py
+++ b/src/xpyd_bench/reporting/rich_output.py
@@ -2,12 +2,175 @@
 
 from __future__ import annotations
 
+import sys
+import time
 from typing import Any
 
 from rich.console import Console
 from rich.live import Live
-from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
+from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 from rich.table import Table
+from rich.text import Text
+
+# Sparkline block characters (ascending height)
+_SPARK_CHARS = "▁▂▃▄▅▆▇█"
+
+
+def _sparkline(values: list[float], width: int = 20) -> str:
+    """Return a sparkline string for the given values."""
+    if not values:
+        return ""
+    recent = values[-width:]
+    lo = min(recent)
+    hi = max(recent)
+    span = hi - lo if hi > lo else 1.0
+    return "".join(
+        _SPARK_CHARS[min(int((v - lo) / span * (len(_SPARK_CHARS) - 1)), len(_SPARK_CHARS) - 1)]
+        for v in recent
+    )
+
+
+class LiveDashboard:
+    """Real-time terminal dashboard using ``rich.live`` during benchmark execution.
+
+    Shows: progress bar, current RPS, latency sparkline, error count, ETA.
+    Auto-detects non-TTY and disables gracefully.
+    """
+
+    def __init__(self, total: int, *, disabled: bool = False) -> None:
+        self._total = total
+        self._completed = 0
+        self._failed = 0
+        self._latencies: list[float] = []
+        self._start_time: float = 0.0
+        self._last_rps_time: float = 0.0
+        self._last_rps_count: int = 0
+        self._current_rps: float = 0.0
+        self._rps_history: list[float] = []
+        self._disabled = disabled or not sys.stderr.isatty()
+        self._console = Console(stderr=True)
+        self._live: Live | None = None
+        self._progress = Progress(
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(bar_width=40),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            TextColumn("({task.completed}/{task.total})"),
+            TimeElapsedColumn(),
+            TimeRemainingColumn(),
+            console=self._console,
+        )
+        self._task_id: Any = None
+
+    @property
+    def disabled(self) -> bool:
+        return self._disabled
+
+    def start(self) -> None:
+        """Start the live dashboard."""
+        self._start_time = time.monotonic()
+        self._last_rps_time = self._start_time
+        self._task_id = self._progress.add_task("Benchmarking", total=self._total)
+        if self._disabled:
+            return
+        self._live = Live(
+            self._build_layout(),
+            console=self._console,
+            refresh_per_second=4,
+            transient=True,
+        )
+        self._live.start()
+
+    def advance(self, *, success: bool = True, latency_ms: float | None = None) -> None:
+        """Record one completed request."""
+        if success:
+            self._completed += 1
+        else:
+            self._failed += 1
+        if latency_ms is not None:
+            self._latencies.append(latency_ms)
+        self._progress.update(self._task_id, advance=1)
+
+        # Update RPS every ~1s
+        now = time.monotonic()
+        elapsed_since = now - self._last_rps_time
+        if elapsed_since >= 1.0:
+            new_requests = (self._completed + self._failed) - self._last_rps_count
+            self._current_rps = new_requests / elapsed_since
+            self._rps_history.append(self._current_rps)
+            self._last_rps_count = self._completed + self._failed
+            self._last_rps_time = now
+
+        if self._live:
+            self._live.update(self._build_layout())
+
+    def stop(self) -> None:
+        """Stop the live dashboard."""
+        if self._live:
+            self._live.stop()
+            self._live = None
+
+    def _build_layout(self) -> Table:
+        """Build the dashboard layout."""
+        grid = Table.grid(padding=(0, 1))
+        grid.add_row(self._progress)
+
+        # Stats line
+        elapsed = time.monotonic() - self._start_time if self._start_time else 0.0
+        overall_rps = (self._completed + self._failed) / elapsed if elapsed > 0 else 0.0
+
+        stats = Text()
+        stats.append("  RPS: ", style="bold")
+        stats.append(f"{self._current_rps:.1f}", style="green")
+        stats.append(f" (avg {overall_rps:.1f})", style="dim")
+        stats.append("  │  Errors: ", style="bold")
+        error_style = "red" if self._failed > 0 else "green"
+        stats.append(f"{self._failed}", style=error_style)
+
+        if self._latencies:
+            recent = self._latencies[-10:]
+            avg_lat = sum(recent) / len(recent)
+            stats.append("  │  Latency: ", style="bold")
+            stats.append(f"{avg_lat:.0f}ms", style="yellow")
+            stats.append("  ", style="")
+            stats.append(_sparkline(self._latencies), style="cyan")
+
+        grid.add_row(stats)
+        return grid
+
+    def print_summary_table(self, result: Any) -> None:
+        """Print a rich summary table after benchmark completion."""
+        table = Table(title="Benchmark Results", show_header=True, header_style="bold magenta")
+        table.add_column("Metric", style="cyan")
+        table.add_column("Mean", justify="right")
+        table.add_column("P50", justify="right")
+        table.add_column("P90", justify="right")
+        table.add_column("P95", justify="right")
+        table.add_column("P99", justify="right")
+
+        for label, prefix in [
+            ("TTFT", "ttft"),
+            ("TPOT", "tpot"),
+            ("ITL", "itl"),
+            ("E2EL", "e2el"),
+        ]:
+            table.add_row(
+                label,
+                f"{getattr(result, f'mean_{prefix}_ms'):.2f}",
+                f"{getattr(result, f'p50_{prefix}_ms'):.2f}",
+                f"{getattr(result, f'p90_{prefix}_ms'):.2f}",
+                f"{getattr(result, f'p95_{prefix}_ms'):.2f}",
+                f"{getattr(result, f'p99_{prefix}_ms'):.2f}",
+            )
+
+        self._console.print()
+        self._console.print(f"  [green]Completed:[/green] {result.completed}")
+        self._console.print(f"  [red]Failed:[/red]    {result.failed}")
+        self._console.print(
+            f"  Duration:  {result.total_duration_s:.2f}s  |  "
+            f"Throughput: {result.request_throughput:.2f} req/s, "
+            f"{result.output_throughput:.2f} tok/s"
+        )
+        self._console.print(table)
 
 
 class RichProgressReporter:

--- a/tests/test_live_dashboard.py
+++ b/tests/test_live_dashboard.py
@@ -1,0 +1,129 @@
+"""Tests for M29: Live Progress Dashboard (Terminal UI)."""
+
+from __future__ import annotations
+
+import io
+import sys
+from unittest.mock import patch
+
+from xpyd_bench.reporting.rich_output import LiveDashboard, _sparkline
+
+# ---------------------------------------------------------------------------
+# Unit: sparkline helper
+# ---------------------------------------------------------------------------
+
+
+class TestSparkline:
+    def test_empty(self) -> None:
+        assert _sparkline([]) == ""
+
+    def test_constant(self) -> None:
+        result = _sparkline([5.0, 5.0, 5.0])
+        assert len(result) == 3
+        # All same value → all same char
+        assert len(set(result)) == 1
+
+    def test_ascending(self) -> None:
+        result = _sparkline([1.0, 2.0, 3.0, 4.0, 5.0])
+        assert len(result) == 5
+        # Should be monotonically non-decreasing in char
+        assert result[0] <= result[-1]
+
+    def test_width_truncation(self) -> None:
+        result = _sparkline(list(range(100)), width=10)
+        assert len(result) == 10
+
+
+# ---------------------------------------------------------------------------
+# Unit: LiveDashboard data feed
+# ---------------------------------------------------------------------------
+
+
+class TestLiveDashboard:
+    def test_init_disabled(self) -> None:
+        """When disabled=True, dashboard should be disabled."""
+        dash = LiveDashboard(total=10, disabled=True)
+        assert dash.disabled is True
+
+    def test_non_tty_auto_disable(self) -> None:
+        """Non-TTY stderr → auto-disabled."""
+        with patch.object(sys, "stderr", new_callable=io.StringIO):
+            dash = LiveDashboard(total=10)
+            assert dash.disabled is True
+
+    def test_advance_tracks_counts(self) -> None:
+        """Advance properly counts completed/failed."""
+        dash = LiveDashboard(total=5, disabled=True)
+        dash.start()
+        dash.advance(success=True, latency_ms=10.0)
+        dash.advance(success=True, latency_ms=20.0)
+        dash.advance(success=False, latency_ms=50.0)
+        assert dash._completed == 2
+        assert dash._failed == 1
+        assert len(dash._latencies) == 3
+        dash.stop()
+
+    def test_advance_no_latency(self) -> None:
+        """Advance works without latency_ms."""
+        dash = LiveDashboard(total=2, disabled=True)
+        dash.start()
+        dash.advance(success=True)
+        assert dash._completed == 1
+        assert len(dash._latencies) == 0
+        dash.stop()
+
+    def test_start_stop_disabled(self) -> None:
+        """Start/stop on disabled dashboard should not raise."""
+        dash = LiveDashboard(total=5, disabled=True)
+        dash.start()
+        dash.stop()
+
+    def test_build_layout(self) -> None:
+        """_build_layout should not raise."""
+        dash = LiveDashboard(total=5, disabled=True)
+        dash.start()
+        dash.advance(success=True, latency_ms=15.0)
+        layout = dash._build_layout()
+        assert layout is not None
+        dash.stop()
+
+
+# ---------------------------------------------------------------------------
+# CLI: --no-live flag
+# ---------------------------------------------------------------------------
+
+
+class TestNoLiveFlag:
+    def test_no_live_parsed(self) -> None:
+        """--no-live flag should set no_live=True."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--no-live", "--model", "m", "--num-prompts", "1"])
+        assert args.no_live is True
+
+    def test_default_no_live_false(self) -> None:
+        """Default no_live should be False."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--model", "m", "--num-prompts", "1"])
+        assert args.no_live is False
+
+
+# ---------------------------------------------------------------------------
+# Config: no_live is a known key
+# ---------------------------------------------------------------------------
+
+
+class TestConfigKnownKey:
+    def test_no_live_in_known_keys(self) -> None:
+        from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+        assert "no_live" in _KNOWN_KEYS


### PR DESCRIPTION
## Summary
Implements M29: Real-time terminal dashboard using `rich.live` during benchmark execution.

### Changes
- **`LiveDashboard` class** in `rich_output.py`: displays progress bar, current/avg RPS, latency sparkline, error count, and ETA
- **`--no-live` CLI flag**: explicitly disables the live dashboard (for CI/piped output)
- **Auto-TTY detection**: non-TTY stderr auto-disables the dashboard gracefully
- **Runner integration**: `LiveDashboard` is the default when not disabled; passes per-request latency for sparkline
- **`no_live` config key** added to known YAML keys
- **13 new tests** covering sparkline helper, dashboard data feed, non-TTY fallback, CLI parsing, config keys

### Testing
- All 598 tests pass (including 13 new)
- `ruff check` and `isort --check` clean

Closes #114