### PR TITLE
feat(m30): Benchmark Result Storage & History

### DIFF
--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -847,6 +847,13 @@ def bench_main(argv: list[str] | None = None) -> None:
     if getattr(args, "debug_log", None):
         print(f"\nDebug log saved to {args.debug_log}")
 
+    # Auto-save to result-dir when set (M30)
+    if args.result_dir and not args.save_result:
+        from xpyd_bench.history import auto_save_result
+
+        saved = auto_save_result(result, args.result_dir, args)
+        print(f"\nResults auto-saved to {saved}")
+
     # Save results if requested
     if args.save_result:
         _save_result(args, result)

--- a/src/xpyd_bench/history.py
+++ b/src/xpyd_bench/history.py
@@ -1,0 +1,189 @@
+"""Benchmark result storage & history (M30).
+
+Usage:
+    xpyd-bench history --result-dir <path> [--last N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+# Sparkline characters (8 levels)
+_SPARK = "▁▂▃▄▅▆▇█"
+
+
+def _sparkline(values: list[float]) -> str:
+    """Return a sparkline string for a list of numeric values."""
+    if not values:
+        return ""
+    lo, hi = min(values), max(values)
+    span = hi - lo if hi != lo else 1.0
+    return "".join(_SPARK[min(int((v - lo) / span * 7), 7)] for v in values)
+
+
+def _parse_timestamp_from_filename(name: str) -> datetime | None:
+    """Try to extract a YYYYMMDD-HHMMSS timestamp from a result filename."""
+    # Pattern: *-YYYYMMDD-HHMMSS.json
+    stem = name.removesuffix(".json")
+    parts = stem.rsplit("-", 2)
+    if len(parts) >= 2:
+        date_part = parts[-2]
+        time_part = parts[-1]
+        try:
+            return datetime.strptime(f"{date_part}-{time_part}", "%Y%m%d-%H%M%S")
+        except ValueError:
+            pass
+    return None
+
+
+def _load_result_summary(path: Path) -> dict | None:
+    """Load a result JSON and return a summary dict, or None on failure."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    # Try to get timestamp from file or data
+    ts = _parse_timestamp_from_filename(path.name)
+    env = data.get("environment", {})
+    ts_str = env.get("timestamp", "")
+    if not ts and ts_str:
+        try:
+            ts = datetime.fromisoformat(ts_str)
+        except ValueError:
+            pass
+    if not ts:
+        # Fall back to file mtime
+        ts = datetime.fromtimestamp(path.stat().st_mtime)
+
+    return {
+        "file": path.name,
+        "timestamp": ts,
+        "model": data.get("model", "?"),
+        "num_prompts": data.get("num_prompts", 0),
+        "completed": data.get("completed", 0),
+        "failed": data.get("failed", 0),
+        "request_throughput": data.get("request_throughput"),
+        "output_throughput": data.get("output_throughput"),
+        "mean_ttft_ms": data.get("mean_ttft_ms"),
+        "mean_e2el_ms": data.get("mean_e2el_ms"),
+        "partial": data.get("partial", False),
+        "total_duration_s": data.get("total_duration_s", 0),
+    }
+
+
+def list_history(result_dir: str | Path, last_n: int | None = None) -> list[dict]:
+    """List benchmark results in *result_dir*, sorted by timestamp (newest last).
+
+    Returns a list of summary dicts.
+    """
+    rdir = Path(result_dir)
+    if not rdir.is_dir():
+        return []
+
+    summaries: list[dict] = []
+    for p in sorted(rdir.glob("*.json")):
+        s = _load_result_summary(p)
+        if s is not None:
+            summaries.append(s)
+
+    # Sort by timestamp
+    summaries.sort(key=lambda s: s["timestamp"])
+
+    if last_n is not None and last_n > 0:
+        summaries = summaries[-last_n:]
+
+    return summaries
+
+
+def format_history_table(summaries: list[dict]) -> str:
+    """Format history summaries as a human-readable table with sparkline trends."""
+    if not summaries:
+        return "No benchmark results found."
+
+    lines: list[str] = []
+    lines.append(f"{'#':>3}  {'Timestamp':<20} {'Model':<16} {'Reqs':>5} "
+                 f"{'OK':>5} {'Fail':>4} {'Thr req/s':>10} {'TTFT ms':>9} "
+                 f"{'E2E ms':>9} {'Partial':>7}")
+    lines.append("-" * 110)
+
+    for i, s in enumerate(summaries, 1):
+        ts = s["timestamp"].strftime("%Y-%m-%d %H:%M:%S")
+        model = (s["model"] or "?")[:15]
+        thr = f"{s['request_throughput']:.1f}" if s["request_throughput"] is not None else "-"
+        ttft = f"{s['mean_ttft_ms']:.1f}" if s["mean_ttft_ms"] is not None else "-"
+        e2e = f"{s['mean_e2el_ms']:.1f}" if s["mean_e2el_ms"] is not None else "-"
+        partial = "yes" if s["partial"] else ""
+        lines.append(
+            f"{i:>3}  {ts:<20} {model:<16} {s['num_prompts']:>5} "
+            f"{s['completed']:>5} {s['failed']:>4} {thr:>10} {ttft:>9} "
+            f"{e2e:>9} {partial:>7}"
+        )
+
+    # Sparkline trends (if ≥2 runs)
+    if len(summaries) >= 2:
+        lines.append("")
+        lines.append("Trends:")
+        for label, key in [
+            ("Throughput (req/s)", "request_throughput"),
+            ("Mean TTFT (ms)", "mean_ttft_ms"),
+            ("Mean E2E (ms)", "mean_e2el_ms"),
+        ]:
+            vals = [s[key] for s in summaries if s[key] is not None]
+            if len(vals) >= 2:
+                spark = _sparkline(vals)
+                lines.append(f"  {label:<22} {spark}  ({vals[0]:.1f} → {vals[-1]:.1f})")
+
+    return "\n".join(lines)
+
+
+def auto_save_result(result: dict, result_dir: str | Path, args) -> Path:
+    """Auto-save a benchmark result JSON with a timestamped filename.
+
+    Returns the path to the saved file.
+    """
+    rdir = Path(result_dir)
+    rdir.mkdir(parents=True, exist_ok=True)
+
+    dt = datetime.now().strftime("%Y%m%d-%H%M%S")
+    rate = getattr(args, "request_rate", "inf")
+    if rate == float("inf"):
+        rate = "inf"
+    model = getattr(args, "model", None) or "unknown"
+    backend = getattr(args, "backend", "openai")
+    filename = f"{backend}-{rate}qps-{model}-{dt}.json"
+
+    filepath = rdir / filename
+    with open(filepath, "w") as f:
+        json.dump(result, f, indent=2, default=str)
+
+    return filepath
+
+
+def history_main(argv: list[str] | None = None) -> None:
+    """Entry point for ``xpyd-bench history`` subcommand."""
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench history",
+        description="List past benchmark runs and show metric trends",
+    )
+    parser.add_argument(
+        "--result-dir",
+        type=str,
+        required=True,
+        help="Directory containing benchmark result JSON files.",
+    )
+    parser.add_argument(
+        "--last",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Show only the last N runs.",
+    )
+    args = parser.parse_args(argv)
+
+    summaries = list_history(args.result_dir, last_n=args.last)
+    print(format_history_table(summaries))

--- a/src/xpyd_bench/main.py
+++ b/src/xpyd_bench/main.py
@@ -72,6 +72,7 @@ _SUBCOMMANDS = {
     "replay",
     "config",
     "aggregate",
+    "history",
 }
 
 
@@ -121,6 +122,10 @@ def main() -> None:
         from xpyd_bench.aggregate import aggregate_main
 
         aggregate_main(rest)
+    elif subcmd == "history":
+        from xpyd_bench.history import history_main
+
+        history_main(rest)
 
 
 def _config_subcommand(argv: list[str]) -> None:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,176 @@
+"""Tests for M30: Benchmark Result Storage & History."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from xpyd_bench.history import (
+    _sparkline,
+    auto_save_result,
+    format_history_table,
+    history_main,
+    list_history,
+)
+
+
+def _make_result(
+    model: str = "test-model",
+    num_prompts: int = 100,
+    completed: int = 100,
+    failed: int = 0,
+    request_throughput: float = 50.0,
+    mean_ttft_ms: float = 10.0,
+    mean_e2el_ms: float = 100.0,
+    partial: bool = False,
+    total_duration_s: float = 2.0,
+) -> dict:
+    return {
+        "model": model,
+        "num_prompts": num_prompts,
+        "completed": completed,
+        "failed": failed,
+        "request_throughput": request_throughput,
+        "output_throughput": 1000.0,
+        "mean_ttft_ms": mean_ttft_ms,
+        "mean_e2el_ms": mean_e2el_ms,
+        "partial": partial,
+        "total_duration_s": total_duration_s,
+        "environment": {"timestamp": datetime.now().isoformat()},
+    }
+
+
+class TestSparkline:
+    def test_empty(self):
+        assert _sparkline([]) == ""
+
+    def test_constant(self):
+        s = _sparkline([5, 5, 5])
+        assert len(s) == 3
+
+    def test_ascending(self):
+        s = _sparkline([0, 1, 2, 3, 4, 5, 6, 7])
+        assert s[0] == "▁"
+        assert s[-1] == "█"
+
+    def test_single(self):
+        s = _sparkline([42])
+        assert len(s) == 1
+
+
+class TestAutoSave:
+    def test_auto_save_creates_file(self, tmp_path: Path):
+        result = _make_result()
+
+        class FakeArgs:
+            request_rate = 10.0
+            model = "gpt-test"
+            backend = "openai"
+
+        saved = auto_save_result(result, tmp_path, FakeArgs())
+        assert saved.exists()
+        assert saved.suffix == ".json"
+        data = json.loads(saved.read_text())
+        assert data["model"] == "test-model"
+
+    def test_auto_save_creates_dir(self, tmp_path: Path):
+        result_dir = tmp_path / "sub" / "dir"
+        result = _make_result()
+
+        class FakeArgs:
+            request_rate = float("inf")
+            model = None
+            backend = "openai"
+
+        saved = auto_save_result(result, result_dir, FakeArgs())
+        assert saved.exists()
+        assert result_dir.is_dir()
+
+    def test_auto_save_inf_rate(self, tmp_path: Path):
+        result = _make_result()
+
+        class FakeArgs:
+            request_rate = float("inf")
+            model = "m"
+            backend = "openai"
+
+        saved = auto_save_result(result, tmp_path, FakeArgs())
+        assert "inf" in saved.name
+
+
+class TestListHistory:
+    def test_empty_dir(self, tmp_path: Path):
+        assert list_history(tmp_path) == []
+
+    def test_nonexistent_dir(self, tmp_path: Path):
+        assert list_history(tmp_path / "nope") == []
+
+    def test_lists_results(self, tmp_path: Path):
+        for i in range(3):
+            p = tmp_path / f"openai-10qps-model-20250401-{120000 + i}.json"
+            p.write_text(json.dumps(_make_result(request_throughput=50.0 + i)))
+        summaries = list_history(tmp_path)
+        assert len(summaries) == 3
+
+    def test_last_n(self, tmp_path: Path):
+        for i in range(5):
+            p = tmp_path / f"openai-10qps-model-20250401-{120000 + i}.json"
+            p.write_text(json.dumps(_make_result()))
+        summaries = list_history(tmp_path, last_n=2)
+        assert len(summaries) == 2
+
+    def test_sorted_by_timestamp(self, tmp_path: Path):
+        # Write out of order
+        (tmp_path / "a-20250401-120002.json").write_text(json.dumps(_make_result()))
+        (tmp_path / "a-20250401-120000.json").write_text(json.dumps(_make_result()))
+        (tmp_path / "a-20250401-120001.json").write_text(json.dumps(_make_result()))
+        summaries = list_history(tmp_path)
+        timestamps = [s["timestamp"] for s in summaries]
+        assert timestamps == sorted(timestamps)
+
+    def test_skips_invalid_json(self, tmp_path: Path):
+        (tmp_path / "bad.json").write_text("not json")
+        (tmp_path / "good-20250401-120000.json").write_text(json.dumps(_make_result()))
+        summaries = list_history(tmp_path)
+        assert len(summaries) == 1
+
+
+class TestFormatHistoryTable:
+    def test_empty(self):
+        output = format_history_table([])
+        assert "No benchmark results found" in output
+
+    def test_single_run(self, tmp_path: Path):
+        p = tmp_path / "openai-10qps-model-20250401-120000.json"
+        p.write_text(json.dumps(_make_result()))
+        summaries = list_history(tmp_path)
+        output = format_history_table(summaries)
+        assert "test-model" in output
+
+    def test_trends_shown_for_multiple_runs(self, tmp_path: Path):
+        for i in range(3):
+            p = tmp_path / f"openai-10qps-model-20250401-{120000 + i}.json"
+            p.write_text(json.dumps(_make_result(request_throughput=50.0 + i * 10)))
+        summaries = list_history(tmp_path)
+        output = format_history_table(summaries)
+        assert "Trends:" in output
+        assert "Throughput" in output
+
+
+class TestHistoryMain:
+    def test_basic(self, tmp_path: Path, capsys):
+        for i in range(2):
+            p = tmp_path / f"r-20250401-{120000 + i}.json"
+            p.write_text(json.dumps(_make_result()))
+        history_main(["--result-dir", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert "test-model" in captured.out
+
+    def test_last_flag(self, tmp_path: Path, capsys):
+        for i in range(5):
+            p = tmp_path / f"r-20250401-{120000 + i}.json"
+            p.write_text(json.dumps(_make_result()))
+        history_main(["--result-dir", str(tmp_path), "--last", "2"])
+        captured = capsys.readouterr()
+        assert "test-model" in captured.out


### PR DESCRIPTION
## Summary
Implements M30 from the roadmap: benchmark result storage and history browsing.

### Changes
- **`src/xpyd_bench/history.py`**: New module with:
  - `auto_save_result()`: Auto-save results with timestamped filenames when `--result-dir` is set
  - `list_history()`: List past runs sorted by timestamp with `--last N` support
  - `format_history_table()`: Human-readable table with sparkline trends
  - `history_main()`: CLI entry point for `xpyd-bench history` subcommand
- **`src/xpyd_bench/main.py`**: Register `history` subcommand
- **`src/xpyd_bench/cli.py`**: Auto-save to `--result-dir` without needing `--save-result`
- **`tests/test_history.py`**: 18 tests covering sparklines, auto-save, listing, trends, CLI

### Features
- `xpyd-bench history --result-dir <path>` lists all past runs
- `--last N` shows only the N most recent runs
- Sparkline trend visualization for throughput, TTFT, and E2E latency
- YAML config support (`result_dir`)

Closes #116