### PR TITLE
feat: M39 — Cost Estimation

### DIFF
--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -588,6 +588,15 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Path to user presets directory (default: ~/.xpyd-bench/presets/).",
     )
 
+    # Cost estimation (M39)
+    parser.add_argument(
+        "--cost-model",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Path to YAML cost model file mapping model names to $/1K tokens.",
+    )
+
 
 def _resolve_base_url(args: argparse.Namespace) -> str:
     """Resolve the base URL from --base-url or --host/--port."""
@@ -716,6 +725,25 @@ def _dry_run(args: argparse.Namespace, base_url: str) -> None:
 
     print()
     print("Dry run complete. Configuration is valid.")
+
+    # Cost estimation in dry-run (M39)
+    cost_model_path = getattr(args, "cost_model", None)
+    if cost_model_path:
+        from xpyd_bench.cost import (
+            estimate_cost_from_counts,
+            format_cost_summary,
+            load_cost_model,
+        )
+
+        cmodel = load_cost_model(cost_model_path)
+        est_input = args.num_prompts * args.input_len
+        est_output = args.num_prompts * args.output_len
+        cost_est = estimate_cost_from_counts(
+            est_input, est_output, cmodel, model_name=args.model or ""
+        )
+        print()
+        print(format_cost_summary(cost_est))
+        print("  (estimated from num_prompts × input_len / output_len)")
 
     # Environment info
     from xpyd_bench.bench.env import collect_env_info
@@ -1012,6 +1040,22 @@ def bench_main(argv: list[str] | None = None) -> None:
     # Save results if requested
     if args.save_result:
         _save_result(args, result)
+
+    # Cost estimation (M39)
+    cost_model_path = getattr(args, "cost_model", None)
+    if cost_model_path:
+        from xpyd_bench.cost import (
+            cost_to_dict,
+            estimate_cost,
+            format_cost_summary,
+            load_cost_model,
+        )
+
+        cmodel = load_cost_model(cost_model_path)
+        cost_est = estimate_cost(bench_result, cmodel)
+        print()
+        print(format_cost_summary(cost_est))
+        result["cost"] = cost_to_dict(cost_est)
 
     # SLA validation (M20)
     sla_path = getattr(args, "sla", None)

--- a/src/xpyd_bench/cost.py
+++ b/src/xpyd_bench/cost.py
@@ -1,0 +1,201 @@
+"""M39: Cost Estimation — compute estimated costs based on token usage and pricing models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from xpyd_bench.bench.models import BenchmarkResult
+
+
+@dataclass
+class CostModel:
+    """Pricing model mapping model names to per-1K-token costs."""
+
+    # model_name -> {"input": float, "output": float} ($/1K tokens)
+    models: dict[str, dict[str, float]] = field(default_factory=dict)
+    # Optional default pricing when model name not found
+    default: dict[str, float] | None = None
+
+
+@dataclass
+class CostEstimate:
+    """Computed cost estimate for a benchmark run."""
+
+    model: str
+    input_tokens: int
+    output_tokens: int
+    input_cost_per_1k: float
+    output_cost_per_1k: float
+    input_cost: float
+    output_cost: float
+    total_cost: float
+    currency: str = "USD"
+    matched: bool = True  # False if fell back to default pricing
+
+
+def load_cost_model(path: str | Path) -> CostModel:
+    """Load a cost model from a YAML file.
+
+    Expected format::
+
+        currency: USD  # optional, default USD
+        default:       # optional fallback
+          input: 0.01
+          output: 0.03
+        models:
+          gpt-4:
+            input: 0.03
+            output: 0.06
+          gpt-3.5-turbo:
+            input: 0.0005
+            output: 0.0015
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Cost model file not found: {p}")
+
+    data = yaml.safe_load(p.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"Cost model must be a YAML mapping, got {type(data).__name__}")
+
+    models_raw = data.get("models", {})
+    if not isinstance(models_raw, dict):
+        raise ValueError("Cost model 'models' must be a mapping")
+
+    models: dict[str, dict[str, float]] = {}
+    for name, pricing in models_raw.items():
+        if not isinstance(pricing, dict):
+            raise ValueError(f"Pricing for model '{name}' must be a mapping with input/output")
+        models[str(name)] = {
+            "input": float(pricing.get("input", 0)),
+            "output": float(pricing.get("output", 0)),
+        }
+
+    default_raw = data.get("default")
+    default = None
+    if isinstance(default_raw, dict):
+        default = {
+            "input": float(default_raw.get("input", 0)),
+            "output": float(default_raw.get("output", 0)),
+        }
+
+    cm = CostModel(models=models, default=default)
+    # Attach currency for downstream use
+    cm._currency = data.get("currency", "USD")  # type: ignore[attr-defined]
+    return cm
+
+
+def estimate_cost(
+    result: BenchmarkResult,
+    cost_model: CostModel,
+    model_override: str | None = None,
+) -> CostEstimate:
+    """Compute cost estimate from benchmark result and cost model."""
+    model_name = model_override or result.model or ""
+    pricing = cost_model.models.get(model_name)
+    matched = True
+    if pricing is None:
+        pricing = cost_model.default
+        matched = False
+    if pricing is None:
+        raise ValueError(
+            f"No pricing found for model '{model_name}' and no default pricing configured"
+        )
+
+    input_per_1k = pricing["input"]
+    output_per_1k = pricing["output"]
+    input_cost = result.total_input_tokens / 1000.0 * input_per_1k
+    output_cost = result.total_output_tokens / 1000.0 * output_per_1k
+
+    currency = getattr(cost_model, "_currency", "USD")
+
+    return CostEstimate(
+        model=model_name,
+        input_tokens=result.total_input_tokens,
+        output_tokens=result.total_output_tokens,
+        input_cost_per_1k=input_per_1k,
+        output_cost_per_1k=output_per_1k,
+        input_cost=input_cost,
+        output_cost=output_cost,
+        total_cost=input_cost + output_cost,
+        currency=currency,
+        matched=matched,
+    )
+
+
+def estimate_cost_from_counts(
+    input_tokens: int,
+    output_tokens: int,
+    cost_model: CostModel,
+    model_name: str = "",
+) -> CostEstimate:
+    """Compute cost estimate from raw token counts (for dry-run)."""
+    pricing = cost_model.models.get(model_name)
+    matched = True
+    if pricing is None:
+        pricing = cost_model.default
+        matched = False
+    if pricing is None:
+        raise ValueError(
+            f"No pricing found for model '{model_name}' and no default pricing configured"
+        )
+
+    input_per_1k = pricing["input"]
+    output_per_1k = pricing["output"]
+    input_cost = input_tokens / 1000.0 * input_per_1k
+    output_cost = output_tokens / 1000.0 * output_per_1k
+
+    currency = getattr(cost_model, "_currency", "USD")
+
+    return CostEstimate(
+        model=model_name,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        input_cost_per_1k=input_per_1k,
+        output_cost_per_1k=output_per_1k,
+        input_cost=input_cost,
+        output_cost=output_cost,
+        total_cost=input_cost + output_cost,
+        currency=currency,
+        matched=matched,
+    )
+
+
+def format_cost_summary(est: CostEstimate) -> str:
+    """Format a human-readable cost summary."""
+    lines = [
+        "Cost Estimation:",
+        f"  Model:              {est.model or '(unknown)'}",
+    ]
+    if not est.matched:
+        lines.append("  Pricing:            (default — model not found in cost model)")
+    lines.extend([
+        f"  Input tokens:       {est.input_tokens:,}",
+        f"  Output tokens:      {est.output_tokens:,}",
+        f"  Input rate:         ${est.input_cost_per_1k:.4f} / 1K tokens",
+        f"  Output rate:        ${est.output_cost_per_1k:.4f} / 1K tokens",
+        f"  Input cost:         ${est.input_cost:.6f}",
+        f"  Output cost:        ${est.output_cost:.6f}",
+        f"  Total cost:         ${est.total_cost:.6f} {est.currency}",
+    ])
+    return "\n".join(lines)
+
+
+def cost_to_dict(est: CostEstimate) -> dict[str, Any]:
+    """Serialize cost estimate to a JSON-compatible dict."""
+    return {
+        "model": est.model,
+        "input_tokens": est.input_tokens,
+        "output_tokens": est.output_tokens,
+        "input_cost_per_1k": est.input_cost_per_1k,
+        "output_cost_per_1k": est.output_cost_per_1k,
+        "input_cost": est.input_cost,
+        "output_cost": est.output_cost,
+        "total_cost": est.total_cost,
+        "currency": est.currency,
+        "model_matched": est.matched,
+    }

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,0 +1,226 @@
+"""Tests for M39: Cost Estimation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from xpyd_bench.bench.models import BenchmarkResult
+from xpyd_bench.cost import (
+    cost_to_dict,
+    estimate_cost,
+    estimate_cost_from_counts,
+    format_cost_summary,
+    load_cost_model,
+)
+
+
+@pytest.fixture()
+def cost_model_file(tmp_path: Path) -> Path:
+    """Create a sample cost model YAML file."""
+    data = {
+        "currency": "USD",
+        "default": {"input": 0.01, "output": 0.03},
+        "models": {
+            "gpt-4": {"input": 0.03, "output": 0.06},
+            "gpt-3.5-turbo": {"input": 0.0005, "output": 0.0015},
+        },
+    }
+    p = tmp_path / "cost_model.yaml"
+    p.write_text(yaml.dump(data))
+    return p
+
+
+@pytest.fixture()
+def cost_model_no_default(tmp_path: Path) -> Path:
+    """Cost model without default pricing."""
+    data = {
+        "models": {
+            "gpt-4": {"input": 0.03, "output": 0.06},
+        },
+    }
+    p = tmp_path / "cost_no_default.yaml"
+    p.write_text(yaml.dump(data))
+    return p
+
+
+class TestLoadCostModel:
+    def test_load_valid(self, cost_model_file: Path) -> None:
+        cm = load_cost_model(cost_model_file)
+        assert "gpt-4" in cm.models
+        assert cm.models["gpt-4"]["input"] == 0.03
+        assert cm.models["gpt-4"]["output"] == 0.06
+        assert cm.default is not None
+        assert cm.default["input"] == 0.01
+
+    def test_load_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_cost_model(tmp_path / "nope.yaml")
+
+    def test_load_invalid_format(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.yaml"
+        p.write_text("- a list")
+        with pytest.raises(ValueError, match="YAML mapping"):
+            load_cost_model(p)
+
+    def test_load_no_default(self, cost_model_no_default: Path) -> None:
+        cm = load_cost_model(cost_model_no_default)
+        assert cm.default is None
+
+
+class TestEstimateCost:
+    def test_known_model(self, cost_model_file: Path) -> None:
+        cm = load_cost_model(cost_model_file)
+        result = BenchmarkResult(
+            model="gpt-4",
+            total_input_tokens=10000,
+            total_output_tokens=5000,
+        )
+        est = estimate_cost(result, cm)
+        assert est.matched is True
+        assert est.model == "gpt-4"
+        assert est.input_cost == pytest.approx(10000 / 1000 * 0.03)
+        assert est.output_cost == pytest.approx(5000 / 1000 * 0.06)
+        assert est.total_cost == pytest.approx(est.input_cost + est.output_cost)
+        assert est.currency == "USD"
+
+    def test_fallback_to_default(self, cost_model_file: Path) -> None:
+        cm = load_cost_model(cost_model_file)
+        result = BenchmarkResult(
+            model="unknown-model",
+            total_input_tokens=2000,
+            total_output_tokens=1000,
+        )
+        est = estimate_cost(result, cm)
+        assert est.matched is False
+        assert est.input_cost == pytest.approx(2000 / 1000 * 0.01)
+        assert est.output_cost == pytest.approx(1000 / 1000 * 0.03)
+
+    def test_no_pricing_raises(self, cost_model_no_default: Path) -> None:
+        cm = load_cost_model(cost_model_no_default)
+        result = BenchmarkResult(
+            model="unknown-model",
+            total_input_tokens=1000,
+            total_output_tokens=500,
+        )
+        with pytest.raises(ValueError, match="No pricing found"):
+            estimate_cost(result, cm)
+
+    def test_model_override(self, cost_model_file: Path) -> None:
+        cm = load_cost_model(cost_model_file)
+        result = BenchmarkResult(
+            model="some-other",
+            total_input_tokens=1000,
+            total_output_tokens=500,
+        )
+        est = estimate_cost(result, cm, model_override="gpt-3.5-turbo")
+        assert est.model == "gpt-3.5-turbo"
+        assert est.matched is True
+        assert est.input_cost_per_1k == 0.0005
+
+
+class TestEstimateCostFromCounts:
+    def test_dry_run_estimation(self, cost_model_file: Path) -> None:
+        cm = load_cost_model(cost_model_file)
+        est = estimate_cost_from_counts(256000, 128000, cm, model_name="gpt-4")
+        assert est.input_tokens == 256000
+        assert est.output_tokens == 128000
+        assert est.total_cost == pytest.approx(
+            256000 / 1000 * 0.03 + 128000 / 1000 * 0.06
+        )
+
+    def test_empty_model_fallback(self, cost_model_file: Path) -> None:
+        cm = load_cost_model(cost_model_file)
+        est = estimate_cost_from_counts(1000, 500, cm, model_name="")
+        assert est.matched is False
+
+
+class TestFormatCostSummary:
+    def test_format_output(self, cost_model_file: Path) -> None:
+        cm = load_cost_model(cost_model_file)
+        result = BenchmarkResult(
+            model="gpt-4",
+            total_input_tokens=10000,
+            total_output_tokens=5000,
+        )
+        est = estimate_cost(result, cm)
+        text = format_cost_summary(est)
+        assert "Cost Estimation:" in text
+        assert "gpt-4" in text
+        assert "Total cost:" in text
+        assert "USD" in text
+
+    def test_format_unmatched(self, cost_model_file: Path) -> None:
+        cm = load_cost_model(cost_model_file)
+        result = BenchmarkResult(
+            model="unknown",
+            total_input_tokens=1000,
+            total_output_tokens=500,
+        )
+        est = estimate_cost(result, cm)
+        text = format_cost_summary(est)
+        assert "default" in text
+
+
+class TestCostToDict:
+    def test_serialization(self, cost_model_file: Path) -> None:
+        cm = load_cost_model(cost_model_file)
+        result = BenchmarkResult(
+            model="gpt-4",
+            total_input_tokens=10000,
+            total_output_tokens=5000,
+        )
+        est = estimate_cost(result, cm)
+        d = cost_to_dict(est)
+        assert d["model"] == "gpt-4"
+        assert d["total_cost"] == est.total_cost
+        assert d["model_matched"] is True
+        # Ensure JSON-serializable
+        json.dumps(d)
+
+
+class TestCLIIntegration:
+    """Test cost estimation via CLI flags."""
+
+    def test_dry_run_with_cost_model(self, cost_model_file: Path, capsys) -> None:
+        """--dry-run with --cost-model should print cost estimate."""
+        from xpyd_bench.cli import bench_main
+
+        bench_main([
+            "--base-url", "http://localhost:9999",
+            "--model", "gpt-4",
+            "--num-prompts", "10",
+            "--input-len", "100",
+            "--output-len", "50",
+            "--dry-run",
+            "--cost-model", str(cost_model_file),
+        ])
+        captured = capsys.readouterr()
+        assert "Cost Estimation:" in captured.out
+        assert "gpt-4" in captured.out
+        assert "Total cost:" in captured.out
+
+    def test_cost_model_cli_flag_parsed(self) -> None:
+        """Verify --cost-model is a recognized CLI flag."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--cost-model", "/tmp/test.yaml"])
+        assert args.cost_model == "/tmp/test.yaml"
+
+    def test_cost_model_default_none(self) -> None:
+        """--cost-model defaults to None."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        assert args.cost_model is None


### PR DESCRIPTION
## Summary
Add cost estimation support to xpyd-bench via `--cost-model <path>` CLI flag.

### Changes
- **`src/xpyd_bench/cost.py`**: Core module — load YAML cost models, compute cost from token counts, format summary, serialize to dict
- **`src/xpyd_bench/cli.py`**: Add `--cost-model` CLI arg, hook cost estimation into post-benchmark reporting and `--dry-run` mode
- **`tests/test_cost.py`**: 16 tests covering loading, calculation, fallback, formatting, serialization, CLI integration

### Cost Model Format
```yaml
currency: USD
default:
  input: 0.01
  output: 0.03
models:
  gpt-4:
    input: 0.03
    output: 0.06
```

### Usage
```bash
# After benchmark
xpyd-bench run --base-url http://localhost:8000 --cost-model pricing.yaml

# Dry-run estimation
xpyd-bench run --dry-run --cost-model pricing.yaml --model gpt-4
```

Closes #134