### PR TITLE
feat: add request latency anomaly detection (M43)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -331,3 +331,12 @@
 - Correlation between client-side and server-side logs
 - YAML config support (`request_id_prefix`)
 - Tests covering ID generation, header injection, echo, and export
+
+## M43: Request Latency Anomaly Detection ✅
+- `detect_anomalies()` function in `src/xpyd_bench/bench/anomaly.py` using IQR method
+- `--anomaly-threshold <float>` CLI flag (default 1.5, 0 disables)
+- BenchmarkResult includes `anomalies` dict field
+- JSON output includes `anomalies` section when anomalies found
+- Terminal summary prints anomaly count and worst offenders
+- YAML config support (`anomaly_threshold`)
+- Tests covering detection logic, threshold customization, no-anomaly case, disabled mode

--- a/src/xpyd_bench/bench/anomaly.py
+++ b/src/xpyd_bench/bench/anomaly.py
@@ -1,0 +1,94 @@
+"""Request latency anomaly detection using IQR method."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class AnomalyInfo:
+    """Information about a single anomalous request."""
+
+    index: int
+    latency_ms: float
+    deviation_factor: float  # how many IQRs above Q3
+
+
+@dataclass
+class AnomalyResult:
+    """Anomaly detection result for a benchmark run."""
+
+    anomalies: list[AnomalyInfo]
+    q1: float
+    q3: float
+    iqr: float
+    threshold: float  # Q3 + multiplier * IQR
+    multiplier: float
+
+    @property
+    def count(self) -> int:
+        return len(self.anomalies)
+
+    def to_dict(self) -> dict:
+        """Serialize to JSON-friendly dict."""
+        return {
+            "count": self.count,
+            "q1_ms": round(self.q1, 2),
+            "q3_ms": round(self.q3, 2),
+            "iqr_ms": round(self.iqr, 2),
+            "threshold_ms": round(self.threshold, 2),
+            "multiplier": self.multiplier,
+            "flagged_requests": [
+                {
+                    "index": a.index,
+                    "latency_ms": round(a.latency_ms, 2),
+                    "deviation_factor": round(a.deviation_factor, 2),
+                }
+                for a in self.anomalies
+            ],
+        }
+
+
+def detect_anomalies(
+    latencies_ms: list[float],
+    multiplier: float = 1.5,
+) -> AnomalyResult | None:
+    """Detect latency anomalies using IQR method.
+
+    Args:
+        latencies_ms: Per-request latencies in milliseconds.
+        multiplier: IQR multiplier for threshold (0 disables detection).
+
+    Returns:
+        AnomalyResult if detection ran, None if disabled or insufficient data.
+    """
+    if multiplier <= 0 or len(latencies_ms) < 4:
+        return None
+
+    arr = np.array(latencies_ms)
+    q1 = float(np.percentile(arr, 25))
+    q3 = float(np.percentile(arr, 75))
+    iqr = q3 - q1
+    threshold = q3 + multiplier * iqr
+
+    anomalies: list[AnomalyInfo] = []
+    for i, lat in enumerate(latencies_ms):
+        if lat > threshold:
+            deviation = (lat - q3) / iqr if iqr > 0 else float("inf")
+            anomalies.append(
+                AnomalyInfo(index=i, latency_ms=lat, deviation_factor=deviation)
+            )
+
+    # Sort by latency descending (worst first)
+    anomalies.sort(key=lambda a: a.latency_ms, reverse=True)
+
+    return AnomalyResult(
+        anomalies=anomalies,
+        q1=q1,
+        q3=q3,
+        iqr=iqr,
+        threshold=threshold,
+        multiplier=multiplier,
+    )

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -87,3 +87,6 @@ class BenchmarkResult:
 
     # User-defined tags for annotation (M36)
     tags: dict[str, str] = field(default_factory=dict)
+
+    # Anomaly detection results (M43)
+    anomalies: dict | None = None

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -864,6 +864,16 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
 
     _compute_metrics(result)
 
+    # Anomaly detection (M43)
+    anomaly_threshold = getattr(args, "anomaly_threshold", 1.5)
+    if anomaly_threshold and anomaly_threshold > 0:
+        from xpyd_bench.bench.anomaly import detect_anomalies
+
+        latencies = [r.latency_ms for r in result.requests if r.success]
+        anomaly_result = detect_anomalies(latencies, multiplier=anomaly_threshold)
+        if anomaly_result is not None and anomaly_result.count > 0:
+            result.anomalies = anomaly_result.to_dict()
+
     if shutdown_requested:
         print(
             f"\n⚠️  Partial results: {result.completed} completed, "
@@ -904,6 +914,15 @@ def _print_summary(r: BenchmarkResult) -> None:
                 f"  {label:5s}  mean={mean:8.2f}  P50={p50:8.2f}  "
                 f"P90={p90:8.2f}  P95={p95:8.2f}  P99={p99:8.2f} ms"
             )
+    if r.anomalies:
+        count = r.anomalies["count"]
+        threshold = r.anomalies["threshold_ms"]
+        print(f"\n  ⚠️  Anomalies: {count} request(s) exceeded {threshold:.1f} ms threshold")
+        for a in r.anomalies["flagged_requests"][:5]:
+            idx = a["index"]
+            lat = a["latency_ms"]
+            dev = a["deviation_factor"]
+            print(f"      Request #{idx}: {lat:.2f} ms ({dev:.1f}x IQR above Q3)")
     print("=" * 60)
 
 
@@ -1029,4 +1048,6 @@ def _to_dict(r: BenchmarkResult) -> dict:
         d["partial"] = True
     if r.tags:
         d["tags"] = r.tags
+    if r.anomalies:
+        d["anomalies"] = r.anomalies
     return d

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -353,6 +353,15 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Enable gzip compression of request bodies (Content-Encoding: gzip).",
     )
 
+    # Anomaly detection (M43)
+    parser.add_argument(
+        "--anomaly-threshold",
+        type=float,
+        default=1.5,
+        dest="anomaly_threshold",
+        help="IQR multiplier for latency anomaly detection (default: 1.5, 0 disables).",
+    )
+
     # Custom headers
     parser.add_argument(
         "--header",

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -93,6 +93,7 @@ _KNOWN_KEYS: set[str] = {
     "warmup",
     "compress",
     "request_id_prefix",
+    "anomaly_threshold",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -1,0 +1,84 @@
+"""Tests for request latency anomaly detection (M43)."""
+
+from __future__ import annotations
+
+from xpyd_bench.bench.anomaly import detect_anomalies
+
+
+class TestDetectAnomalies:
+    """Tests for the detect_anomalies function."""
+
+    def test_detects_obvious_outliers(self) -> None:
+        """Requests with much higher latency are flagged."""
+        latencies = [10.0] * 50 + [100.0, 200.0]
+        result = detect_anomalies(latencies, multiplier=1.5)
+        assert result is not None
+        assert result.count == 2
+        assert result.anomalies[0].latency_ms == 200.0
+        assert result.anomalies[1].latency_ms == 100.0
+
+    def test_no_anomalies_in_uniform_data(self) -> None:
+        """Uniform latencies should have zero anomalies."""
+        latencies = [10.0] * 100
+        result = detect_anomalies(latencies, multiplier=1.5)
+        assert result is not None
+        assert result.count == 0
+
+    def test_disabled_when_multiplier_zero(self) -> None:
+        """Multiplier of 0 disables detection."""
+        latencies = [10.0] * 50 + [1000.0]
+        result = detect_anomalies(latencies, multiplier=0)
+        assert result is None
+
+    def test_disabled_when_multiplier_negative(self) -> None:
+        """Negative multiplier disables detection."""
+        result = detect_anomalies([10.0, 20.0, 30.0, 40.0, 500.0], multiplier=-1.0)
+        assert result is None
+
+    def test_insufficient_data(self) -> None:
+        """Less than 4 data points returns None."""
+        result = detect_anomalies([10.0, 20.0, 30.0], multiplier=1.5)
+        assert result is None
+
+    def test_custom_threshold(self) -> None:
+        """Higher multiplier means fewer anomalies."""
+        latencies = [10.0] * 50 + [50.0]
+        # With low multiplier, 50 may be an anomaly
+        r_low = detect_anomalies(latencies, multiplier=0.5)
+        # With high multiplier, 50 may not be
+        r_high = detect_anomalies(latencies, multiplier=10.0)
+        assert r_low is not None
+        assert r_high is not None
+        assert r_low.count >= r_high.count
+
+    def test_to_dict_structure(self) -> None:
+        """to_dict returns expected keys."""
+        latencies = [10.0] * 50 + [200.0]
+        result = detect_anomalies(latencies, multiplier=1.5)
+        assert result is not None
+        d = result.to_dict()
+        assert "count" in d
+        assert "q1_ms" in d
+        assert "q3_ms" in d
+        assert "iqr_ms" in d
+        assert "threshold_ms" in d
+        assert "multiplier" in d
+        assert "flagged_requests" in d
+        assert isinstance(d["flagged_requests"], list)
+
+    def test_anomalies_sorted_by_latency_desc(self) -> None:
+        """Anomalies should be sorted worst-first."""
+        latencies = [10.0] * 50 + [150.0, 300.0, 200.0]
+        result = detect_anomalies(latencies, multiplier=1.5)
+        assert result is not None
+        assert result.count >= 2
+        for i in range(len(result.anomalies) - 1):
+            assert result.anomalies[i].latency_ms >= result.anomalies[i + 1].latency_ms
+
+    def test_deviation_factor_positive(self) -> None:
+        """Deviation factors should be positive for anomalies."""
+        latencies = [10.0] * 50 + [500.0]
+        result = detect_anomalies(latencies, multiplier=1.5)
+        assert result is not None
+        for a in result.anomalies:
+            assert a.deviation_factor > 0


### PR DESCRIPTION
## Summary
Add IQR-based request latency anomaly detection to flag individual requests with abnormally high latency during benchmark runs.

## Changes
- New `src/xpyd_bench/bench/anomaly.py` with `detect_anomalies()` function
- `--anomaly-threshold <float>` CLI flag (default: 1.5, 0 disables)
- `BenchmarkResult.anomalies` field included in JSON output
- Terminal summary shows anomaly count and top 5 worst offenders
- YAML config support (`anomaly_threshold`)
- `anomaly_threshold` added to `_KNOWN_KEYS` for config validation
- 9 tests covering: detection, no-anomaly, disabled, insufficient data, custom threshold, sorting, serialization

## How it works
Uses the Interquartile Range (IQR) method:
- Compute Q1, Q3, IQR from per-request e2e latencies
- Threshold = Q3 + multiplier × IQR
- Requests above threshold are flagged as anomalies

Closes #142