### PR TITLE
feat: add multi-turn conversation benchmarking (M45)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -350,3 +350,16 @@
 - JSON output with per-level results via `--sweep-output <path>`
 - YAML config support (`sweep` section)
 - Tests covering sweep orchestration, result aggregation, optimal detection, CLI integration
+
+## M45: Multi-Turn Conversation Benchmarking ⬜
+- `xpyd-bench run --multi-turn <path>` CLI flag to load multi-turn conversation datasets
+- JSONL format with `messages` array per line (OpenAI chat format)
+- Sequential turn execution: send turn 1, wait for response, append to context, send turn 2, etc.
+- Per-turn metrics: TTFT, TPOT, latency for each turn in the conversation
+- Aggregate metrics across all conversations and per-turn-index
+- Context growth impact analysis: latency vs conversation depth
+- `--max-turns N` to cap conversation length
+- Synthetic multi-turn generation with configurable turn count and message lengths
+- Dummy server stateful conversation support (maintains context window)
+- YAML config support (`multi_turn`, `max_turns`)
+- Tests covering multi-turn execution, per-turn metrics, context growth, and CLI integration

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -624,6 +624,32 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Path to YAML cost model file mapping model names to $/1K tokens.",
     )
 
+    # Multi-turn conversation benchmarking (M45)
+    parser.add_argument(
+        "--multi-turn",
+        type=str,
+        default=None,
+        dest="multi_turn",
+        metavar="PATH",
+        help=(
+            "Path to JSONL file with multi-turn conversations, or 'synthetic' "
+            "for auto-generated conversations."
+        ),
+    )
+    parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=None,
+        dest="max_turns",
+        help="Maximum number of turns per conversation (default: unlimited).",
+    )
+    parser.add_argument(
+        "--turns",
+        type=int,
+        default=5,
+        help="Number of turns for synthetic multi-turn generation (default: 5).",
+    )
+
 
 def _resolve_base_url(args: argparse.Namespace) -> str:
     """Resolve the base URL from --base-url or --host/--port."""
@@ -968,6 +994,104 @@ def bench_main(argv: list[str] | None = None) -> None:
     # Dry run: validate config and dataset, print plan, exit
     if getattr(args, "dry_run", False):
         _dry_run(args, base_url)
+        return
+
+    # Multi-turn conversation mode (M45)
+    multi_turn_path = getattr(args, "multi_turn", None)
+    if multi_turn_path:
+        from xpyd_bench.multi_turn import (
+            compute_multi_turn_stats,
+            generate_synthetic_conversations,
+            load_multi_turn_dataset,
+            run_conversation,
+        )
+
+        print(f"xpyd-bench v{__version__} (multi-turn mode)")
+        print(f"  Base URL:       {base_url}")
+        print(f"  Model:          {args.model or '(auto-detect)'}")
+        max_turns = getattr(args, "max_turns", None)
+        print(f"  Max turns:      {max_turns or 'unlimited'}")
+
+        if multi_turn_path == "synthetic":
+            conversations = generate_synthetic_conversations(
+                num_conversations=args.num_prompts,
+                turns=getattr(args, "turns", 5),
+                input_len=args.input_len,
+                seed=getattr(args, "seed", 42),
+            )
+            print(f"  Conversations:  {len(conversations)} (synthetic)")
+        else:
+            conversations = load_multi_turn_dataset(multi_turn_path)
+            print(f"  Conversations:  {len(conversations)} (from {multi_turn_path})")
+        print()
+
+        import httpx
+
+        async def _run_multi_turn() -> list:
+            async with httpx.AsyncClient() as client:
+                results = []
+                for i, msgs in enumerate(conversations):
+                    conv_result = await run_conversation(
+                        client=client,
+                        base_url=base_url,
+                        model=args.model or "mock-model",
+                        messages=msgs,
+                        conversation_id=i,
+                        max_turns=max_turns,
+                        endpoint="/v1/chat/completions",
+                        api_key=getattr(args, "api_key", None),
+                        timeout=getattr(args, "timeout", 300.0),
+                    )
+                    results.append(conv_result)
+                    print(
+                        f"  Conversation {i+1}/{len(conversations)}: "
+                        f"{conv_result.total_turns} turns, "
+                        f"{conv_result.total_latency_ms:.0f}ms"
+                    )
+                return results
+
+        conv_results = asyncio.run(_run_multi_turn())
+        mt_result = compute_multi_turn_stats(conv_results)
+
+        # Print summary
+        stats = mt_result.aggregate_stats
+        print(f"\n{'='*60}")
+        print("  Multi-Turn Benchmark Summary")
+        print(f"{'='*60}")
+        print(f"  Conversations:    {stats.get('total_conversations', 0)}")
+        print(f"  Total turns:      {stats.get('total_turns', 0)}")
+        print(f"  Errors:           {stats.get('total_errors', 0)}")
+        print(f"  Mean TTFT:        {stats.get('mean_ttft_ms', 0):.2f} ms")
+        print(f"  Mean latency:     {stats.get('mean_latency_ms', 0):.2f} ms")
+        if "p50_latency_ms" in stats:
+            print(f"  P50 latency:      {stats['p50_latency_ms']:.2f} ms")
+            print(f"  P99 latency:      {stats['p99_latency_ms']:.2f} ms")
+
+        # Per-turn stats
+        if mt_result.per_turn_stats:
+            print("\n  Per-Turn Statistics:")
+            print(
+                f"  {'Turn':>6}  {'Count':>6}  {'TTFT(ms)':>10}  "
+                f"{'Latency(ms)':>12}  {'Context(tok)':>13}"
+            )
+            for idx in sorted(mt_result.per_turn_stats.keys()):
+                ts = mt_result.per_turn_stats[idx]
+                print(
+                    f"  {idx:>6}  {ts['count']:>6}  "
+                    f"{ts['mean_ttft_ms']:>10.2f}  "
+                    f"{ts['mean_latency_ms']:>12.2f}  "
+                    f"{ts['mean_context_tokens']:>13.0f}"
+                )
+        print(f"{'='*60}")
+
+        # Save result if requested
+        result = mt_result.to_dict()
+        if getattr(args, "save_result", None):
+            p = Path(args.save_result)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(json.dumps(result, indent=2))
+            print(f"\nResults saved to {p}")
+
         return
 
     print(f"xpyd-bench v{__version__}")

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -95,6 +95,9 @@ _KNOWN_KEYS: set[str] = {
     "request_id_prefix",
     "anomaly_threshold",
     "sweep",
+    "multi_turn",
+    "max_turns",
+    "turns",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/src/xpyd_bench/multi_turn.py
+++ b/src/xpyd_bench/multi_turn.py
@@ -1,0 +1,355 @@
+"""Multi-turn conversation benchmarking (M45).
+
+Supports sequential multi-turn conversations where each turn builds
+on the previous context, measuring per-turn and aggregate metrics.
+
+Usage:
+    xpyd-bench run --multi-turn conversations.jsonl
+    xpyd-bench run --multi-turn synthetic --turns 5 --input-len 256
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+@dataclass
+class TurnResult:
+    """Metrics for a single conversation turn."""
+
+    turn_index: int
+    ttft_ms: float
+    total_latency_ms: float
+    prompt_tokens: int
+    completion_tokens: int
+    context_tokens: int  # total tokens in context at this turn
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "turn_index": self.turn_index,
+            "ttft_ms": round(self.ttft_ms, 2),
+            "total_latency_ms": round(self.total_latency_ms, 2),
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "context_tokens": self.context_tokens,
+        }
+        if self.error:
+            d["error"] = self.error
+        return d
+
+
+@dataclass
+class ConversationResult:
+    """Result for a full multi-turn conversation."""
+
+    conversation_id: int
+    turns: list[TurnResult] = field(default_factory=list)
+    total_turns: int = 0
+    total_latency_ms: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "conversation_id": self.conversation_id,
+            "total_turns": self.total_turns,
+            "total_latency_ms": round(self.total_latency_ms, 2),
+            "turns": [t.to_dict() for t in self.turns],
+        }
+
+
+@dataclass
+class MultiTurnResult:
+    """Aggregated multi-turn benchmark results."""
+
+    conversations: list[ConversationResult] = field(default_factory=list)
+    per_turn_stats: dict[int, dict[str, float]] = field(default_factory=dict)
+    aggregate_stats: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "conversations": [c.to_dict() for c in self.conversations],
+            "per_turn_stats": self.per_turn_stats,
+            "aggregate_stats": self.aggregate_stats,
+        }
+
+
+def load_multi_turn_dataset(path: str) -> list[list[dict[str, str]]]:
+    """Load multi-turn conversations from JSONL file.
+
+    Each line is a JSON object with a ``messages`` array in OpenAI chat
+    format (list of ``{"role": ..., "content": ...}`` dicts).
+
+    Returns:
+        List of conversations, each a list of message dicts.
+    """
+    conversations: list[list[dict[str, str]]] = []
+    p = Path(path)
+    for line in p.read_text().strip().splitlines():
+        obj = json.loads(line)
+        messages = obj.get("messages", [])
+        if messages:
+            conversations.append(messages)
+    return conversations
+
+
+def generate_synthetic_conversations(
+    num_conversations: int = 10,
+    turns: int = 5,
+    input_len: int = 256,
+    seed: int | None = None,
+) -> list[list[dict[str, str]]]:
+    """Generate synthetic multi-turn conversations.
+
+    Args:
+        num_conversations: Number of conversations to generate.
+        turns: Number of user turns per conversation.
+        input_len: Approximate token count per user message.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        List of conversations in OpenAI chat format.
+    """
+    rng = random.Random(seed)
+    words = [
+        "the", "be", "to", "of", "and", "a", "in", "that", "have", "I",
+        "it", "for", "not", "on", "with", "he", "as", "you", "do", "at",
+        "this", "but", "his", "by", "from", "they", "we", "say", "her",
+        "she", "or", "an", "will", "my", "one", "all", "would", "there",
+        "their", "what", "so", "up", "out", "if", "about", "who", "get",
+        "which", "go", "me", "when", "make", "can", "like", "time", "no",
+    ]
+    conversations: list[list[dict[str, str]]] = []
+    for _ in range(num_conversations):
+        msgs: list[dict[str, str]] = []
+        msgs.append({
+            "role": "system",
+            "content": "You are a helpful assistant.",
+        })
+        for t in range(turns):
+            # Generate user message
+            word_count = max(1, input_len // 4)  # rough tokens-to-words
+            user_text = " ".join(rng.choices(words, k=word_count))
+            msgs.append({"role": "user", "content": user_text})
+            # Placeholder for assistant response (will be filled by server)
+            if t < turns - 1:
+                msgs.append({
+                    "role": "assistant",
+                    "content": " ".join(rng.choices(words, k=word_count // 2)),
+                })
+        conversations.append(msgs)
+    return conversations
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token estimation (word count * 1.3)."""
+    return max(1, int(len(text.split()) * 1.3))
+
+
+async def run_conversation(
+    client: httpx.AsyncClient,
+    base_url: str,
+    model: str,
+    messages: list[dict[str, str]],
+    conversation_id: int,
+    max_turns: int | None = None,
+    endpoint: str = "/v1/chat/completions",
+    api_key: str | None = None,
+    timeout: float = 300.0,
+) -> ConversationResult:
+    """Execute a single multi-turn conversation.
+
+    Sends user messages sequentially, appending assistant responses to
+    context before sending the next turn.
+
+    Args:
+        client: HTTP client.
+        base_url: Server base URL.
+        model: Model name.
+        messages: Full conversation messages (user + assistant placeholders).
+        conversation_id: ID for tracking.
+        max_turns: Maximum turns to execute.
+        endpoint: API endpoint.
+        api_key: Optional API key.
+        timeout: Per-request timeout.
+
+    Returns:
+        ConversationResult with per-turn metrics.
+    """
+    result = ConversationResult(conversation_id=conversation_id)
+    url = f"{base_url.rstrip('/')}{endpoint}"
+
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    # Build conversation context incrementally
+    context: list[dict[str, str]] = []
+    turn_index = 0
+    conv_start = time.monotonic()
+
+    for msg in messages:
+        if msg["role"] == "system":
+            context.append(msg)
+            continue
+        if msg["role"] == "assistant":
+            # Skip pre-filled assistant messages; we use server responses
+            continue
+        if msg["role"] == "user":
+            if max_turns is not None and turn_index >= max_turns:
+                break
+
+            context.append(msg)
+            context_tokens = sum(_estimate_tokens(m["content"]) for m in context)
+
+            payload = {
+                "model": model,
+                "messages": context,
+                "max_tokens": 128,
+                "stream": True,
+            }
+
+            ttft_ms = 0.0
+            total_latency_ms = 0.0
+            completion_tokens = 0
+            prompt_tokens = context_tokens
+            error: str | None = None
+            assistant_text = ""
+
+            req_start = time.monotonic()
+            first_token_time: float | None = None
+
+            try:
+                async with client.stream(
+                    "POST",
+                    url,
+                    json=payload,
+                    headers=headers,
+                    timeout=timeout,
+                ) as resp:
+                    resp.raise_for_status()
+                    async for raw_line in resp.aiter_lines():
+                        line = raw_line.strip()
+                        if not line or not line.startswith("data:"):
+                            continue
+                        data_str = line[len("data:"):].strip()
+                        if data_str == "[DONE]":
+                            break
+                        if first_token_time is None:
+                            first_token_time = time.monotonic()
+                        try:
+                            chunk = json.loads(data_str)
+                            choices = chunk.get("choices", [])
+                            if choices:
+                                delta = choices[0].get("delta", {})
+                                content = delta.get("content", "")
+                                if content:
+                                    assistant_text += content
+                                    completion_tokens += 1
+                        except json.JSONDecodeError:
+                            continue
+            except Exception as e:
+                error = str(e)
+
+            req_end = time.monotonic()
+            total_latency_ms = (req_end - req_start) * 1000
+            if first_token_time is not None:
+                ttft_ms = (first_token_time - req_start) * 1000
+
+            # Append assistant response to context
+            if assistant_text:
+                context.append({"role": "assistant", "content": assistant_text})
+
+            turn_result = TurnResult(
+                turn_index=turn_index,
+                ttft_ms=ttft_ms,
+                total_latency_ms=total_latency_ms,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                context_tokens=context_tokens,
+                error=error,
+            )
+            result.turns.append(turn_result)
+            turn_index += 1
+
+    result.total_turns = turn_index
+    result.total_latency_ms = (time.monotonic() - conv_start) * 1000
+    return result
+
+
+def compute_multi_turn_stats(
+    conversations: list[ConversationResult],
+) -> MultiTurnResult:
+    """Compute aggregate and per-turn statistics.
+
+    Args:
+        conversations: List of completed conversation results.
+
+    Returns:
+        MultiTurnResult with per-turn and aggregate statistics.
+    """
+    mt = MultiTurnResult(conversations=conversations)
+
+    # Collect per-turn metrics
+    turn_metrics: dict[int, list[TurnResult]] = {}
+    all_ttft: list[float] = []
+    all_latency: list[float] = []
+    total_errors = 0
+    total_turns_count = 0
+
+    for conv in conversations:
+        for turn in conv.turns:
+            total_turns_count += 1
+            if turn.error:
+                total_errors += 1
+                continue
+            turn_metrics.setdefault(turn.turn_index, []).append(turn)
+            all_ttft.append(turn.ttft_ms)
+            all_latency.append(turn.total_latency_ms)
+
+    # Per-turn stats
+    for idx in sorted(turn_metrics.keys()):
+        turns = turn_metrics[idx]
+        ttfts = [t.ttft_ms for t in turns]
+        lats = [t.total_latency_ms for t in turns]
+        ctx_tokens = [t.context_tokens for t in turns]
+        mt.per_turn_stats[idx] = {
+            "count": len(turns),
+            "mean_ttft_ms": round(sum(ttfts) / len(ttfts), 2) if ttfts else 0,
+            "mean_latency_ms": round(sum(lats) / len(lats), 2) if lats else 0,
+            "mean_context_tokens": round(
+                sum(ctx_tokens) / len(ctx_tokens), 2
+            ) if ctx_tokens else 0,
+        }
+
+    # Aggregate stats
+    mt.aggregate_stats = {
+        "total_conversations": len(conversations),
+        "total_turns": total_turns_count,
+        "total_errors": total_errors,
+        "mean_ttft_ms": round(sum(all_ttft) / len(all_ttft), 2)
+        if all_ttft
+        else 0,
+        "mean_latency_ms": round(sum(all_latency) / len(all_latency), 2)
+        if all_latency
+        else 0,
+    }
+
+    # Sort per-turn latencies for percentiles
+    if all_latency:
+        all_latency.sort()
+        n = len(all_latency)
+        mt.aggregate_stats["p50_latency_ms"] = round(
+            all_latency[int(n * 0.5)], 2
+        )
+        mt.aggregate_stats["p99_latency_ms"] = round(
+            all_latency[min(int(n * 0.99), n - 1)], 2
+        )
+
+    return mt

--- a/tests/test_multi_turn.py
+++ b/tests/test_multi_turn.py
@@ -1,0 +1,242 @@
+"""Tests for multi-turn conversation benchmarking (M45)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from xpyd_bench.multi_turn import (
+    ConversationResult,
+    TurnResult,
+    compute_multi_turn_stats,
+    generate_synthetic_conversations,
+    load_multi_turn_dataset,
+)
+
+
+class TestLoadMultiTurnDataset:
+    """Tests for JSONL dataset loading."""
+
+    def test_load_valid_jsonl(self, tmp_path: Path) -> None:
+        data = tmp_path / "conversations.jsonl"
+        conv1 = {
+            "messages": [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+                {"role": "user", "content": "How are you?"},
+            ]
+        }
+        conv2 = {
+            "messages": [
+                {"role": "user", "content": "What is 2+2?"},
+            ]
+        }
+        data.write_text(json.dumps(conv1) + "\n" + json.dumps(conv2) + "\n")
+
+        result = load_multi_turn_dataset(str(data))
+        assert len(result) == 2
+        assert len(result[0]) == 4
+        assert len(result[1]) == 1
+        assert result[0][0]["role"] == "system"
+
+    def test_load_empty_messages_skipped(self, tmp_path: Path) -> None:
+        data = tmp_path / "empty.jsonl"
+        data.write_text(json.dumps({"messages": []}) + "\n")
+        result = load_multi_turn_dataset(str(data))
+        assert len(result) == 0
+
+
+class TestGenerateSyntheticConversations:
+    """Tests for synthetic conversation generation."""
+
+    def test_basic_generation(self) -> None:
+        convs = generate_synthetic_conversations(
+            num_conversations=3, turns=4, input_len=100, seed=42
+        )
+        assert len(convs) == 3
+        for conv in convs:
+            # Should have system + alternating user/assistant
+            assert conv[0]["role"] == "system"
+            user_turns = [m for m in conv if m["role"] == "user"]
+            assert len(user_turns) == 4
+
+    def test_deterministic_with_seed(self) -> None:
+        a = generate_synthetic_conversations(num_conversations=2, turns=3, seed=123)
+        b = generate_synthetic_conversations(num_conversations=2, turns=3, seed=123)
+        assert a == b
+
+    def test_different_seeds_differ(self) -> None:
+        a = generate_synthetic_conversations(num_conversations=2, turns=3, seed=1)
+        b = generate_synthetic_conversations(num_conversations=2, turns=3, seed=2)
+        assert a != b
+
+
+class TestTurnResult:
+    """Tests for TurnResult serialization."""
+
+    def test_to_dict(self) -> None:
+        tr = TurnResult(
+            turn_index=0,
+            ttft_ms=15.5,
+            total_latency_ms=120.3,
+            prompt_tokens=50,
+            completion_tokens=30,
+            context_tokens=50,
+        )
+        d = tr.to_dict()
+        assert d["turn_index"] == 0
+        assert d["ttft_ms"] == 15.5
+        assert "error" not in d
+
+    def test_to_dict_with_error(self) -> None:
+        tr = TurnResult(
+            turn_index=1,
+            ttft_ms=0,
+            total_latency_ms=0,
+            prompt_tokens=100,
+            completion_tokens=0,
+            context_tokens=100,
+            error="Connection refused",
+        )
+        d = tr.to_dict()
+        assert d["error"] == "Connection refused"
+
+
+class TestConversationResult:
+    """Tests for ConversationResult serialization."""
+
+    def test_to_dict(self) -> None:
+        turn = TurnResult(0, 10.0, 100.0, 50, 30, 50)
+        conv = ConversationResult(
+            conversation_id=0,
+            turns=[turn],
+            total_turns=1,
+            total_latency_ms=100.0,
+        )
+        d = conv.to_dict()
+        assert d["conversation_id"] == 0
+        assert d["total_turns"] == 1
+        assert len(d["turns"]) == 1
+
+
+class TestComputeMultiTurnStats:
+    """Tests for aggregate statistics computation."""
+
+    def _make_conv(
+        self, conv_id: int, turns: list[tuple[float, float, int]]
+    ) -> ConversationResult:
+        """Helper: create a ConversationResult from (ttft, latency, ctx_tokens) tuples."""
+        result = ConversationResult(conversation_id=conv_id)
+        for i, (ttft, lat, ctx) in enumerate(turns):
+            result.turns.append(
+                TurnResult(
+                    turn_index=i,
+                    ttft_ms=ttft,
+                    total_latency_ms=lat,
+                    prompt_tokens=ctx,
+                    completion_tokens=30,
+                    context_tokens=ctx,
+                )
+            )
+        result.total_turns = len(turns)
+        result.total_latency_ms = sum(t[1] for t in turns)
+        return result
+
+    def test_aggregate_stats(self) -> None:
+        conv1 = self._make_conv(0, [(10, 100, 50), (15, 150, 100)])
+        conv2 = self._make_conv(1, [(12, 110, 55), (18, 160, 110)])
+        mt = compute_multi_turn_stats([conv1, conv2])
+
+        assert mt.aggregate_stats["total_conversations"] == 2
+        assert mt.aggregate_stats["total_turns"] == 4
+        assert mt.aggregate_stats["total_errors"] == 0
+        assert mt.aggregate_stats["mean_ttft_ms"] > 0
+        assert mt.aggregate_stats["mean_latency_ms"] > 0
+
+    def test_per_turn_stats(self) -> None:
+        conv1 = self._make_conv(0, [(10, 100, 50), (20, 200, 120)])
+        conv2 = self._make_conv(1, [(12, 110, 55), (22, 210, 125)])
+        mt = compute_multi_turn_stats([conv1, conv2])
+
+        assert 0 in mt.per_turn_stats
+        assert 1 in mt.per_turn_stats
+        # Turn 0 mean TTFT = (10 + 12) / 2 = 11
+        assert mt.per_turn_stats[0]["mean_ttft_ms"] == 11.0
+        assert mt.per_turn_stats[0]["count"] == 2
+        # Turn 1 mean context should be (120 + 125) / 2 = 122.5
+        assert mt.per_turn_stats[1]["mean_context_tokens"] == 122.5
+
+    def test_error_turns_excluded(self) -> None:
+        conv = ConversationResult(conversation_id=0)
+        conv.turns.append(
+            TurnResult(0, 10.0, 100.0, 50, 30, 50)
+        )
+        conv.turns.append(
+            TurnResult(1, 0, 0, 100, 0, 100, error="timeout")
+        )
+        conv.total_turns = 2
+        conv.total_latency_ms = 100.0
+
+        mt = compute_multi_turn_stats([conv])
+        assert mt.aggregate_stats["total_errors"] == 1
+        assert mt.aggregate_stats["total_turns"] == 2
+        # Only turn 0 in per_turn_stats
+        assert 0 in mt.per_turn_stats
+        assert 1 not in mt.per_turn_stats
+
+    def test_to_dict_structure(self) -> None:
+        conv = self._make_conv(0, [(10, 100, 50)])
+        mt = compute_multi_turn_stats([conv])
+        d = mt.to_dict()
+        assert "conversations" in d
+        assert "per_turn_stats" in d
+        assert "aggregate_stats" in d
+
+    def test_percentiles(self) -> None:
+        # Create enough data points for percentiles
+        turns = [(float(i), float(i * 10), i * 5) for i in range(1, 21)]
+        conv = self._make_conv(0, turns)
+        mt = compute_multi_turn_stats([conv])
+        assert "p50_latency_ms" in mt.aggregate_stats
+        assert "p99_latency_ms" in mt.aggregate_stats
+
+    def test_context_growth_visible(self) -> None:
+        """Per-turn stats should show increasing context tokens."""
+        conv = self._make_conv(0, [
+            (10, 100, 50),
+            (15, 150, 120),
+            (20, 200, 200),
+        ])
+        mt = compute_multi_turn_stats([conv])
+        ctx_0 = mt.per_turn_stats[0]["mean_context_tokens"]
+        ctx_1 = mt.per_turn_stats[1]["mean_context_tokens"]
+        ctx_2 = mt.per_turn_stats[2]["mean_context_tokens"]
+        assert ctx_0 < ctx_1 < ctx_2
+
+
+class TestMultiTurnCLI:
+    """Tests for multi-turn CLI integration."""
+
+    def test_multi_turn_arg_added(self) -> None:
+        """--multi-turn argument exists in CLI parser."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--multi-turn", "test.jsonl", "--max-turns", "3"])
+        assert args.multi_turn == "test.jsonl"
+        assert args.max_turns == 3
+
+    def test_turns_arg_default(self) -> None:
+        """--turns defaults to 5."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        assert args.turns == 5


### PR DESCRIPTION
## Summary

Add multi-turn conversation benchmarking support to xPyD-bench.

### Changes
- **`src/xpyd_bench/multi_turn.py`**: Core module with JSONL dataset loading, synthetic generation, conversation execution, and per-turn/aggregate statistics
- **`src/xpyd_bench/cli.py`**: `--multi-turn`, `--max-turns`, `--turns` CLI flags with full multi-turn flow
- **`src/xpyd_bench/config_cmd.py`**: Added `multi_turn`, `max_turns`, `turns` to known config keys
- **`ROADMAP.md`**: Added M45 milestone
- **`tests/test_multi_turn.py`**: 16 tests covering dataset loading, synthetic generation, turn/conversation serialization, aggregate stats, per-turn stats, error handling, percentiles, context growth, and CLI integration

### Features
- Sequential multi-turn conversation execution with growing context
- Per-turn metrics: TTFT, latency, prompt/completion/context tokens
- Context growth impact analysis (latency vs conversation depth)
- Synthetic multi-turn generation with configurable turns and input length
- Aggregate stats with percentiles (P50, P99)

Closes #146