### PR TITLE
feat(tags): add benchmark annotations & tags (M36)

### DIFF
--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -83,3 +83,6 @@ class BenchmarkResult:
 
     # Environment metadata for reproducibility
     environment: dict[str, str] = field(default_factory=dict)
+
+    # User-defined tags for annotation (M36)
+    tags: dict[str, str] = field(default_factory=dict)

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -953,4 +953,6 @@ def _to_dict(r: BenchmarkResult) -> dict:
         d["environment"] = r.environment
     if r.partial:
         d["partial"] = True
+    if r.tags:
+        d["tags"] = r.tags
     return d

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -552,12 +552,39 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Display a latency heatmap in the terminal after the benchmark.",
     )
 
+    # Tags (M36)
+    parser.add_argument(
+        "--tag",
+        action="append",
+        dest="tags",
+        default=None,
+        metavar="KEY=VALUE",
+        help="Attach a metadata tag (repeatable). E.g. --tag env=prod --tag gpu=A100",
+    )
+
 
 def _resolve_base_url(args: argparse.Namespace) -> str:
     """Resolve the base URL from --base-url or --host/--port."""
     if args.base_url:
         return args.base_url.rstrip("/")
     return f"http://{args.host}:{args.port}"
+
+
+def _parse_tags(args: argparse.Namespace) -> dict[str, str]:
+    """Parse --tag KEY=VALUE items and YAML ``tags`` config into a dict."""
+    tags: dict[str, str] = {}
+    # YAML config may set args.tags as a dict directly
+    yaml_tags = getattr(args, "tags", None)
+    if isinstance(yaml_tags, dict):
+        tags.update({str(k): str(v) for k, v in yaml_tags.items()})
+        return tags
+    # CLI sets args.tags as a list of "KEY=VALUE" strings
+    if yaml_tags:
+        for item in yaml_tags:
+            if "=" in item:
+                k, v = item.split("=", 1)
+                tags[k.strip()] = v.strip()
+    return tags
 
 
 def _dry_run(args: argparse.Namespace, base_url: str) -> None:
@@ -846,6 +873,12 @@ def bench_main(argv: list[str] | None = None) -> None:
     print()
 
     result, bench_result = asyncio.run(run_benchmark(args, base_url))
+
+    # Inject tags (M36)
+    parsed_tags = _parse_tags(args)
+    if parsed_tags:
+        bench_result.tags = parsed_tags
+        result["tags"] = parsed_tags
 
     # Export reports (M6)
     if args.export_requests:

--- a/src/xpyd_bench/history.py
+++ b/src/xpyd_bench/history.py
@@ -73,11 +73,22 @@ def _load_result_summary(path: Path) -> dict | None:
         "mean_e2el_ms": data.get("mean_e2el_ms"),
         "partial": data.get("partial", False),
         "total_duration_s": data.get("total_duration_s", 0),
+        "tags": data.get("tags", {}),
     }
 
 
-def list_history(result_dir: str | Path, last_n: int | None = None) -> list[dict]:
+def list_history(
+    result_dir: str | Path,
+    last_n: int | None = None,
+    filter_tags: dict[str, str] | None = None,
+) -> list[dict]:
     """List benchmark results in *result_dir*, sorted by timestamp (newest last).
+
+    Parameters
+    ----------
+    filter_tags:
+        If provided, only include results whose ``tags`` contain all the
+        specified key-value pairs.
 
     Returns a list of summary dicts.
     """
@@ -90,6 +101,13 @@ def list_history(result_dir: str | Path, last_n: int | None = None) -> list[dict
         s = _load_result_summary(p)
         if s is not None:
             summaries.append(s)
+
+    # Filter by tags (M36)
+    if filter_tags:
+        summaries = [
+            s for s in summaries
+            if all(s.get("tags", {}).get(k) == v for k, v in filter_tags.items())
+        ]
 
     # Sort by timestamp
     summaries.sort(key=lambda s: s["timestamp"])
@@ -183,7 +201,24 @@ def history_main(argv: list[str] | None = None) -> None:
         metavar="N",
         help="Show only the last N runs.",
     )
+    parser.add_argument(
+        "--filter-tag",
+        action="append",
+        dest="filter_tags",
+        default=None,
+        metavar="KEY=VALUE",
+        help="Filter results by tag (repeatable). E.g. --filter-tag env=prod",
+    )
     args = parser.parse_args(argv)
 
-    summaries = list_history(args.result_dir, last_n=args.last)
+    # Parse filter tags
+    filter_tags: dict[str, str] | None = None
+    if args.filter_tags:
+        filter_tags = {}
+        for item in args.filter_tags:
+            if "=" in item:
+                k, v = item.split("=", 1)
+                filter_tags[k.strip()] = v.strip()
+
+    summaries = list_history(args.result_dir, last_n=args.last, filter_tags=filter_tags)
     print(format_history_table(summaries))

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,210 @@
+"""Tests for M36: Benchmark Annotations & Tags."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from xpyd_bench.bench.models import BenchmarkResult
+
+
+class TestTagsInModel:
+    """Test tags field on BenchmarkResult."""
+
+    def test_default_empty(self):
+        r = BenchmarkResult()
+        assert r.tags == {}
+
+    def test_set_tags(self):
+        r = BenchmarkResult(tags={"env": "prod", "gpu": "A100"})
+        assert r.tags == {"env": "prod", "gpu": "A100"}
+
+
+class TestTagsSerialization:
+    """Test that tags survive serialization through _to_dict."""
+
+    def test_to_dict_includes_tags(self):
+        from xpyd_bench.bench.runner import _to_dict
+
+        r = BenchmarkResult(tags={"env": "staging", "run_id": "42"})
+        d = _to_dict(r)
+        assert d["tags"] == {"env": "staging", "run_id": "42"}
+
+    def test_to_dict_omits_empty_tags(self):
+        from xpyd_bench.bench.runner import _to_dict
+
+        r = BenchmarkResult()
+        d = _to_dict(r)
+        assert "tags" not in d
+
+
+class TestParseTagsCLI:
+    """Test --tag CLI parsing."""
+
+    def test_parse_tags_from_list(self):
+        import argparse
+
+        from xpyd_bench.cli import _parse_tags
+
+        ns = argparse.Namespace(tags=["env=prod", "gpu=A100"])
+        tags = _parse_tags(ns)
+        assert tags == {"env": "prod", "gpu": "A100"}
+
+    def test_parse_tags_from_dict(self):
+        """YAML config may set tags as a dict."""
+        import argparse
+
+        from xpyd_bench.cli import _parse_tags
+
+        ns = argparse.Namespace(tags={"env": "prod", "gpu": "A100"})
+        tags = _parse_tags(ns)
+        assert tags == {"env": "prod", "gpu": "A100"}
+
+    def test_parse_tags_none(self):
+        import argparse
+
+        from xpyd_bench.cli import _parse_tags
+
+        ns = argparse.Namespace(tags=None)
+        tags = _parse_tags(ns)
+        assert tags == {}
+
+    def test_parse_tags_no_attr(self):
+        import argparse
+
+        from xpyd_bench.cli import _parse_tags
+
+        ns = argparse.Namespace()
+        tags = _parse_tags(ns)
+        assert tags == {}
+
+    def test_parse_tags_value_with_equals(self):
+        """Values can contain = signs."""
+        import argparse
+
+        from xpyd_bench.cli import _parse_tags
+
+        ns = argparse.Namespace(tags=["formula=a=b+c"])
+        tags = _parse_tags(ns)
+        assert tags == {"formula": "a=b+c"}
+
+
+class TestHistoryFilterTags:
+    """Test history filtering by tags."""
+
+    def _write_result(self, tmpdir: Path, name: str, tags: dict | None = None):
+        data = {
+            "model": "test",
+            "num_prompts": 10,
+            "completed": 10,
+            "failed": 0,
+            "request_throughput": 1.0,
+            "output_throughput": 1.0,
+            "mean_ttft_ms": 10.0,
+            "mean_e2el_ms": 50.0,
+            "total_duration_s": 10.0,
+        }
+        if tags:
+            data["tags"] = tags
+        (tmpdir / name).write_text(json.dumps(data))
+
+    def test_filter_tags_match(self, tmp_path):
+        from xpyd_bench.history import list_history
+
+        self._write_result(tmp_path, "a-20260101-120000.json", {"env": "prod"})
+        self._write_result(tmp_path, "b-20260101-120001.json", {"env": "staging"})
+        self._write_result(tmp_path, "c-20260101-120002.json", {"env": "prod", "gpu": "A100"})
+
+        results = list_history(tmp_path, filter_tags={"env": "prod"})
+        assert len(results) == 2
+        files = {r["file"] for r in results}
+        assert "a-20260101-120000.json" in files
+        assert "c-20260101-120002.json" in files
+
+    def test_filter_tags_no_match(self, tmp_path):
+        from xpyd_bench.history import list_history
+
+        self._write_result(tmp_path, "a-20260101-120000.json", {"env": "prod"})
+
+        results = list_history(tmp_path, filter_tags={"env": "staging"})
+        assert len(results) == 0
+
+    def test_filter_multiple_tags(self, tmp_path):
+        from xpyd_bench.history import list_history
+
+        self._write_result(tmp_path, "a-20260101-120000.json", {"env": "prod", "gpu": "A100"})
+        self._write_result(tmp_path, "b-20260101-120001.json", {"env": "prod", "gpu": "H100"})
+
+        results = list_history(tmp_path, filter_tags={"env": "prod", "gpu": "A100"})
+        assert len(results) == 1
+        assert results[0]["file"] == "a-20260101-120000.json"
+
+    def test_no_filter_returns_all(self, tmp_path):
+        from xpyd_bench.history import list_history
+
+        self._write_result(tmp_path, "a-20260101-120000.json", {"env": "prod"})
+        self._write_result(tmp_path, "b-20260101-120001.json")
+
+        results = list_history(tmp_path)
+        assert len(results) == 2
+
+    def test_filter_no_tags_in_result(self, tmp_path):
+        from xpyd_bench.history import list_history
+
+        self._write_result(tmp_path, "a-20260101-120000.json")
+
+        results = list_history(tmp_path, filter_tags={"env": "prod"})
+        assert len(results) == 0
+
+
+class TestHistoryCLIFilterTag:
+    """Test history CLI --filter-tag flag."""
+
+    def test_filter_tag_cli(self, tmp_path):
+        from xpyd_bench.history import history_main
+
+        # Write two results
+        for name, tags in [
+            ("a-20260101-120000.json", {"env": "prod"}),
+            ("b-20260101-120001.json", {"env": "staging"}),
+        ]:
+            data = {
+                "model": "test", "num_prompts": 10, "completed": 10,
+                "failed": 0, "request_throughput": 1.0, "mean_ttft_ms": 10.0,
+                "mean_e2el_ms": 50.0, "total_duration_s": 10.0, "tags": tags,
+            }
+            (tmp_path / name).write_text(json.dumps(data))
+
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            history_main([
+                "--result-dir", str(tmp_path),
+                "--filter-tag", "env=prod",
+            ])
+        output = buf.getvalue()
+        # Should only show 1 result row (the prod one)
+        assert "test" in output
+        # The table has a header + separator + 1 data row
+
+
+class TestTagsYAMLConfig:
+    """Test tags from YAML config."""
+
+    def test_yaml_tags_loaded(self, tmp_path):
+        import argparse
+
+        import yaml
+
+        from xpyd_bench.cli import _parse_tags
+
+        config = {"tags": {"env": "prod", "gpu": "A100"}}
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.dump(config))
+
+        # Simulate YAML loading setting tags as dict
+        ns = argparse.Namespace(tags=config["tags"])
+        tags = _parse_tags(ns)
+        assert tags == {"env": "prod", "gpu": "A100"}


### PR DESCRIPTION
## Summary
Implements M36: Benchmark Annotations & Tags from the roadmap.

### Changes
- **`src/xpyd_bench/bench/models.py`**: Added `tags: dict[str, str]` field to `BenchmarkResult`
- **`src/xpyd_bench/bench/runner.py`**: Include tags in `_to_dict()` serialization
- **`src/xpyd_bench/cli.py`**: Added `--tag KEY=VALUE` CLI flag (repeatable), `_parse_tags()` helper supporting both CLI list and YAML dict formats
- **`src/xpyd_bench/history.py`**: Added `--filter-tag` CLI flag and `filter_tags` parameter to `list_history()`
- **`tests/test_tags.py`**: 16 tests covering model, serialization, CLI parsing, YAML config, and history filtering

### Features
- `--tag env=prod --tag gpu=A100` attaches metadata to benchmark runs
- Tags stored in result JSON `tags` field
- YAML config: `tags: {env: prod, gpu: A100}`
- `xpyd-bench history --filter-tag env=prod` filters by tags
- Values can contain `=` signs (e.g. `--tag formula=a=b+c`)
- Empty tags omitted from JSON output

Closes #128