### PR TITLE
feat: add request payload compression (M40)

### DIFF
--- a/src/xpyd_bench/bench/debug_log.py
+++ b/src/xpyd_bench/bench/debug_log.py
@@ -26,6 +26,8 @@ class DebugLogEntry:
     success: bool
     error: str | None = None
     retries: int = 0
+    payload_bytes: int | None = None
+    compressed_bytes: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
@@ -40,6 +42,10 @@ class DebugLogEntry:
             d["error"] = self.error
         if self.retries > 0:
             d["retries"] = self.retries
+        if self.payload_bytes is not None:
+            d["payload_bytes"] = self.payload_bytes
+        if self.compressed_bytes is not None:
+            d["compressed_bytes"] = self.compressed_bytes
         return d
 
 
@@ -73,6 +79,8 @@ class DebugLogger:
         url: str,
         payload: dict[str, Any],
         result: RequestResult,
+        payload_bytes: int | None = None,
+        compressed_bytes: int | None = None,
     ) -> None:
         """Write one log entry for a completed request."""
         # Truncate payload
@@ -91,6 +99,8 @@ class DebugLogger:
             success=result.success,
             error=result.error,
             retries=result.retries,
+            payload_bytes=payload_bytes,
+            compressed_bytes=compressed_bytes,
         )
         self._file.write(json.dumps(entry.to_dict(), ensure_ascii=False) + "\n")
         self._file.flush()

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import gzip
 import json
 import random
 import signal
@@ -142,6 +143,24 @@ def _is_retryable(exc: Exception) -> bool:
     return False
 
 
+def _compressed_request_kwargs(
+    payload: dict[str, Any],
+    compress: bool,
+) -> dict[str, Any]:
+    """Build request kwargs, optionally gzip-compressing the body."""
+    if not compress:
+        return {"json": payload}
+    raw = json.dumps(payload).encode()
+    compressed = gzip.compress(raw)
+    return {
+        "content": compressed,
+        "headers": {
+            "Content-Encoding": "gzip",
+            "Content-Type": "application/json",
+        },
+    }
+
+
 async def _send_request(
     client: httpx.AsyncClient,
     url: str,
@@ -150,6 +169,7 @@ async def _send_request(
     request_timeout: float = 300.0,
     retries: int = 0,
     retry_delay: float = 1.0,
+    compress: bool = False,
 ) -> RequestResult:
     """Send one request and collect metrics, with optional retry."""
     last_result = RequestResult()
@@ -164,10 +184,12 @@ async def _send_request(
         try:
             if is_streaming:
                 result = await _send_streaming(
-                    client, url, payload, start, request_timeout=request_timeout
+                    client, url, payload, start, request_timeout=request_timeout,
+                    compress=compress,
                 )
             else:
-                resp = await client.post(url, json=payload, timeout=request_timeout)
+                req_kw = _compressed_request_kwargs(payload, compress)
+                resp = await client.post(url, **req_kw, timeout=request_timeout)
                 resp.raise_for_status()
                 end = time.perf_counter()
                 result.latency_ms = (end - start) * 1000.0
@@ -207,6 +229,7 @@ async def _send_streaming(
     payload: dict[str, Any],
     start: float,
     request_timeout: float = 300.0,
+    compress: bool = False,
 ) -> RequestResult:
     """Send a streaming request, measure TTFT / ITL."""
     result = RequestResult()
@@ -218,7 +241,8 @@ async def _send_streaming(
     stream_usage: dict[str, Any] | None = None
 
     try:
-        async with client.stream("POST", url, json=payload, timeout=request_timeout) as resp:
+        req_kw = _compressed_request_kwargs(payload, compress)
+        async with client.stream("POST", url, **req_kw, timeout=request_timeout) as resp:
             resp.raise_for_status()
             async for line in resp.aiter_lines():
                 if not line.startswith("data: "):
@@ -591,6 +615,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     request_timeout = getattr(args, "timeout", 300.0) or 300.0
     req_retries = getattr(args, "retries", 0) or 0
     req_retry_delay = getattr(args, "retry_delay", 1.0) or 1.0
+    req_compress = getattr(args, "compress", False) or False
 
     def _mk_payload(prompt: str) -> dict[str, Any]:
         if use_plugin:
@@ -615,6 +640,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
             request_timeout=request_timeout,
             retries=req_retries,
             retry_delay=req_retry_delay,
+            compress=req_compress,
         )
 
     async def _task(client: httpx.AsyncClient, prompt: str) -> RequestResult:
@@ -705,7 +731,15 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         payload = _mk_payload(prompt)
         r = await _task(client, prompt)
         if debug_logger:
-            debug_logger.log(url, payload, r)
+            p_bytes: int | None = None
+            c_bytes: int | None = None
+            if req_compress:
+                import gzip as _gzip
+
+                raw = json.dumps(payload).encode()
+                p_bytes = len(raw)
+                c_bytes = len(_gzip.compress(raw))
+            debug_logger.log(url, payload, r, payload_bytes=p_bytes, compressed_bytes=c_bytes)
         if reporter:
             latency = r.latency * 1000 if r.latency is not None else None
             if isinstance(reporter, _LiveDashboardType):

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -335,6 +335,14 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Base delay between retries in seconds, with exponential backoff. Default: 1.0.",
     )
 
+    # Request compression (M40)
+    parser.add_argument(
+        "--compress",
+        action="store_true",
+        default=False,
+        help="Enable gzip compression of request bodies (Content-Encoding: gzip).",
+    )
+
     # Custom headers
     parser.add_argument(
         "--header",

--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import gzip
 import json
 import random
 import time
@@ -13,6 +14,15 @@ from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse, StreamingResponse
 from starlette.routing import Route
+
+
+async def _parse_json_body(request: Request) -> dict:
+    """Parse JSON body, handling gzip Content-Encoding transparently."""
+    raw = await request.body()
+    encoding = request.headers.get("content-encoding", "").lower()
+    if encoding == "gzip":
+        raw = gzip.decompress(raw)
+    return json.loads(raw)
 
 
 @dataclass
@@ -232,7 +242,7 @@ def _check_stop(text: str, stop: list[str] | str | None) -> tuple[bool, str]:
 
 async def _handle_completions(request: Request) -> JSONResponse | StreamingResponse:
     try:
-        body = await request.json()
+        body = await _parse_json_body(request)
     except Exception:
         return JSONResponse(
             {
@@ -480,7 +490,7 @@ async def _stream_completions(
 
 async def _handle_chat_completions(request: Request) -> JSONResponse | StreamingResponse:
     try:
-        body = await request.json()
+        body = await _parse_json_body(request)
     except Exception:
         return JSONResponse(
             {
@@ -750,7 +760,7 @@ async def _handle_models(request: Request) -> JSONResponse:
 async def _handle_embeddings(request: Request) -> JSONResponse:
     """Handle POST /v1/embeddings — return random embedding vectors."""
     cfg = _config
-    body = await request.json()
+    body = await _parse_json_body(request)
 
     model = body.get("model", cfg.model_name)
     raw_input = body.get("input", "")

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -1,0 +1,247 @@
+"""Tests for M40: Request Payload Compression."""
+
+from __future__ import annotations
+
+import gzip
+import json
+
+import pytest
+
+from xpyd_bench.bench.debug_log import DebugLogEntry, DebugLogger
+from xpyd_bench.bench.runner import _compressed_request_kwargs
+
+# ---------------------------------------------------------------------------
+# Unit tests for _compressed_request_kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestCompressedRequestKwargs:
+    def test_no_compress_returns_json(self):
+        payload = {"model": "test", "prompt": "hello"}
+        kw = _compressed_request_kwargs(payload, compress=False)
+        assert kw == {"json": payload}
+
+    def test_compress_returns_content_and_headers(self):
+        payload = {"model": "test", "prompt": "hello"}
+        kw = _compressed_request_kwargs(payload, compress=True)
+        assert "content" in kw
+        assert "headers" in kw
+        assert kw["headers"]["Content-Encoding"] == "gzip"
+        assert kw["headers"]["Content-Type"] == "application/json"
+        # Verify content is valid gzip of the JSON payload
+        decompressed = gzip.decompress(kw["content"])
+        assert json.loads(decompressed) == payload
+
+    def test_compress_large_payload(self):
+        payload = {"model": "test", "prompt": "a" * 10000}
+        kw = _compressed_request_kwargs(payload, compress=True)
+        raw = json.dumps(payload).encode()
+        compressed = kw["content"]
+        # Compression should reduce size for repetitive data
+        assert len(compressed) < len(raw)
+        assert json.loads(gzip.decompress(compressed)) == payload
+
+
+# ---------------------------------------------------------------------------
+# CLI flag parsing
+# ---------------------------------------------------------------------------
+
+
+class TestCompressCLI:
+    def test_compress_flag_default(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        assert args.compress is False
+
+    def test_compress_flag_enabled(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--compress"])
+        assert args.compress is True
+
+    def test_compress_yaml_config(self, tmp_path):
+        import argparse
+
+        import yaml
+
+        from xpyd_bench.cli import (
+            _add_vllm_compat_args,
+            _get_explicit_keys,
+            _load_yaml_config,
+        )
+
+        yaml_file = tmp_path / "config.yaml"
+        yaml_file.write_text(yaml.dump({"compress": True}))
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        explicit = _get_explicit_keys(parser, args)
+        args = _load_yaml_config(str(yaml_file), args, explicit_keys=explicit)
+        assert args.compress is True
+
+
+# ---------------------------------------------------------------------------
+# Debug log payload size tracking
+# ---------------------------------------------------------------------------
+
+
+class TestDebugLogCompression:
+    def test_entry_without_compression(self):
+        entry = DebugLogEntry(
+            timestamp="2025-01-01T00:00:00",
+            url="http://localhost/v1/completions",
+            payload='{"prompt":"hi"}',
+            status="ok",
+            latency_ms=10.0,
+            success=True,
+        )
+        d = entry.to_dict()
+        assert "payload_bytes" not in d
+        assert "compressed_bytes" not in d
+
+    def test_entry_with_compression(self):
+        entry = DebugLogEntry(
+            timestamp="2025-01-01T00:00:00",
+            url="http://localhost/v1/completions",
+            payload='{"prompt":"hi"}',
+            status="ok",
+            latency_ms=10.0,
+            success=True,
+            payload_bytes=500,
+            compressed_bytes=120,
+        )
+        d = entry.to_dict()
+        assert d["payload_bytes"] == 500
+        assert d["compressed_bytes"] == 120
+
+    def test_debug_logger_with_sizes(self, tmp_path):
+        from xpyd_bench.bench.models import RequestResult
+
+        log_path = tmp_path / "debug.jsonl"
+        logger = DebugLogger(log_path)
+        result = RequestResult()
+        result.latency_ms = 5.0
+        result.success = True
+        logger.log(
+            url="http://localhost/v1/completions",
+            payload={"prompt": "test"},
+            result=result,
+            payload_bytes=200,
+            compressed_bytes=80,
+        )
+        logger.close()
+
+        lines = log_path.read_text().strip().split("\n")
+        entry = json.loads(lines[0])
+        assert entry["payload_bytes"] == 200
+        assert entry["compressed_bytes"] == 80
+
+
+# ---------------------------------------------------------------------------
+# Dummy server gzip decompression
+# ---------------------------------------------------------------------------
+
+
+class TestDummyServerGzip:
+    @pytest.fixture
+    def dummy_app(self):
+        from xpyd_bench.dummy.server import create_app
+
+        return create_app()
+
+    def test_dummy_server_accepts_gzip(self, dummy_app):
+        """Test that the dummy server correctly decompresses gzip request bodies."""
+        from starlette.testclient import TestClient
+
+        client = TestClient(dummy_app)
+        payload = {
+            "model": "test-model",
+            "prompt": "Hello, world!",
+            "max_tokens": 10,
+        }
+        raw = json.dumps(payload).encode()
+        compressed = gzip.compress(raw)
+
+        resp = client.post(
+            "/v1/completions",
+            content=compressed,
+            headers={
+                "Content-Encoding": "gzip",
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "choices" in body
+
+    def test_dummy_server_uncompressed_still_works(self, dummy_app):
+        """Ensure plain JSON still works (no regression)."""
+        from starlette.testclient import TestClient
+
+        client = TestClient(dummy_app)
+        payload = {
+            "model": "test-model",
+            "prompt": "Hello!",
+            "max_tokens": 5,
+        }
+        resp = client.post("/v1/completions", json=payload)
+        assert resp.status_code == 200
+        assert "choices" in resp.json()
+
+    def test_dummy_chat_accepts_gzip(self, dummy_app):
+        """Test chat endpoint with gzip."""
+        from starlette.testclient import TestClient
+
+        client = TestClient(dummy_app)
+        payload = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 5,
+        }
+        raw = json.dumps(payload).encode()
+        compressed = gzip.compress(raw)
+
+        resp = client.post(
+            "/v1/chat/completions",
+            content=compressed,
+            headers={
+                "Content-Encoding": "gzip",
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 200
+        assert "choices" in resp.json()
+
+    def test_dummy_embeddings_accepts_gzip(self, dummy_app):
+        """Test embeddings endpoint with gzip."""
+        from starlette.testclient import TestClient
+
+        client = TestClient(dummy_app)
+        payload = {
+            "model": "test-model",
+            "input": "Hello embeddings",
+        }
+        raw = json.dumps(payload).encode()
+        compressed = gzip.compress(raw)
+
+        resp = client.post(
+            "/v1/embeddings",
+            content=compressed,
+            headers={
+                "Content-Encoding": "gzip",
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "data" in body


### PR DESCRIPTION
## Summary
Add `--compress` CLI flag to enable gzip compression of HTTP request bodies, reducing network overhead for large-prompt benchmarks.

## Changes
- **CLI**: `--compress` flag (default: off)
- **Runner**: `_compressed_request_kwargs()` helper; both streaming and non-streaming paths support compression
- **Dummy server**: `_parse_json_body()` transparently handles `Content-Encoding: gzip`
- **Debug log**: Tracks `payload_bytes` and `compressed_bytes` per request when compression + debug-log are both enabled
- **YAML config**: `compress: true`
- **Tests**: 13 tests covering all aspects

Closes #136