### PR TITLE
feat(presets): add benchmark presets library (M38)

### DIFF
--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -572,6 +572,22 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Path to JSON/YAML file with template variables for prompt substitution.",
     )
 
+    # Presets (M38)
+    parser.add_argument(
+        "--preset",
+        type=str,
+        default=None,
+        help="Use a benchmark preset (e.g. throughput-max, latency-optimal, soak-test, "
+        "cold-start). CLI flags override preset values. Use 'xpyd-bench presets list' "
+        "to see available presets.",
+    )
+    parser.add_argument(
+        "--presets-dir",
+        type=str,
+        default=None,
+        help="Path to user presets directory (default: ~/.xpyd-bench/presets/).",
+    )
+
 
 def _resolve_base_url(args: argparse.Namespace) -> str:
     """Resolve the base URL from --base-url or --host/--port."""
@@ -847,10 +863,38 @@ def bench_main(argv: list[str] | None = None) -> None:
             if current is None or current == parser.get_default(key):
                 setattr(args, key, value)
 
+    # Apply preset defaults (CLI flags take precedence) (M38)
+    preset_name = getattr(args, "preset", None)
+    if preset_name:
+        from pathlib import Path as _Path
+
+        from xpyd_bench.presets import get_preset
+
+        pdir = _Path(args.presets_dir) if getattr(args, "presets_dir", None) else None
+        preset = get_preset(preset_name, pdir)
+        for key, value in preset.to_overrides().items():
+            current = getattr(args, key, None)
+            if current is None or current == parser.get_default(key):
+                setattr(args, key, value)
+
     # Merge YAML config if provided
     if args.config:
         explicit = _get_explicit_keys(parser, args)
         args = _load_yaml_config(args.config, args, explicit_keys=explicit)
+
+    # Apply preset from YAML config if not already set via CLI (M38)
+    yaml_preset = getattr(args, "preset", None)
+    if yaml_preset and not preset_name:
+        from pathlib import Path as _Path
+
+        from xpyd_bench.presets import get_preset
+
+        pdir = _Path(args.presets_dir) if getattr(args, "presets_dir", None) else None
+        preset = get_preset(yaml_preset, pdir)
+        for key, value in preset.to_overrides().items():
+            current = getattr(args, key, None)
+            if current is None or current == parser.get_default(key):
+                setattr(args, key, value)
 
     base_url = _resolve_base_url(args)
 

--- a/src/xpyd_bench/main.py
+++ b/src/xpyd_bench/main.py
@@ -74,6 +74,7 @@ _SUBCOMMANDS = {
     "aggregate",
     "history",
     "distributed",
+    "presets",
 }
 
 
@@ -131,6 +132,8 @@ def main() -> None:
         from xpyd_bench.distributed.cli import distributed_main
 
         distributed_main(rest)
+    elif subcmd == "presets":
+        _presets_subcommand(rest)
 
 
 def _config_subcommand(argv: list[str]) -> None:
@@ -153,6 +156,31 @@ def _config_subcommand(argv: list[str]) -> None:
     else:
         print(
             f"Unknown config subcommand '{sub}'. Use 'dump' or 'validate'.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _presets_subcommand(argv: list[str]) -> None:
+    """Handle 'xpyd-bench presets <list|show>' subcommand."""
+    if not argv:
+        print("Usage: xpyd-bench presets <list|show> [options]", file=sys.stderr)
+        sys.exit(1)
+
+    sub = argv[0]
+    rest = argv[1:]
+
+    if sub == "list":
+        from xpyd_bench.presets import presets_list_main
+
+        presets_list_main(rest)
+    elif sub == "show":
+        from xpyd_bench.presets import presets_show_main
+
+        presets_show_main(rest)
+    else:
+        print(
+            f"Unknown presets subcommand '{sub}'. Use 'list' or 'show'.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/src/xpyd_bench/presets.py
+++ b/src/xpyd_bench/presets.py
@@ -1,0 +1,214 @@
+"""Benchmark presets library (M38).
+
+Provides built-in and user-defined benchmark configuration presets.
+User presets are loaded from ``~/.xpyd-bench/presets/*.yaml``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class PresetConfig:
+    """A named benchmark preset with full configuration."""
+
+    name: str
+    description: str
+    source: str = "built-in"  # "built-in" or "user"
+
+    # All fields map directly to CLI arguments / YAML config keys
+    config: dict[str, Any] = field(default_factory=dict)
+
+    def to_overrides(self) -> dict[str, Any]:
+        """Return config dict for applying to args."""
+        return dict(self.config)
+
+
+# ---------------------------------------------------------------------------
+# Built-in presets
+# ---------------------------------------------------------------------------
+
+THROUGHPUT_MAX = PresetConfig(
+    name="throughput-max",
+    description="Maximize request throughput — high concurrency, short prompts, no rate limit",
+    config={
+        "num_prompts": 10000,
+        "input_len": 64,
+        "output_len": 32,
+        "request_rate": float("inf"),
+        "max_concurrency": 512,
+        "temperature": 0.0,
+        "stream": False,
+    },
+)
+
+LATENCY_OPTIMAL = PresetConfig(
+    name="latency-optimal",
+    description="Measure optimal latency — low concurrency, sequential requests",
+    config={
+        "num_prompts": 100,
+        "input_len": 128,
+        "output_len": 64,
+        "request_rate": 1.0,
+        "max_concurrency": 1,
+        "temperature": 0.0,
+        "stream": True,
+    },
+)
+
+SOAK_TEST = PresetConfig(
+    name="soak-test",
+    description="Long-running stability test — moderate rate over many requests",
+    config={
+        "num_prompts": 50000,
+        "input_len": 256,
+        "output_len": 128,
+        "request_rate": 10.0,
+        "max_concurrency": 32,
+        "dataset_name": "synthetic",
+        "synthetic_input_len_dist": "uniform",
+        "synthetic_output_len_dist": "uniform",
+    },
+)
+
+COLD_START = PresetConfig(
+    name="cold-start",
+    description="Cold-start measurement — few requests with warmup to isolate first-request",
+    config={
+        "num_prompts": 10,
+        "input_len": 128,
+        "output_len": 64,
+        "request_rate": 1.0,
+        "max_concurrency": 1,
+        "warmup": 0,
+        "stream": True,
+        "temperature": 0.0,
+    },
+)
+
+_BUILTIN_PRESETS: dict[str, PresetConfig] = {
+    p.name: p for p in [THROUGHPUT_MAX, LATENCY_OPTIMAL, SOAK_TEST, COLD_START]
+}
+
+
+def _user_presets_dir() -> Path:
+    """Return the user presets directory."""
+    return Path.home() / ".xpyd-bench" / "presets"
+
+
+def load_user_presets(presets_dir: Path | None = None) -> dict[str, PresetConfig]:
+    """Load user-defined presets from YAML files in the presets directory."""
+    d = presets_dir or _user_presets_dir()
+    presets: dict[str, PresetConfig] = {}
+    if not d.is_dir():
+        return presets
+    for f in sorted(d.glob("*.yaml")):
+        try:
+            with open(f) as fh:
+                data = yaml.safe_load(fh) or {}
+            name = data.get("name", f.stem)
+            desc = data.get("description", "")
+            # Everything except name/description is config
+            config = {k: v for k, v in data.items() if k not in ("name", "description")}
+            presets[name] = PresetConfig(
+                name=name,
+                description=desc,
+                source="user",
+                config=config,
+            )
+        except Exception:
+            # Skip malformed files silently
+            continue
+    return presets
+
+
+def list_presets(presets_dir: Path | None = None) -> list[PresetConfig]:
+    """Return all available presets (built-in + user). User presets override built-in."""
+    merged = dict(_BUILTIN_PRESETS)
+    merged.update(load_user_presets(presets_dir))
+    return list(merged.values())
+
+
+def get_preset(name: str, presets_dir: Path | None = None) -> PresetConfig:
+    """Look up a preset by name. Raises ``KeyError`` if not found."""
+    # Check user presets first (override built-in)
+    user = load_user_presets(presets_dir)
+    if name in user:
+        return user[name]
+    if name in _BUILTIN_PRESETS:
+        return _BUILTIN_PRESETS[name]
+    available = sorted(set(list(_BUILTIN_PRESETS.keys()) + list(user.keys())))
+    raise KeyError(f"Unknown preset '{name}'. Available: {', '.join(available)}")
+
+
+def format_preset_detail(preset: PresetConfig) -> str:
+    """Format a preset for display."""
+    lines = [
+        f"Preset: {preset.name}",
+        f"Source: {preset.source}",
+        f"Description: {preset.description}",
+        "",
+        "Configuration:",
+    ]
+    for k, v in sorted(preset.config.items()):
+        lines.append(f"  {k}: {v}")
+    return "\n".join(lines)
+
+
+def format_preset_list(presets: list[PresetConfig]) -> str:
+    """Format a list of presets for display."""
+    lines = ["Available presets:", ""]
+    for p in presets:
+        tag = f" [{p.source}]" if p.source != "built-in" else ""
+        lines.append(f"  {p.name:20s} {p.description}{tag}")
+    return "\n".join(lines)
+
+
+def presets_list_main(argv: list[str] | None = None) -> None:
+    """Entry point for ``xpyd-bench presets list``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench presets list",
+        description="List available benchmark presets",
+    )
+    parser.add_argument(
+        "--presets-dir",
+        type=str,
+        default=None,
+        help="Path to user presets directory (default: ~/.xpyd-bench/presets/)",
+    )
+    args = parser.parse_args(argv)
+    pdir = Path(args.presets_dir) if args.presets_dir else None
+    presets = list_presets(pdir)
+    print(format_preset_list(presets))
+
+
+def presets_show_main(argv: list[str] | None = None) -> None:
+    """Entry point for ``xpyd-bench presets show <name>``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench presets show",
+        description="Show details of a benchmark preset",
+    )
+    parser.add_argument("name", help="Preset name")
+    parser.add_argument(
+        "--presets-dir",
+        type=str,
+        default=None,
+        help="Path to user presets directory (default: ~/.xpyd-bench/presets/)",
+    )
+    args = parser.parse_args(argv)
+    pdir = Path(args.presets_dir) if args.presets_dir else None
+    try:
+        preset = get_preset(args.name, pdir)
+    except KeyError as e:
+        print(str(e))
+        raise SystemExit(1) from e
+    print(format_preset_detail(preset))

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,240 @@
+"""Tests for M38: Benchmark Presets Library."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from xpyd_bench.presets import (
+    COLD_START,
+    LATENCY_OPTIMAL,
+    SOAK_TEST,
+    THROUGHPUT_MAX,
+    PresetConfig,
+    format_preset_detail,
+    format_preset_list,
+    get_preset,
+    list_presets,
+    load_user_presets,
+)
+
+
+class TestBuiltinPresets:
+    """Verify built-in presets exist and have expected structure."""
+
+    def test_all_builtins_present(self):
+        presets = list_presets(presets_dir=Path("/nonexistent"))
+        names = {p.name for p in presets}
+        assert names == {"throughput-max", "latency-optimal", "soak-test", "cold-start"}
+
+    @pytest.mark.parametrize(
+        "preset",
+        [THROUGHPUT_MAX, LATENCY_OPTIMAL, SOAK_TEST, COLD_START],
+        ids=lambda p: p.name,
+    )
+    def test_preset_has_config(self, preset: PresetConfig):
+        assert preset.name
+        assert preset.description
+        assert preset.source == "built-in"
+        assert isinstance(preset.config, dict)
+        assert len(preset.config) > 0
+
+    def test_to_overrides(self):
+        overrides = THROUGHPUT_MAX.to_overrides()
+        assert overrides["num_prompts"] == 10000
+        assert overrides["max_concurrency"] == 512
+
+    def test_get_preset_builtin(self):
+        p = get_preset("latency-optimal")
+        assert p.name == "latency-optimal"
+        assert p.config["max_concurrency"] == 1
+
+    def test_get_preset_not_found(self):
+        with pytest.raises(KeyError, match="Unknown preset"):
+            get_preset("nonexistent-preset")
+
+
+class TestUserPresets:
+    """Test user-defined preset loading from YAML files."""
+
+    def test_load_from_dir(self, tmp_path: Path):
+        preset_file = tmp_path / "my-preset.yaml"
+        preset_file.write_text(
+            yaml.dump(
+                {
+                    "name": "my-preset",
+                    "description": "Custom test preset",
+                    "num_prompts": 42,
+                    "input_len": 512,
+                    "request_rate": 5.0,
+                }
+            )
+        )
+        presets = load_user_presets(tmp_path)
+        assert "my-preset" in presets
+        p = presets["my-preset"]
+        assert p.source == "user"
+        assert p.config["num_prompts"] == 42
+        assert p.config["input_len"] == 512
+
+    def test_user_overrides_builtin(self, tmp_path: Path):
+        preset_file = tmp_path / "throughput-max.yaml"
+        preset_file.write_text(
+            yaml.dump(
+                {
+                    "name": "throughput-max",
+                    "description": "My custom throughput preset",
+                    "num_prompts": 999,
+                }
+            )
+        )
+        p = get_preset("throughput-max", presets_dir=tmp_path)
+        assert p.source == "user"
+        assert p.config["num_prompts"] == 999
+
+    def test_name_defaults_to_stem(self, tmp_path: Path):
+        preset_file = tmp_path / "auto-name.yaml"
+        preset_file.write_text(yaml.dump({"description": "No name field", "num_prompts": 7}))
+        presets = load_user_presets(tmp_path)
+        assert "auto-name" in presets
+
+    def test_empty_dir(self, tmp_path: Path):
+        presets = load_user_presets(tmp_path)
+        assert presets == {}
+
+    def test_nonexistent_dir(self):
+        presets = load_user_presets(Path("/nonexistent/path"))
+        assert presets == {}
+
+    def test_malformed_yaml_skipped(self, tmp_path: Path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text(": : : invalid yaml {{{{")
+        good = tmp_path / "good.yaml"
+        good.write_text(yaml.dump({"name": "good", "description": "ok", "num_prompts": 1}))
+        presets = load_user_presets(tmp_path)
+        assert "good" in presets
+        assert "bad" not in presets
+
+    def test_list_presets_includes_user(self, tmp_path: Path):
+        preset_file = tmp_path / "extra.yaml"
+        preset_file.write_text(
+            yaml.dump({"name": "extra", "description": "Extra preset", "num_prompts": 5})
+        )
+        all_presets = list_presets(presets_dir=tmp_path)
+        names = {p.name for p in all_presets}
+        assert "extra" in names
+        assert "throughput-max" in names
+
+
+class TestFormatting:
+    """Test display formatting functions."""
+
+    def test_format_preset_detail(self):
+        output = format_preset_detail(LATENCY_OPTIMAL)
+        assert "latency-optimal" in output
+        assert "built-in" in output
+        assert "max_concurrency: 1" in output
+
+    def test_format_preset_list(self):
+        presets = list_presets(presets_dir=Path("/nonexistent"))
+        output = format_preset_list(presets)
+        assert "throughput-max" in output
+        assert "soak-test" in output
+        assert "Available presets" in output
+
+    def test_format_user_preset_shows_tag(self):
+        user_preset = PresetConfig(
+            name="custom", description="Test", source="user", config={"num_prompts": 1}
+        )
+        output = format_preset_list([user_preset])
+        assert "[user]" in output
+
+
+class TestCLIIntegration:
+    """Test CLI --preset flag and presets subcommand."""
+
+    def test_presets_list_subcommand(self, capsys):
+        from xpyd_bench.main import main
+
+        with patch("sys.argv", ["xpyd-bench", "presets", "list"]):
+            main()
+        out = capsys.readouterr().out
+        assert "throughput-max" in out
+        assert "latency-optimal" in out
+
+    def test_presets_show_subcommand(self, capsys):
+        from xpyd_bench.main import main
+
+        with patch("sys.argv", ["xpyd-bench", "presets", "show", "cold-start"]):
+            main()
+        out = capsys.readouterr().out
+        assert "cold-start" in out
+        assert "num_prompts" in out
+
+    def test_presets_show_not_found(self):
+        from xpyd_bench.main import main
+
+        with patch("sys.argv", ["xpyd-bench", "presets", "show", "nope"]):
+            with pytest.raises(SystemExit, match="1"):
+                main()
+
+    def test_preset_flag_in_dry_run(self, capsys):
+        from xpyd_bench.main import main
+
+        with patch(
+            "sys.argv",
+            ["xpyd-bench", "run", "--preset", "throughput-max", "--dry-run", "--model", "test"],
+        ):
+            main()
+        out = capsys.readouterr().out
+        assert "10000" in out
+
+    def test_cli_flag_overrides_preset(self, capsys):
+        from xpyd_bench.main import main
+
+        with patch(
+            "sys.argv",
+            [
+                "xpyd-bench", "run", "--preset", "throughput-max",
+                "--num-prompts", "42", "--dry-run", "--model", "test",
+            ],
+        ):
+            main()
+        out = capsys.readouterr().out
+        assert "42" in out
+
+    def test_presets_list_with_user_dir(self, tmp_path: Path, capsys):
+        from xpyd_bench.main import main
+
+        preset_file = tmp_path / "my-test.yaml"
+        preset_file.write_text(
+            yaml.dump({"name": "my-test", "description": "CLI test preset", "num_prompts": 77})
+        )
+        with patch(
+            "sys.argv",
+            ["xpyd-bench", "presets", "list", "--presets-dir", str(tmp_path)],
+        ):
+            main()
+        out = capsys.readouterr().out
+        assert "my-test" in out
+        assert "[user]" in out
+
+
+class TestYAMLConfigPreset:
+    """Test preset application via YAML config."""
+
+    def test_preset_from_yaml(self, tmp_path: Path, capsys):
+        from xpyd_bench.main import main
+
+        config = tmp_path / "config.yaml"
+        config.write_text(yaml.dump({"preset": "latency-optimal"}))
+        with patch(
+            "sys.argv",
+            ["xpyd-bench", "run", "--config", str(config), "--dry-run", "--model", "test"],
+        ):
+            main()
+        out = capsys.readouterr().out
+        assert "1.0" in out


### PR DESCRIPTION
## Summary
Add a benchmark presets library for common benchmark configurations.

## Changes
- New `src/xpyd_bench/presets.py` module with 4 built-in presets:
  - **throughput-max**: High concurrency, short prompts, no rate limit
  - **latency-optimal**: Low concurrency, sequential requests
  - **soak-test**: Long-running stability test with moderate rate
  - **cold-start**: Few requests to measure first-request latency
- User-defined presets from `~/.xpyd-bench/presets/*.yaml` (user presets override built-in)
- `xpyd-bench presets list` and `xpyd-bench presets show <name>` subcommands
- `--preset <name>` CLI flag in run subcommand (CLI flags take precedence)
- YAML config support (`preset: <name>`)
- 25 tests covering all functionality

## Testing
```
ruff check src tests && isort --check src tests  # ✅
pytest tests/test_presets.py -v                   # 25 passed ✅
```

Closes #132