### PR TITLE
feat: M41 — Batch Inference API Benchmarking

### DIFF
--- a/src/xpyd_bench/batch.py
+++ b/src/xpyd_bench/batch.py
@@ -1,0 +1,295 @@
+"""Batch Inference API benchmarking (M41).
+
+Supports the OpenAI Batch API workflow:
+  1. Submit batch job (POST /v1/batches)
+  2. Poll for completion (GET /v1/batches/{id})
+  3. Retrieve results from completed batch
+
+Metrics tracked: queue_time_ms, processing_time_ms per batch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from argparse import Namespace
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from xpyd_bench.bench.env import collect_env_info
+from xpyd_bench.bench.models import BenchmarkResult
+
+
+@dataclass
+class BatchRequestResult:
+    """Metrics for a single batch job."""
+
+    batch_id: str = ""
+    status: str = ""
+    total_requests: int = 0
+    completed_requests: int = 0
+    failed_requests: int = 0
+    queue_time_ms: float = 0.0  # Time from submission to processing start
+    processing_time_ms: float = 0.0  # Time from processing start to completion
+    total_time_ms: float = 0.0  # End-to-end time
+    error: str | None = None
+    success: bool = True
+    results: list[dict[str, Any]] = field(default_factory=list)
+
+
+async def submit_batch(
+    client: httpx.AsyncClient,
+    url: str,
+    requests: list[dict[str, Any]],
+    *,
+    model: str = "",
+    endpoint: str = "/v1/completions",
+    metadata: dict[str, str] | None = None,
+    request_timeout: float = 300.0,
+) -> dict[str, Any]:
+    """Submit a batch job. Returns the batch object."""
+    # Build JSONL input_data inline (simplified from file-based approach)
+    input_requests = []
+    for i, req in enumerate(requests):
+        input_requests.append({
+            "custom_id": f"request-{i}",
+            "method": "POST",
+            "url": endpoint,
+            "body": req,
+        })
+
+    payload: dict[str, Any] = {
+        "input": input_requests,
+        "endpoint": endpoint,
+        "completion_window": "24h",
+    }
+    if model:
+        payload["model"] = model
+    if metadata:
+        payload["metadata"] = metadata
+
+    resp = await client.post(url, json=payload, timeout=request_timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def poll_batch(
+    client: httpx.AsyncClient,
+    url: str,
+    batch_id: str,
+    *,
+    poll_interval: float = 2.0,
+    timeout: float = 600.0,
+    request_timeout: float = 300.0,
+) -> dict[str, Any]:
+    """Poll batch status until terminal state. Returns final batch object."""
+    terminal_states = {"completed", "failed", "cancelled", "expired"}
+    start = time.monotonic()
+
+    while True:
+        resp = await client.get(
+            f"{url}/{batch_id}", timeout=request_timeout,
+        )
+        resp.raise_for_status()
+        batch = resp.json()
+
+        if batch.get("status") in terminal_states:
+            return batch
+
+        elapsed = time.monotonic() - start
+        if elapsed >= timeout:
+            raise TimeoutError(
+                f"Batch {batch_id} did not complete within {timeout}s "
+                f"(current status: {batch.get('status')})"
+            )
+
+        await asyncio.sleep(poll_interval)
+
+
+def _compute_batch_metrics(
+    batch_obj: dict[str, Any],
+    submit_time: float,
+) -> BatchRequestResult:
+    """Extract metrics from a completed batch object."""
+    result = BatchRequestResult()
+    result.batch_id = batch_obj.get("id", "")
+    result.status = batch_obj.get("status", "unknown")
+
+    counts = batch_obj.get("request_counts", {})
+    result.total_requests = counts.get("total", 0)
+    result.completed_requests = counts.get("completed", 0)
+    result.failed_requests = counts.get("failed", 0)
+
+    created_at = batch_obj.get("created_at", 0)
+    in_progress_at = batch_obj.get("in_progress_at", 0)
+    completed_at = batch_obj.get("completed_at", 0)
+
+    if in_progress_at and created_at:
+        result.queue_time_ms = (in_progress_at - created_at) * 1000.0
+    if completed_at and in_progress_at:
+        result.processing_time_ms = (completed_at - in_progress_at) * 1000.0
+    if completed_at and created_at:
+        result.total_time_ms = (completed_at - created_at) * 1000.0
+
+    result.success = result.status == "completed"
+    if result.status == "failed":
+        errors = batch_obj.get("errors", {}).get("data", [])
+        if errors:
+            result.error = errors[0].get("message", "batch failed")
+        else:
+            result.error = "batch failed"
+
+    result.results = batch_obj.get("results", [])
+    return result
+
+
+async def run_batch_benchmark(
+    args: Namespace, base_url: str,
+) -> tuple[dict[str, Any], BenchmarkResult]:
+    """Execute a batch inference benchmark.
+
+    Submits prompts as a batch job, polls for completion, and collects metrics.
+    """
+    from xpyd_bench.bench.runner import _generate_random_prompts
+
+    # Generate prompts
+    num_prompts = args.num_prompts
+    input_len = args.input_len
+    output_len = args.output_len
+    model = args.model or ""
+    seed = args.seed
+
+    dataset_path = getattr(args, "dataset_path", None)
+    if dataset_path:
+        from xpyd_bench.datasets.loader import load_dataset
+
+        entries = load_dataset(
+            path=dataset_path,
+            num_prompts=num_prompts,
+            input_len=input_len,
+            output_len=output_len,
+            seed=seed,
+        )
+        prompts = [e.prompt for e in entries]
+        num_prompts = len(prompts)
+    else:
+        prompts = _generate_random_prompts(num_prompts, input_len, seed)
+
+    # Build per-request payloads
+    is_chat = "chat" in getattr(args, "batch_endpoint", "/v1/completions")
+    request_bodies = []
+    for prompt in prompts:
+        if is_chat:
+            body: dict[str, Any] = {
+                "model": model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": output_len,
+            }
+        else:
+            body = {
+                "model": model,
+                "prompt": prompt,
+                "max_tokens": output_len,
+            }
+        request_bodies.append(body)
+
+    # Headers
+    headers: dict[str, str] = {}
+    api_key = getattr(args, "api_key", None)
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    custom_headers = getattr(args, "custom_headers", None) or {}
+    headers.update(custom_headers)
+
+    poll_interval = getattr(args, "poll_interval", 2.0) or 2.0
+    batch_timeout = getattr(args, "batch_timeout", 600.0) or 600.0
+    request_timeout = getattr(args, "timeout", 300.0) or 300.0
+    batch_endpoint = getattr(args, "batch_endpoint", "/v1/completions")
+
+    batches_url = f"{base_url}/v1/batches"
+
+    result = BenchmarkResult(
+        backend="openai",
+        base_url=base_url,
+        endpoint="/v1/batch",
+        model=model,
+        num_prompts=num_prompts,
+        input_len=input_len,
+        output_len=output_len,
+        environment=collect_env_info(),
+    )
+
+    overall_start = time.perf_counter()
+
+    async with httpx.AsyncClient(headers=headers) as client:
+        # Submit batch
+        submit_start = time.perf_counter()
+        batch_obj = await submit_batch(
+            client,
+            batches_url,
+            request_bodies,
+            model=model,
+            endpoint=batch_endpoint,
+            request_timeout=request_timeout,
+        )
+        batch_id = batch_obj["id"]
+
+        if not getattr(args, "disable_tqdm", False):
+            print(f"Batch submitted: {batch_id} ({num_prompts} requests)")
+
+        # Poll for completion
+        final_batch = await poll_batch(
+            client,
+            batches_url,
+            batch_id,
+            poll_interval=poll_interval,
+            timeout=batch_timeout,
+            request_timeout=request_timeout,
+        )
+
+    overall_end = time.perf_counter()
+    result.total_duration_s = overall_end - overall_start
+
+    # Compute batch-specific metrics
+    batch_metrics = _compute_batch_metrics(final_batch, submit_start)
+
+    # Convert to RequestResults for compatibility
+    result.completed = batch_metrics.completed_requests
+    result.failed = batch_metrics.failed_requests
+
+    # Build output dict
+    result_dict: dict[str, Any] = {
+        "backend": result.backend,
+        "base_url": result.base_url,
+        "endpoint": result.endpoint,
+        "model": result.model,
+        "num_prompts": result.num_prompts,
+        "total_duration_s": result.total_duration_s,
+        "completed": result.completed,
+        "failed": result.failed,
+        "batch_id": batch_metrics.batch_id,
+        "batch_status": batch_metrics.status,
+        "queue_time_ms": batch_metrics.queue_time_ms,
+        "processing_time_ms": batch_metrics.processing_time_ms,
+        "total_batch_time_ms": batch_metrics.total_time_ms,
+    }
+    if result.environment:
+        result_dict["environment"] = result.environment
+
+    if not getattr(args, "disable_tqdm", False):
+        print("=" * 60)
+        print("Batch Benchmark Results")
+        print("=" * 60)
+        print(f"  Batch ID:              {batch_metrics.batch_id}")
+        print(f"  Status:                {batch_metrics.status}")
+        print(f"  Completed:             {batch_metrics.completed_requests}")
+        print(f"  Failed:                {batch_metrics.failed_requests}")
+        print(f"  Queue time:            {batch_metrics.queue_time_ms:.2f} ms")
+        print(f"  Processing time:       {batch_metrics.processing_time_ms:.2f} ms")
+        print(f"  Total batch time:      {batch_metrics.total_time_ms:.2f} ms")
+        print(f"  Total duration:        {result.total_duration_s:.2f} s")
+        print("=" * 60)
+
+    return result_dict, result

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -1429,3 +1429,67 @@ def _save_result(args: argparse.Namespace, result: dict) -> None:
     with open(filepath, "w") as f:
         json.dump(result, f, indent=2, default=str)
     print(f"\nResults saved to {filepath}")
+
+
+def batch_main(argv: list[str] | None = None) -> None:
+    """CLI entry point for batch inference benchmarking (M41)."""
+    parser = argparse.ArgumentParser(
+        description="Batch inference API benchmarking",
+    )
+    parser.add_argument("--base-url", default="http://localhost:8000",
+                        help="Server base URL")
+    parser.add_argument("--model", default="", help="Model name")
+    parser.add_argument("--num-prompts", type=int, default=10,
+                        help="Number of prompts in the batch")
+    parser.add_argument("--input-len", type=int, default=256,
+                        help="Input length in tokens")
+    parser.add_argument("--output-len", type=int, default=128,
+                        help="Max output tokens")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument("--poll-interval", type=float, default=2.0,
+                        help="Batch status poll interval in seconds")
+    parser.add_argument("--batch-timeout", type=float, default=600.0,
+                        help="Maximum time to wait for batch completion")
+    parser.add_argument("--batch-endpoint", default="/v1/completions",
+                        help="Target endpoint for batch requests")
+    parser.add_argument("--api-key", default=None, help="API key")
+    parser.add_argument("--timeout", type=float, default=300.0,
+                        help="Per-request HTTP timeout")
+    parser.add_argument("--dataset-path", default=None,
+                        help="Path to dataset file")
+    parser.add_argument("--save-result", default=None,
+                        help="Save result JSON to this path")
+    parser.add_argument("--disable-tqdm", action="store_true",
+                        help="Disable progress output")
+    parser.add_argument("--config", default=None, help="YAML config file")
+
+    if argv is not None:
+        args = parser.parse_args(argv)
+    else:
+        args = parser.parse_args()
+
+    # Load YAML config overrides
+    if args.config:
+        from xpyd_bench.config_cmd import _load_yaml_config
+        yaml_cfg = _load_yaml_config(args.config)
+        for key, value in yaml_cfg.items():
+            if not hasattr(args, key) or getattr(args, key) is None:
+                setattr(args, key, value)
+
+    # Env var fallback for API key
+    if not args.api_key:
+        import os
+        args.api_key = os.environ.get("OPENAI_API_KEY")
+
+    from xpyd_bench.batch import run_batch_benchmark
+
+    result_dict, bench_result = asyncio.run(
+        run_batch_benchmark(args, args.base_url)
+    )
+
+    if args.save_result:
+        p = Path(args.save_result)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "w") as f:
+            json.dump(result_dict, f, indent=2, default=str)
+        print(f"\nResult saved to {p}")

--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -823,6 +823,150 @@ async def _handle_health(request: Request) -> JSONResponse:
 
 
 # ---------------------------------------------------------------------------
+# Batch API (M41)
+# ---------------------------------------------------------------------------
+
+# In-memory batch store for the dummy server
+_batches: dict[str, dict] = {}
+
+
+async def _handle_create_batch(request: Request) -> JSONResponse:
+    """Handle POST /v1/batches — create a batch job."""
+    body = await _parse_json_body(request)
+    cfg = _config
+
+    input_requests = body.get("input", [])
+    endpoint = body.get("endpoint", "/v1/completions")
+    model = body.get("model", cfg.model_name)
+    metadata = body.get("metadata", {})
+
+    batch_id = f"batch_{uuid.uuid4().hex[:16]}"
+    now = time.time()
+    queue_delay = cfg.prefill_ms / 1000.0  # Simulate queue time using prefill_ms
+
+    batch_obj: dict = {
+        "id": batch_id,
+        "object": "batch",
+        "endpoint": endpoint,
+        "model": model,
+        "status": "validating",
+        "created_at": now,
+        "in_progress_at": None,
+        "completed_at": None,
+        "request_counts": {
+            "total": len(input_requests),
+            "completed": 0,
+            "failed": 0,
+        },
+        "metadata": metadata,
+        "input": input_requests,
+        "results": [],
+        "errors": {"object": "list", "data": []},
+        "_queue_delay": queue_delay,
+        "_process_delay": cfg.decode_ms * len(input_requests) / 1000.0,
+    }
+    _batches[batch_id] = batch_obj
+
+    # Schedule async processing
+    asyncio.create_task(_process_batch(batch_id))
+
+    # Return initial state
+    return JSONResponse({
+        "id": batch_id,
+        "object": "batch",
+        "endpoint": endpoint,
+        "status": "validating",
+        "created_at": now,
+        "request_counts": batch_obj["request_counts"],
+        "metadata": metadata,
+    })
+
+
+async def _process_batch(batch_id: str) -> None:
+    """Simulate batch processing in the background."""
+    batch = _batches.get(batch_id)
+    if not batch:
+        return
+
+    cfg = _config
+    queue_delay = batch["_queue_delay"]
+    process_delay = batch["_process_delay"]
+
+    # Simulate queue time
+    await asyncio.sleep(queue_delay)
+    now = time.time()
+    batch["status"] = "in_progress"
+    batch["in_progress_at"] = now
+
+    # Simulate processing time
+    await asyncio.sleep(process_delay)
+
+    # Generate dummy results
+    results = []
+    input_requests = batch.get("input", [])
+    for req in input_requests:
+        custom_id = req.get("custom_id", "")
+        body = req.get("body", {})
+        max_tokens = body.get("max_tokens", cfg.max_tokens_default)
+        rng = random.Random(hash(custom_id) & 0xFFFFFFFF)
+        n_tokens = rng.randint(
+            max(1, int(max_tokens * cfg.eos_min_ratio)), max_tokens,
+        )
+        text = " ".join(
+            rng.choice(["the", "a", "an", "is", "was", "will", "be", "to"])
+            for _ in range(n_tokens)
+        )
+        results.append({
+            "custom_id": custom_id,
+            "response": {
+                "status_code": 200,
+                "body": {
+                    "choices": [{"text": text, "index": 0, "finish_reason": "stop"}],
+                    "usage": {
+                        "prompt_tokens": len(
+                            str(body.get("prompt", body.get("messages", ""))).split()
+                        ),
+                        "completion_tokens": n_tokens,
+                        "total_tokens": len(
+                            str(body.get("prompt", body.get("messages", ""))).split()
+                        ) + n_tokens,
+                    },
+                },
+            },
+        })
+
+    batch["results"] = results
+    batch["request_counts"]["completed"] = len(results)
+    batch["status"] = "completed"
+    batch["completed_at"] = time.time()
+
+
+async def _handle_retrieve_batch(request: Request) -> JSONResponse:
+    """Handle GET /v1/batches/{batch_id} — retrieve batch status."""
+    batch_id = request.path_params["batch_id"]
+    batch = _batches.get(batch_id)
+    if not batch:
+        return JSONResponse(
+            {"error": {"message": f"Batch {batch_id} not found", "type": "not_found"}},
+            status_code=404,
+        )
+
+    return JSONResponse({
+        "id": batch["id"],
+        "object": "batch",
+        "endpoint": batch["endpoint"],
+        "status": batch["status"],
+        "created_at": batch["created_at"],
+        "in_progress_at": batch.get("in_progress_at"),
+        "completed_at": batch.get("completed_at"),
+        "request_counts": batch["request_counts"],
+        "metadata": batch.get("metadata", {}),
+        "results": batch.get("results", []),
+        "errors": batch.get("errors", {"object": "list", "data": []}),
+    })
+
+
+# ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
 
@@ -850,10 +994,15 @@ def create_app(config: ServerConfig | None = None) -> Starlette:
                     )
             return await call_next(request)
 
+    # Clear batch store on app creation
+    _batches.clear()
+
     routes = [
         Route("/v1/completions", _handle_completions, methods=["POST"]),
         Route("/v1/chat/completions", _handle_chat_completions, methods=["POST"]),
         Route("/v1/embeddings", _handle_embeddings, methods=["POST"]),
+        Route("/v1/batches", _handle_create_batch, methods=["POST"]),
+        Route("/v1/batches/{batch_id}", _handle_retrieve_batch, methods=["GET"]),
         Route("/v1/models", _handle_models, methods=["GET"]),
         Route("/health", _handle_health, methods=["GET"]),
     ]

--- a/src/xpyd_bench/main.py
+++ b/src/xpyd_bench/main.py
@@ -75,6 +75,7 @@ _SUBCOMMANDS = {
     "history",
     "distributed",
     "presets",
+    "batch",
 }
 
 
@@ -134,6 +135,10 @@ def main() -> None:
         distributed_main(rest)
     elif subcmd == "presets":
         _presets_subcommand(rest)
+    elif subcmd == "batch":
+        from xpyd_bench.cli import batch_main
+
+        batch_main(rest)
 
 
 def _config_subcommand(argv: list[str]) -> None:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,263 @@
+"""Tests for M41: Batch Inference API Benchmarking."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from argparse import Namespace
+
+import httpx
+import pytest
+
+from xpyd_bench.batch import (
+    BatchRequestResult,
+    _compute_batch_metrics,
+    poll_batch,
+    run_batch_benchmark,
+    submit_batch,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for BatchRequestResult
+# ---------------------------------------------------------------------------
+
+
+class TestBatchRequestResult:
+    def test_defaults(self):
+        r = BatchRequestResult()
+        assert r.batch_id == ""
+        assert r.queue_time_ms == 0.0
+        assert r.processing_time_ms == 0.0
+        assert r.success is True
+        assert r.results == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _compute_batch_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestComputeBatchMetrics:
+    def test_completed_batch(self):
+        batch_obj = {
+            "id": "batch_123",
+            "status": "completed",
+            "created_at": 1000.0,
+            "in_progress_at": 1002.0,
+            "completed_at": 1010.0,
+            "request_counts": {"total": 5, "completed": 5, "failed": 0},
+            "results": [{"custom_id": "r-0"}],
+        }
+        m = _compute_batch_metrics(batch_obj, 999.0)
+        assert m.batch_id == "batch_123"
+        assert m.status == "completed"
+        assert m.success is True
+        assert m.queue_time_ms == pytest.approx(2000.0)
+        assert m.processing_time_ms == pytest.approx(8000.0)
+        assert m.total_time_ms == pytest.approx(10000.0)
+        assert m.total_requests == 5
+        assert m.completed_requests == 5
+        assert m.failed_requests == 0
+
+    def test_failed_batch(self):
+        batch_obj = {
+            "id": "batch_fail",
+            "status": "failed",
+            "created_at": 100.0,
+            "in_progress_at": 101.0,
+            "completed_at": None,
+            "request_counts": {"total": 3, "completed": 0, "failed": 3},
+            "errors": {"object": "list", "data": [{"message": "server error"}]},
+        }
+        m = _compute_batch_metrics(batch_obj, 99.0)
+        assert m.success is False
+        assert m.error == "server error"
+        assert m.failed_requests == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration test with dummy server
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def dummy_batch_server():
+    """Start the dummy server with batch endpoints in a background thread."""
+    import threading
+
+    import uvicorn
+
+    from xpyd_bench.dummy.server import ServerConfig, create_app
+
+    cfg = ServerConfig(prefill_ms=10, decode_ms=2, model_name="test-model")
+    app = create_app(cfg)
+
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error"))
+
+    # Find a free port
+    import socket
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    server_cfg = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(server_cfg)
+
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    # Wait for server to be ready
+    import time as _time
+    base_url = f"http://127.0.0.1:{port}"
+    for _ in range(50):
+        try:
+            httpx.get(f"{base_url}/health", timeout=1.0)
+            break
+        except Exception:
+            _time.sleep(0.1)
+    else:
+        raise RuntimeError("Dummy server failed to start")
+
+    yield base_url
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+class TestDummyServerBatch:
+    def test_create_and_retrieve_batch(self, dummy_batch_server):
+        base_url = dummy_batch_server
+
+        async def _run():
+            async with httpx.AsyncClient() as client:
+                # Submit batch
+                batch = await submit_batch(
+                    client,
+                    f"{base_url}/v1/batches",
+                    [
+                        {"model": "test-model", "prompt": "hello", "max_tokens": 10},
+                        {"model": "test-model", "prompt": "world", "max_tokens": 10},
+                    ],
+                    model="test-model",
+                )
+                assert "id" in batch
+                assert batch["status"] == "validating"
+
+                # Poll until complete
+                final = await poll_batch(
+                    client,
+                    f"{base_url}/v1/batches",
+                    batch["id"],
+                    poll_interval=0.1,
+                    timeout=30.0,
+                )
+                assert final["status"] == "completed"
+                assert final["request_counts"]["completed"] == 2
+                assert len(final["results"]) == 2
+                assert final["in_progress_at"] is not None
+                assert final["completed_at"] is not None
+
+        asyncio.run(_run())
+
+    def test_batch_metrics(self, dummy_batch_server):
+        base_url = dummy_batch_server
+
+        async def _run():
+            async with httpx.AsyncClient() as client:
+                batch = await submit_batch(
+                    client,
+                    f"{base_url}/v1/batches",
+                    [{"model": "m", "prompt": "p", "max_tokens": 5}],
+                )
+                final = await poll_batch(
+                    client,
+                    f"{base_url}/v1/batches",
+                    batch["id"],
+                    poll_interval=0.1,
+                    timeout=30.0,
+                )
+                metrics = _compute_batch_metrics(final, time.time())
+                assert metrics.success is True
+                assert metrics.queue_time_ms > 0
+                assert metrics.processing_time_ms > 0
+
+        asyncio.run(_run())
+
+    def test_batch_not_found(self, dummy_batch_server):
+        base_url = dummy_batch_server
+
+        async def _run():
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(f"{base_url}/v1/batches/nonexistent")
+                assert resp.status_code == 404
+
+        asyncio.run(_run())
+
+
+class TestRunBatchBenchmark:
+    def test_full_batch_benchmark(self, dummy_batch_server):
+        base_url = dummy_batch_server
+        args = Namespace(
+            num_prompts=3,
+            input_len=32,
+            output_len=16,
+            model="test-model",
+            seed=42,
+            poll_interval=0.1,
+            batch_timeout=30.0,
+            batch_endpoint="/v1/completions",
+            api_key=None,
+            timeout=300.0,
+            dataset_path=None,
+            disable_tqdm=True,
+            custom_headers=None,
+        )
+
+        result_dict, bench_result = asyncio.run(
+            run_batch_benchmark(args, base_url)
+        )
+
+        assert result_dict["endpoint"] == "/v1/batch"
+        assert result_dict["completed"] == 3
+        assert result_dict["failed"] == 0
+        assert result_dict["batch_status"] == "completed"
+        assert result_dict["queue_time_ms"] > 0
+        assert result_dict["processing_time_ms"] > 0
+        assert "batch_id" in result_dict
+        assert bench_result.total_duration_s > 0
+
+
+class TestPollTimeout:
+    def test_poll_timeout_raises(self):
+        """Poll should raise TimeoutError if batch never completes."""
+
+        async def _run():
+            transport = httpx.MockTransport(
+                lambda req: httpx.Response(
+                    200,
+                    json={
+                        "id": "batch_slow",
+                        "status": "in_progress",
+                        "request_counts": {"total": 1, "completed": 0, "failed": 0},
+                    },
+                )
+            )
+            async with httpx.AsyncClient(transport=transport) as client:
+                with pytest.raises(TimeoutError, match="did not complete"):
+                    await poll_batch(
+                        client,
+                        "http://fake/v1/batches",
+                        "batch_slow",
+                        poll_interval=0.05,
+                        timeout=0.2,
+                    )
+
+        asyncio.run(_run())
+
+
+class TestBatchCLI:
+    def test_batch_subcommand_routing(self):
+        """Verify 'batch' is in the subcommands set."""
+        from xpyd_bench.main import _SUBCOMMANDS
+        assert "batch" in _SUBCOMMANDS


### PR DESCRIPTION
## Summary
Implement M41: Batch Inference API Benchmarking.

### Changes
- **`src/xpyd_bench/batch.py`**: New module with batch workflow (submit → poll → retrieve), `BatchRequestResult` dataclass, and `run_batch_benchmark()`
- **`src/xpyd_bench/dummy/server.py`**: Added `/v1/batches` (POST create, GET retrieve) endpoints with background processing simulation
- **`src/xpyd_bench/main.py`**: Added `batch` to subcommand routing
- **`src/xpyd_bench/cli.py`**: Added `batch_main()` with CLI args (`--poll-interval`, `--batch-timeout`, `--batch-endpoint`)
- **`tests/test_batch.py`**: 9 tests covering unit, integration, and CLI

### Metrics
- `queue_time_ms`: Time from submission to processing start
- `processing_time_ms`: Time from processing start to completion

### All 797 tests pass.

Closes #138