### PR TITLE
feat(plugins): add plugin architecture for custom backends (M31)

### DIFF
--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -446,6 +446,18 @@ def _compute_metrics(result: BenchmarkResult) -> None:
 
 async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, BenchmarkResult]:
     """Execute the benchmark and return (result_dict, BenchmarkResult)."""
+    # Resolve backend plugin (M31)
+    backend_name = getattr(args, "backend", "openai")
+    use_plugin = False
+    plugin = None
+
+    # "openai" and "openai-chat" use the legacy code path for full backward compat
+    if backend_name not in ("openai", "openai-chat"):
+        from xpyd_bench.plugins import registry
+
+        plugin = registry.get(backend_name)
+        use_plugin = True
+
     is_chat = "chat" in args.endpoint
     is_embeddings = "embeddings" in args.endpoint
     # Use explicit --stream/--no-stream if provided; default to endpoint type for
@@ -456,7 +468,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         is_streaming = False
     else:
         is_streaming = stream_flag if stream_flag is not None else is_chat
-    url = f"{base_url}{args.endpoint}"
+    url = plugin.build_url(base_url, args) if use_plugin else f"{base_url}{args.endpoint}"
 
     # Build default headers (authentication + custom)
     headers: dict[str, str] = {}
@@ -572,34 +584,45 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     req_retries = getattr(args, "retries", 0) or 0
     req_retry_delay = getattr(args, "retry_delay", 1.0) or 1.0
 
+    def _mk_payload(prompt: str) -> dict[str, Any]:
+        if use_plugin:
+            return plugin.build_payload(
+                args, prompt, is_chat=is_chat, is_embeddings=is_embeddings
+            )
+        return _build_payload(args, prompt, is_chat, is_embeddings)
+
+    async def _do_send(
+        client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> RequestResult:
+        if use_plugin:
+            return await plugin.send_request(
+                client, url, payload,
+                is_streaming=is_streaming,
+                request_timeout=request_timeout,
+                retries=req_retries,
+                retry_delay=req_retry_delay,
+            )
+        return await _send_request(
+            client, url, payload, is_streaming,
+            request_timeout=request_timeout,
+            retries=req_retries,
+            retry_delay=req_retry_delay,
+        )
+
     async def _task(client: httpx.AsyncClient, prompt: str) -> RequestResult:
+        payload = _mk_payload(prompt)
         if adaptive_limiter:
             await adaptive_limiter.acquire()
             try:
-                r = await _send_request(
-                    client, url, _build_payload(args, prompt, is_chat, is_embeddings), is_streaming,
-                    request_timeout=request_timeout,
-                    retries=req_retries,
-                    retry_delay=req_retry_delay,
-                )
+                r = await _do_send(client, payload)
             finally:
                 adaptive_limiter.release()
             await adaptive_limiter.record_latency(r.latency_ms)
             return r
         if semaphore:
             async with semaphore:
-                return await _send_request(
-                    client, url, _build_payload(args, prompt, is_chat, is_embeddings), is_streaming,
-                    request_timeout=request_timeout,
-                    retries=req_retries,
-                    retry_delay=req_retry_delay,
-                )
-        return await _send_request(
-            client, url, _build_payload(args, prompt, is_chat, is_embeddings), is_streaming,
-            request_timeout=request_timeout,
-            retries=req_retries,
-            retry_delay=req_retry_delay,
-        )
+                return await _do_send(client, payload)
+        return await _do_send(client, payload)
 
     # Live dashboard (M29) — use LiveDashboard when not explicitly disabled
     no_live = getattr(args, "no_live", False)
@@ -657,7 +680,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     shutdown_requested = False
 
     async def _tracked_task(client: httpx.AsyncClient, prompt: str) -> RequestResult:
-        payload = _build_payload(args, prompt, is_chat, is_embeddings)
+        payload = _mk_payload(prompt)
         r = await _task(client, prompt)
         if debug_logger:
             debug_logger.log(url, payload, r)

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -17,8 +17,19 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         "--backend",
         type=str,
         default="openai",
-        choices=["openai", "openai-chat"],
-        help="Backend type (default: openai).",
+        help="Backend type (default: openai). Use --list-backends to see available.",
+    )
+    parser.add_argument(
+        "--backend-plugin",
+        type=str,
+        default=None,
+        help="Dotted module path for a custom backend plugin (e.g. my_pkg.my_backend).",
+    )
+    parser.add_argument(
+        "--list-backends",
+        action="store_true",
+        default=False,
+        help="List available backend plugins and exit.",
     )
     parser.add_argument(
         "--base-url",
@@ -731,6 +742,27 @@ def bench_main(argv: list[str] | None = None) -> None:
     )
     _add_vllm_compat_args(parser)
     args = parser.parse_args(argv)
+
+    # List backends and exit
+    if getattr(args, "list_backends", False):
+        from xpyd_bench.plugins import registry
+
+        backends = registry.list_backends()
+        print("Available backends:\n")
+        for b in backends:
+            print(f"  {b}")
+        print(
+            "\nUse --backend <name> to select a backend, or "
+            "--backend-plugin <module> to load a custom one."
+        )
+        return
+
+    # Load custom backend plugin if specified
+    backend_plugin_module = getattr(args, "backend_plugin", None)
+    if backend_plugin_module:
+        from xpyd_bench.plugins import registry
+
+        registry.load_module_plugin(backend_plugin_module)
 
     # List scenarios and exit
     if args.list_scenarios:

--- a/src/xpyd_bench/plugins/__init__.py
+++ b/src/xpyd_bench/plugins/__init__.py
@@ -1,0 +1,161 @@
+"""Plugin architecture for custom backends (M31).
+
+Provides an abstract base class for backend plugins and a registry for
+discovering / loading them.
+"""
+
+from __future__ import annotations
+
+import abc
+import importlib
+import importlib.metadata
+from argparse import Namespace
+from typing import Any
+
+from xpyd_bench.bench.models import RequestResult
+
+__all__ = [
+    "BackendPlugin",
+    "PluginRegistry",
+    "registry",
+]
+
+ENTRY_POINT_GROUP = "xpyd.backends"
+
+
+# ---------------------------------------------------------------------------
+# Abstract base class
+# ---------------------------------------------------------------------------
+
+
+class BackendPlugin(abc.ABC):
+    """Interface that every backend plugin must implement."""
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Unique backend name (e.g. ``"openai"``, ``"vllm-native"``)."""
+
+    @abc.abstractmethod
+    def build_payload(
+        self,
+        args: Namespace,
+        prompt: str,
+        *,
+        is_chat: bool = False,
+        is_embeddings: bool = False,
+    ) -> dict[str, Any]:
+        """Build the JSON body for a single request."""
+
+    @abc.abstractmethod
+    async def send_request(
+        self,
+        client: Any,
+        url: str,
+        payload: dict[str, Any],
+        *,
+        is_streaming: bool = False,
+        request_timeout: float = 300.0,
+        retries: int = 0,
+        retry_delay: float = 1.0,
+    ) -> RequestResult:
+        """Send one request and return collected metrics."""
+
+    def build_url(self, base_url: str, args: Namespace) -> str:
+        """Build the full request URL.  Default: ``base_url + args.endpoint``."""
+        return f"{base_url.rstrip('/')}{args.endpoint}"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class PluginRegistry:
+    """Central registry for backend plugins."""
+
+    def __init__(self) -> None:
+        self._plugins: dict[str, BackendPlugin] = {}
+        self._ep_loaded = False
+
+    # -- public API ---------------------------------------------------------
+
+    def register(self, plugin: BackendPlugin) -> None:
+        """Register a plugin instance.  Overwrites any existing with same name."""
+        self._plugins[plugin.name] = plugin
+
+    def get(self, name: str) -> BackendPlugin:
+        """Return the plugin for *name*, raising ``KeyError`` if not found."""
+        self._load_entry_points()
+        if name not in self._plugins:
+            raise KeyError(
+                f"Unknown backend '{name}'. "
+                f"Available: {', '.join(self.list_backends())}"
+            )
+        return self._plugins[name]
+
+    def list_backends(self) -> list[str]:
+        """Return sorted list of registered backend names."""
+        self._load_entry_points()
+        return sorted(self._plugins)
+
+    # -- entry-point discovery ----------------------------------------------
+
+    def _load_entry_points(self) -> None:
+        """Discover plugins registered via ``pyproject.toml`` entry points."""
+        if self._ep_loaded:
+            return
+        self._ep_loaded = True
+        try:
+            eps = importlib.metadata.entry_points()
+            # Python 3.12+ returns SelectableGroups; earlier returns dict
+            if hasattr(eps, "select"):
+                group = eps.select(group=ENTRY_POINT_GROUP)
+            else:
+                group = eps.get(ENTRY_POINT_GROUP, [])
+            for ep in group:
+                try:
+                    plugin_cls_or_inst = ep.load()
+                    if isinstance(plugin_cls_or_inst, type):
+                        inst = plugin_cls_or_inst()
+                    else:
+                        inst = plugin_cls_or_inst
+                    if isinstance(inst, BackendPlugin) and inst.name not in self._plugins:
+                        self._plugins[inst.name] = inst
+                except Exception:  # noqa: BLE001
+                    pass  # silently skip broken entry points
+        except Exception:  # noqa: BLE001
+            pass
+
+    def load_module_plugin(self, module_path: str) -> BackendPlugin:
+        """Load a plugin from a dotted module path.
+
+        The module must define a ``plugin`` attribute (instance) **or** a
+        ``Plugin`` class that is a ``BackendPlugin`` subclass.
+        """
+        mod = importlib.import_module(module_path)
+        if hasattr(mod, "plugin") and isinstance(mod.plugin, BackendPlugin):
+            plugin = mod.plugin
+        elif hasattr(mod, "Plugin") and issubclass(mod.Plugin, BackendPlugin):
+            plugin = mod.Plugin()
+        else:
+            raise ImportError(
+                f"Module '{module_path}' does not expose a 'plugin' instance "
+                "or a 'Plugin' class that subclasses BackendPlugin."
+            )
+        self.register(plugin)
+        return plugin
+
+
+# Singleton registry
+registry = PluginRegistry()
+
+
+def _register_builtins() -> None:
+    """Register the built-in OpenAI backend plugin."""
+    from xpyd_bench.plugins.openai_backend import OpenAIBackendPlugin
+
+    registry.register(OpenAIBackendPlugin())
+
+
+_register_builtins()

--- a/src/xpyd_bench/plugins/examples/__init__.py
+++ b/src/xpyd_bench/plugins/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example plugins package."""

--- a/src/xpyd_bench/plugins/examples/vllm_native.py
+++ b/src/xpyd_bench/plugins/examples/vllm_native.py
@@ -1,0 +1,159 @@
+"""Example vLLM native protocol backend plugin (M31).
+
+Demonstrates how to implement a custom backend for xpyd-bench.
+This plugin targets the vLLM ``/generate`` endpoint which uses a
+different payload format than the OpenAI-compatible API.
+
+Usage::
+
+    xpyd-bench run --backend vllm-native --backend-plugin xpyd_bench.plugins.examples.vllm_native \\
+        --base-url http://localhost:8000 --model my-model --num-prompts 10
+
+Or register via entry point in your ``pyproject.toml``::
+
+    [project.entry-points."xpyd.backends"]
+    vllm-native = "xpyd_bench.plugins.examples.vllm_native:Plugin"
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from argparse import Namespace
+from typing import Any
+
+from xpyd_bench.bench.models import RequestResult
+from xpyd_bench.plugins import BackendPlugin
+
+
+class Plugin(BackendPlugin):
+    """Backend plugin for vLLM native ``/generate`` endpoint."""
+
+    @property
+    def name(self) -> str:
+        return "vllm-native"
+
+    def build_url(self, base_url: str, args: Namespace) -> str:
+        """vLLM native endpoint is ``/generate``."""
+        return f"{base_url.rstrip('/')}/generate"
+
+    def build_payload(
+        self,
+        args: Namespace,
+        prompt: str,
+        *,
+        is_chat: bool = False,
+        is_embeddings: bool = False,
+    ) -> dict[str, Any]:
+        """Build a vLLM native ``/generate`` payload."""
+        payload: dict[str, Any] = {
+            "prompt": prompt,
+            "max_tokens": getattr(args, "output_len", 128),
+        }
+        if args.model:
+            payload["model"] = args.model
+        if getattr(args, "temperature", None) is not None:
+            payload["temperature"] = args.temperature
+        if getattr(args, "top_p", None) is not None:
+            payload["top_p"] = args.top_p
+        if getattr(args, "top_k", None) is not None:
+            payload["top_k"] = args.top_k
+        if getattr(args, "stream", False):
+            payload["stream"] = True
+        return payload
+
+    async def send_request(
+        self,
+        client: Any,
+        url: str,
+        payload: dict[str, Any],
+        *,
+        is_streaming: bool = False,
+        request_timeout: float = 300.0,
+        retries: int = 0,
+        retry_delay: float = 1.0,
+    ) -> RequestResult:
+        """Send a request to vLLM native endpoint."""
+        result = RequestResult()
+        start = time.perf_counter()
+        result.start_time = start
+
+        try:
+            if is_streaming:
+                result = await self._stream(client, url, payload, start, request_timeout)
+            else:
+                resp = await client.post(url, json=payload, timeout=request_timeout)
+                resp.raise_for_status()
+                end = time.perf_counter()
+                result.latency_ms = (end - start) * 1000.0
+
+                body = resp.json()
+                # vLLM native returns text in "text" field (list)
+                texts = body.get("text", [])
+                if texts:
+                    # Rough token estimate: split by whitespace
+                    result.completion_tokens = sum(
+                        len(t.split()) for t in texts
+                    )
+        except Exception as exc:  # noqa: BLE001
+            end = time.perf_counter()
+            result.latency_ms = (end - start) * 1000.0
+            result.success = False
+            result.error = str(exc)
+
+        return result
+
+    async def _stream(
+        self,
+        client: Any,
+        url: str,
+        payload: dict[str, Any],
+        start: float,
+        request_timeout: float,
+    ) -> RequestResult:
+        """Handle streaming from vLLM native endpoint."""
+        result = RequestResult()
+        result.start_time = start
+        first_token_time: float | None = None
+        last_token_time = start
+        token_count = 0
+
+        try:
+            async with client.stream("POST", url, json=payload, timeout=request_timeout) as resp:
+                resp.raise_for_status()
+                async for line in resp.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    data_str = line[len("data: "):]
+                    if data_str.strip() == "[DONE]":
+                        break
+                    now = time.perf_counter()
+                    try:
+                        chunk = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+                    texts = chunk.get("text", [])
+                    if not texts or not any(texts):
+                        continue
+                    token_count += 1
+                    if first_token_time is None:
+                        first_token_time = now
+                        result.ttft_ms = (now - start) * 1000.0
+                    else:
+                        result.itl_ms.append((now - last_token_time) * 1000.0)
+                    last_token_time = now
+        except Exception as exc:  # noqa: BLE001
+            result.success = False
+            result.error = str(exc)
+
+        end = time.perf_counter()
+        result.latency_ms = (end - start) * 1000.0
+        result.completion_tokens = token_count
+        if token_count > 1 and first_token_time is not None:
+            generation_ms = (last_token_time - first_token_time) * 1000.0
+            result.tpot_ms = generation_ms / (token_count - 1)
+        return result
+
+
+# Module-level instance for ``load_module_plugin`` convenience
+plugin = Plugin()

--- a/src/xpyd_bench/plugins/openai_backend.py
+++ b/src/xpyd_bench/plugins/openai_backend.py
@@ -1,0 +1,56 @@
+"""Built-in OpenAI-compatible backend plugin (M31).
+
+Wraps the existing ``runner._send_request`` / ``runner._build_payload`` so
+the default behaviour is unchanged while satisfying the plugin interface.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from typing import Any
+
+from xpyd_bench.bench.models import RequestResult
+from xpyd_bench.plugins import BackendPlugin
+
+
+class OpenAIBackendPlugin(BackendPlugin):
+    """Default backend — speaks the OpenAI HTTP API."""
+
+    @property
+    def name(self) -> str:
+        return "openai"
+
+    def build_payload(
+        self,
+        args: Namespace,
+        prompt: str,
+        *,
+        is_chat: bool = False,
+        is_embeddings: bool = False,
+    ) -> dict[str, Any]:
+        from xpyd_bench.bench.runner import _build_payload
+
+        return _build_payload(args, prompt, is_chat, is_embeddings)
+
+    async def send_request(
+        self,
+        client: Any,
+        url: str,
+        payload: dict[str, Any],
+        *,
+        is_streaming: bool = False,
+        request_timeout: float = 300.0,
+        retries: int = 0,
+        retry_delay: float = 1.0,
+    ) -> RequestResult:
+        from xpyd_bench.bench.runner import _send_request
+
+        return await _send_request(
+            client,
+            url,
+            payload,
+            is_streaming,
+            request_timeout=request_timeout,
+            retries=retries,
+            retry_delay=retry_delay,
+        )

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,248 @@
+"""Tests for M31: Plugin Architecture for Custom Backends."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from typing import Any
+
+import pytest
+
+from xpyd_bench.bench.models import RequestResult
+from xpyd_bench.plugins import BackendPlugin, PluginRegistry, registry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class DummyPlugin(BackendPlugin):
+    """Minimal plugin for testing."""
+
+    @property
+    def name(self) -> str:
+        return "dummy-test"
+
+    def build_payload(
+        self, args: Namespace, prompt: str, *, is_chat: bool = False, is_embeddings: bool = False
+    ) -> dict[str, Any]:
+        return {"prompt": prompt, "custom": True}
+
+    async def send_request(
+        self,
+        client: Any,
+        url: str,
+        payload: dict[str, Any],
+        *,
+        is_streaming: bool = False,
+        request_timeout: float = 300.0,
+        retries: int = 0,
+        retry_delay: float = 1.0,
+    ) -> RequestResult:
+        r = RequestResult()
+        r.latency_ms = 42.0
+        r.success = True
+        r.completion_tokens = 10
+        return r
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestPluginRegistry:
+    def test_register_and_get(self) -> None:
+        reg = PluginRegistry()
+        p = DummyPlugin()
+        reg.register(p)
+        assert reg.get("dummy-test") is p
+
+    def test_get_unknown_raises(self) -> None:
+        reg = PluginRegistry()
+        with pytest.raises(KeyError, match="Unknown backend"):
+            reg.get("nonexistent")
+
+    def test_list_backends(self) -> None:
+        reg = PluginRegistry()
+        reg.register(DummyPlugin())
+        assert "dummy-test" in reg.list_backends()
+
+    def test_register_overwrites(self) -> None:
+        reg = PluginRegistry()
+        p1 = DummyPlugin()
+        p2 = DummyPlugin()
+        reg.register(p1)
+        reg.register(p2)
+        assert reg.get("dummy-test") is p2
+
+
+class TestGlobalRegistry:
+    def test_openai_builtin(self) -> None:
+        """Built-in OpenAI plugin should be registered by default."""
+        assert "openai" in registry.list_backends()
+        p = registry.get("openai")
+        assert p.name == "openai"
+
+
+# ---------------------------------------------------------------------------
+# Plugin interface tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackendPluginInterface:
+    def test_build_payload(self) -> None:
+        p = DummyPlugin()
+        args = Namespace(model="test")
+        payload = p.build_payload(args, "hello world")
+        assert payload == {"prompt": "hello world", "custom": True}
+
+    @pytest.mark.asyncio
+    async def test_send_request(self) -> None:
+        p = DummyPlugin()
+        result = await p.send_request(None, "http://localhost/test", {"prompt": "hi"})
+        assert result.success is True
+        assert result.latency_ms == 42.0
+        assert result.completion_tokens == 10
+
+    def test_build_url_default(self) -> None:
+        p = DummyPlugin()
+        args = Namespace(endpoint="/v1/completions")
+        url = p.build_url("http://localhost:8000", args)
+        assert url == "http://localhost:8000/v1/completions"
+
+
+# ---------------------------------------------------------------------------
+# Module plugin loading
+# ---------------------------------------------------------------------------
+
+
+class TestLoadModulePlugin:
+    def test_load_vllm_example(self) -> None:
+        reg = PluginRegistry()
+        plugin = reg.load_module_plugin("xpyd_bench.plugins.examples.vllm_native")
+        assert plugin.name == "vllm-native"
+        assert "vllm-native" in reg.list_backends()
+
+    def test_load_nonexistent_module(self) -> None:
+        reg = PluginRegistry()
+        with pytest.raises(ImportError):
+            reg.load_module_plugin("nonexistent.module.path")
+
+    def test_load_module_without_plugin(self) -> None:
+        reg = PluginRegistry()
+        with pytest.raises(ImportError, match="does not expose"):
+            reg.load_module_plugin("json")  # json has no plugin/Plugin
+
+
+# ---------------------------------------------------------------------------
+# vLLM native example plugin tests
+# ---------------------------------------------------------------------------
+
+
+class TestVLLMNativePlugin:
+    def test_name(self) -> None:
+        from xpyd_bench.plugins.examples.vllm_native import Plugin
+
+        p = Plugin()
+        assert p.name == "vllm-native"
+
+    def test_build_url(self) -> None:
+        from xpyd_bench.plugins.examples.vllm_native import Plugin
+
+        p = Plugin()
+        args = Namespace(endpoint="/v1/completions")
+        url = p.build_url("http://localhost:8000", args)
+        assert url == "http://localhost:8000/generate"
+
+    def test_build_payload(self) -> None:
+        from xpyd_bench.plugins.examples.vllm_native import Plugin
+
+        p = Plugin()
+        args = Namespace(
+            model="my-model",
+            output_len=64,
+            temperature=0.5,
+            top_p=None,
+            top_k=None,
+            stream=False,
+        )
+        payload = p.build_payload(args, "hello")
+        assert payload == {
+            "prompt": "hello",
+            "max_tokens": 64,
+            "model": "my-model",
+            "temperature": 0.5,
+        }
+
+    def test_build_payload_streaming(self) -> None:
+        from xpyd_bench.plugins.examples.vllm_native import Plugin
+
+        p = Plugin()
+        args = Namespace(
+            model="m", output_len=10, temperature=None, top_p=None, top_k=None, stream=True
+        )
+        payload = p.build_payload(args, "test")
+        assert payload["stream"] is True
+
+
+# ---------------------------------------------------------------------------
+# OpenAI backend plugin tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIBackendPlugin:
+    def test_name(self) -> None:
+        from xpyd_bench.plugins.openai_backend import OpenAIBackendPlugin
+
+        p = OpenAIBackendPlugin()
+        assert p.name == "openai"
+
+    def test_build_payload_delegates(self) -> None:
+        from xpyd_bench.plugins.openai_backend import OpenAIBackendPlugin
+
+        p = OpenAIBackendPlugin()
+        args = Namespace(
+            model="gpt-4",
+            output_len=50,
+            temperature=None,
+            top_p=None,
+            top_k=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            best_of=None,
+            use_beam_search=False,
+            logprobs=None,
+            ignore_eos=False,
+        )
+        payload = p.build_payload(args, "hi", is_chat=False)
+        assert payload["prompt"] == "hi"
+        assert payload["max_tokens"] == 50
+        assert payload["model"] == "gpt-4"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLIIntegration:
+    def test_list_backends_flag(self, capsys: pytest.CaptureFixture) -> None:
+        from xpyd_bench.cli import bench_main
+
+        bench_main(["--list-backends"])
+        out = capsys.readouterr().out
+        assert "openai" in out
+        assert "Available backends" in out
+
+    def test_backend_plugin_flag_unknown(self) -> None:
+        """--backend-plugin with nonexistent module should fail."""
+        from xpyd_bench.cli import bench_main
+
+        with pytest.raises((ImportError, SystemExit)):
+            bench_main([
+                "--backend-plugin", "nonexistent_module_xyz",
+                "--backend", "nonexistent",
+                "--base-url", "http://localhost:9999",
+                "--num-prompts", "1",
+                "--disable-tqdm",
+            ])


### PR DESCRIPTION
## Summary
Implements M31: Plugin Architecture for Custom Backends.

Closes #118

## Changes
- **`BackendPlugin` ABC** (`src/xpyd_bench/plugins/__init__.py`): Abstract base class defining the interface — `name`, `build_payload()`, `send_request()`, `build_url()`
- **`PluginRegistry`**: Central registry with `register()`, `get()`, `list_backends()`, entry point discovery via `xpyd.backends` group, and `load_module_plugin()` for dotted module paths
- **Built-in OpenAI plugin** (`openai_backend.py`): Wraps existing runner functions, fully backward compatible
- **Example vLLM native plugin** (`plugins/examples/vllm_native.py`): Demonstrates the interface for `/generate` endpoint
- **CLI flags**: `--backend-plugin <module>` to load custom plugins, `--list-backends` to show available backends
- **Runner integration**: Dispatches through plugin when non-default backend is selected
- **19 tests** covering registration, loading, execution, error handling, CLI integration

## Testing
```
ruff check src tests && isort --check src tests  # ✅
pytest tests/ -q                                   # 635 passed ✅
```