### PR TITLE
feat(templating): add request body templating (M37)

### DIFF
--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -530,6 +530,14 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         else:
             prompts = _generate_random_prompts(args.num_prompts, args.input_len, args.seed)
 
+    # Apply template variable substitution (M37)
+    template_vars_path = getattr(args, "template_vars", None)
+    if template_vars_path:
+        from xpyd_bench.templating import apply_templates, load_template_vars
+
+        tvars = load_template_vars(template_vars_path)
+        prompts = apply_templates(prompts, tvars)
+
     # Generate inter-arrival intervals
     rate_algorithm = getattr(args, "rate_algorithm", "default")
     rate_pattern = getattr(args, "rate_pattern", None)

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -562,6 +562,16 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Attach a metadata tag (repeatable). E.g. --tag env=prod --tag gpu=A100",
     )
 
+    # Template variables (M37)
+    parser.add_argument(
+        "--template-vars",
+        type=str,
+        default=None,
+        dest="template_vars",
+        metavar="PATH",
+        help="Path to JSON/YAML file with template variables for prompt substitution.",
+    )
+
 
 def _resolve_base_url(args: argparse.Namespace) -> str:
     """Resolve the base URL from --base-url or --host/--port."""

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -88,6 +88,8 @@ _KNOWN_KEYS: set[str] = {
     "use_beam_search",
     "user",
     "metrics_ws_port",
+    "tags",
+    "template_vars",
     "warmup",
 }
 

--- a/src/xpyd_bench/templating.py
+++ b/src/xpyd_bench/templating.py
@@ -1,0 +1,106 @@
+"""Request body templating with Jinja2-style variable substitution (M37)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+class TemplateError(Exception):
+    """Raised when template rendering fails."""
+
+
+_VAR_PATTERN = re.compile(r"\{\{\s*(\w+)\s*\}\}")
+
+
+def load_template_vars(path: str) -> dict[str, Any]:
+    """Load template variables from a JSON or YAML file.
+
+    Parameters
+    ----------
+    path:
+        Path to a .json or .yaml/.yml file containing a flat dict of variables.
+
+    Returns
+    -------
+    dict:
+        Variable name -> value mapping.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Template vars file not found: {path}")
+
+    text = p.read_text(encoding="utf-8")
+    ext = p.suffix.lower()
+
+    if ext == ".json":
+        data = json.loads(text)
+    elif ext in (".yaml", ".yml"):
+        import yaml
+
+        data = yaml.safe_load(text)
+    else:
+        raise ValueError(
+            f"Unsupported template vars format: {ext}. Use .json, .yaml, or .yml."
+        )
+
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Template vars file must contain a dict/object, got {type(data).__name__}"
+        )
+    return data
+
+
+def render_template(template: str, variables: dict[str, Any]) -> str:
+    """Render a template string by substituting ``{{ variable }}`` placeholders.
+
+    Parameters
+    ----------
+    template:
+        String potentially containing ``{{ var }}`` placeholders.
+    variables:
+        Variable name -> value mapping.
+
+    Returns
+    -------
+    str:
+        Rendered string with all placeholders replaced.
+
+    Raises
+    ------
+    TemplateError:
+        If a placeholder references an undefined variable.
+    """
+
+    def _replace(match: re.Match) -> str:
+        name = match.group(1)
+        if name not in variables:
+            raise TemplateError(
+                f"Undefined template variable: '{name}'. "
+                f"Available variables: {sorted(variables.keys())}"
+            )
+        return str(variables[name])
+
+    return _VAR_PATTERN.sub(_replace, template)
+
+
+def apply_templates(
+    prompts: list[str], variables: dict[str, Any]
+) -> list[str]:
+    """Apply template variable substitution to a list of prompt strings.
+
+    Parameters
+    ----------
+    prompts:
+        List of prompt strings, potentially containing ``{{ var }}`` placeholders.
+    variables:
+        Variable name -> value mapping.
+
+    Returns
+    -------
+    list[str]:
+        Prompts with all placeholders replaced.
+    """
+    return [render_template(p, variables) for p in prompts]

--- a/tests/test_template_vars.py
+++ b/tests/test_template_vars.py
@@ -1,0 +1,178 @@
+"""Tests for M37: Request Body Templating."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from xpyd_bench.templating import (
+    TemplateError,
+    apply_templates,
+    load_template_vars,
+    render_template,
+)
+
+# ---------------------------------------------------------------------------
+# render_template
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTemplate:
+    def test_simple_substitution(self):
+        result = render_template("Hello {{ name }}!", {"name": "World"})
+        assert result == "Hello World!"
+
+    def test_multiple_variables(self):
+        result = render_template(
+            "{{ greeting }} {{ name }}, welcome to {{ place }}.",
+            {"greeting": "Hi", "name": "Alice", "place": "Wonderland"},
+        )
+        assert result == "Hi Alice, welcome to Wonderland."
+
+    def test_no_placeholders(self):
+        result = render_template("No placeholders here.", {"foo": "bar"})
+        assert result == "No placeholders here."
+
+    def test_missing_variable_raises(self):
+        with pytest.raises(TemplateError, match="Undefined template variable: 'missing'"):
+            render_template("Hello {{ missing }}!", {})
+
+    def test_whitespace_variants(self):
+        for template in ["{{name}}", "{{ name }}", "{{  name  }}"]:
+            assert render_template(template, {"name": "OK"}) == "OK"
+
+    def test_numeric_value(self):
+        result = render_template("Count: {{ n }}", {"n": 42})
+        assert result == "Count: 42"
+
+    def test_repeated_variable(self):
+        result = render_template("{{ x }} and {{ x }}", {"x": "same"})
+        assert result == "same and same"
+
+    def test_empty_string_value(self):
+        result = render_template("prefix{{ v }}suffix", {"v": ""})
+        assert result == "prefixsuffix"
+
+
+# ---------------------------------------------------------------------------
+# apply_templates
+# ---------------------------------------------------------------------------
+
+
+class TestApplyTemplates:
+    def test_list_of_prompts(self):
+        prompts = ["Hello {{ name }}", "Goodbye {{ name }}"]
+        result = apply_templates(prompts, {"name": "Bob"})
+        assert result == ["Hello Bob", "Goodbye Bob"]
+
+    def test_empty_list(self):
+        assert apply_templates([], {"a": "b"}) == []
+
+    def test_error_propagates(self):
+        with pytest.raises(TemplateError):
+            apply_templates(["{{ undefined }}"], {})
+
+
+# ---------------------------------------------------------------------------
+# load_template_vars
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTemplateVars:
+    def test_load_json(self, tmp_path: Path):
+        p = tmp_path / "vars.json"
+        p.write_text(json.dumps({"env": "prod", "gpu": "A100"}))
+        result = load_template_vars(str(p))
+        assert result == {"env": "prod", "gpu": "A100"}
+
+    def test_load_yaml(self, tmp_path: Path):
+        p = tmp_path / "vars.yaml"
+        p.write_text(yaml.dump({"model": "llama", "size": "70b"}))
+        result = load_template_vars(str(p))
+        assert result == {"model": "llama", "size": "70b"}
+
+    def test_load_yml(self, tmp_path: Path):
+        p = tmp_path / "vars.yml"
+        p.write_text(yaml.dump({"key": "value"}))
+        result = load_template_vars(str(p))
+        assert result == {"key": "value"}
+
+    def test_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_template_vars("/nonexistent/path.json")
+
+    def test_unsupported_extension(self, tmp_path: Path):
+        p = tmp_path / "vars.txt"
+        p.write_text("hello")
+        with pytest.raises(ValueError, match="Unsupported template vars format"):
+            load_template_vars(str(p))
+
+    def test_non_dict_raises(self, tmp_path: Path):
+        p = tmp_path / "vars.json"
+        p.write_text(json.dumps([1, 2, 3]))
+        with pytest.raises(ValueError, match="must contain a dict"):
+            load_template_vars(str(p))
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+class TestCLIIntegration:
+    """Test --template-vars flag is recognized by the argument parser."""
+
+    def _make_parser(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        return parser
+
+    def test_parser_accepts_flag(self):
+        parser = self._make_parser()
+        args = parser.parse_args(["--template-vars", "/some/path.json"])
+        assert args.template_vars == "/some/path.json"
+
+    def test_parser_default_none(self):
+        parser = self._make_parser()
+        args = parser.parse_args([])
+        assert args.template_vars is None
+
+
+# ---------------------------------------------------------------------------
+# YAML config integration
+# ---------------------------------------------------------------------------
+
+
+class TestYAMLConfig:
+    def test_template_vars_is_known_key(self):
+        from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+        assert "template_vars" in _KNOWN_KEYS
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: load + render
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def test_load_and_apply(self, tmp_path: Path):
+        p = tmp_path / "vars.json"
+        p.write_text(json.dumps({"user": "Alice", "topic": "AI"}))
+        variables = load_template_vars(str(p))
+        prompts = [
+            "{{ user }} asks about {{ topic }}",
+            "Tell {{ user }} more about {{ topic }}",
+        ]
+        result = apply_templates(prompts, variables)
+        assert result == [
+            "Alice asks about AI",
+            "Tell Alice more about AI",
+        ]


### PR DESCRIPTION
## Summary
Implements M37: Request Body Templating from the roadmap.

### Changes
- **`src/xpyd_bench/templating.py`**: New module with Jinja2-style `{{ variable }}` template rendering
- **`src/xpyd_bench/cli.py`**: Added `--template-vars <path>` CLI flag
- **`src/xpyd_bench/bench/runner.py`**: Template substitution applied to prompts before dispatch
- **`src/xpyd_bench/config_cmd.py`**: Added `template_vars` to known YAML keys
- **`tests/test_template_vars.py`**: 21 tests covering all functionality

### Features
- `--template-vars vars.json` loads variables from JSON or YAML
- Prompts containing `{{ name }}` are substituted before sending
- Clear error on undefined variables
- YAML config support (`template_vars: path/to/vars.json`)
- Works with all input formats (string, JSONL, CSV, synthetic)

Closes #130