### PR TITLE
feat: add duration-based benchmarking (--duration)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -363,3 +363,13 @@
 - Dummy server stateful conversation support (maintains context window)
 - YAML config support (`multi_turn`, `max_turns`)
 - Tests covering multi-turn execution, per-turn metrics, context growth, and CLI integration
+
+## M46: Duration-based Benchmarking ✅
+- `--duration SECONDS` CLI flag to run benchmark for a fixed time period
+- Prompts cycle round-robin until duration expires
+- When combined with `--num-prompts`, benchmark stops at whichever limit is reached first
+- `BenchmarkResult` includes `duration_limit` field
+- YAML config support (`duration`)
+- Works with all rate patterns, token bucket, adaptive concurrency
+- Dry-run shows duration mode info
+- Tests covering CLI parsing, dry-run output, YAML config, model serialization

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -36,6 +36,7 @@ class BenchmarkResult:
     max_concurrency: int | None = None
     input_len: int = 256
     output_len: int = 128
+    duration_limit: float | None = None
 
     # Per-request results
     requests: list[RequestResult] = field(default_factory=list)

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -619,6 +619,9 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     # Concurrency limiter
     semaphore = asyncio.Semaphore(args.max_concurrency) if args.max_concurrency else None
 
+    # Duration mode (M46)
+    duration_limit = getattr(args, "duration", None)
+
     result = BenchmarkResult(
         backend=args.backend,
         base_url=base_url,
@@ -629,6 +632,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         max_concurrency=args.max_concurrency,
         input_len=args.input_len,
         output_len=args.output_len,
+        duration_limit=duration_limit,
         environment=collect_env_info(),
     )
 
@@ -699,13 +703,13 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         from xpyd_bench.reporting.rich_output import LiveDashboard
 
         _LiveDashboardType = LiveDashboard
-        reporter = LiveDashboard(total=args.num_prompts)
+        reporter = LiveDashboard(total=args.num_prompts if not duration_limit else 0)
     elif not args.disable_tqdm and not no_live:
         use_rich = getattr(args, "rich_progress", False)
         if use_rich:
             from xpyd_bench.reporting.rich_output import RichProgressReporter
 
-            reporter = RichProgressReporter(total=args.num_prompts)
+            reporter = RichProgressReporter(total=args.num_prompts if not duration_limit else 0)
 
     # --- Warmup phase ---
     warmup_count = getattr(args, "warmup", 0) or 0
@@ -806,21 +810,43 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         except NotImplementedError:
             pass  # Windows doesn't support add_signal_handler
 
-        for i, prompt in enumerate(prompts):
+        # Duration-based or count-based request dispatch
+        prompt_count = len(prompts)
+        i = 0
+        deadline = (overall_start + duration_limit) if duration_limit else None
+
+        while True:
             if shutdown_requested:
                 break
+            # Check duration limit
+            if deadline and time.perf_counter() >= deadline:
+                break
+            # Check num_prompts limit (unless in pure duration mode)
+            if not duration_limit and i >= len(prompts):
+                break
+            if duration_limit and args.num_prompts and i >= args.num_prompts:
+                break
+
+            prompt = prompts[i % prompt_count]
+
             if i > 0:
+                interval_idx = i if i < len(intervals) else i % len(intervals)
                 if token_bucket:
                     await token_bucket.acquire()
                 else:
-                    await asyncio.sleep(intervals[i])
+                    await asyncio.sleep(intervals[interval_idx])
                 if shutdown_requested:
+                    break
+                if deadline and time.perf_counter() >= deadline:
                     break
             task = asyncio.create_task(_tracked_task(client, prompt))
             tasks.append(task)
 
             if not reporter and not args.disable_tqdm and (i + 1) % 100 == 0:
-                print(f"  Launched {i + 1}/{args.num_prompts} requests...")
+                total_label = args.num_prompts if not duration_limit else "∞"
+                print(f"  Launched {i + 1}/{total_label} requests...")
+
+            i += 1
 
         # Wait for all launched tasks to complete (with grace period if shutting down)
         if shutdown_requested and tasks:
@@ -855,6 +881,10 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     result.total_duration_s = overall_end - overall_start
     result.requests = results_list
     result.partial = shutdown_requested
+
+    # Update num_prompts to actual count in duration mode
+    if duration_limit:
+        result.num_prompts = len(results_list)
 
     if debug_logger:
         debug_logger.close()

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -77,6 +77,16 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Total number of prompts/requests to send (default: 1000).",
     )
     parser.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help=(
+            "Run benchmark for a fixed duration in seconds. Prompts cycle "
+            "round-robin until time expires. When combined with --num-prompts, "
+            "benchmark stops at whichever limit is reached first."
+        ),
+    )
+    parser.add_argument(
         "--request-rate",
         type=float,
         default=float("inf"),
@@ -693,6 +703,12 @@ def _dry_run(args: argparse.Namespace, base_url: str) -> None:
     print(f"  Backend:         {args.backend}")
     print(f"  Model:           {args.model or '(auto-detect)'}")
     print(f"  Num prompts:     {args.num_prompts}")
+    duration_limit = getattr(args, "duration", None)
+    if duration_limit:
+        print(f"  Duration limit:  {duration_limit}s")
+        print("  Mode:            duration (prompts cycle until time expires)")
+    else:
+        print(f"  Mode:            count-based ({args.num_prompts} prompts)")
     print(f"  Request rate:    {args.request_rate}")
     print(f"  Max concurrency: {args.max_concurrency or 'unlimited'}")
     print(f"  Input len:       {args.input_len}")

--- a/tests/test_duration.py
+++ b/tests/test_duration.py
@@ -1,0 +1,65 @@
+"""Tests for M46: Duration-based Benchmarking (--duration)."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+import pytest
+
+from xpyd_bench.bench.models import BenchmarkResult
+from xpyd_bench.cli import bench_main
+
+
+class TestDurationCLI:
+    """Test --duration CLI flag parsing and dry-run output."""
+
+    def test_duration_flag_parsed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """--duration should be accepted and shown in dry-run."""
+        bench_main(["--dry-run", "--duration", "10", "--num-prompts", "5"])
+        out = capsys.readouterr().out
+        assert "Duration limit:" in out
+        assert "10" in out
+
+    def test_duration_mode_label(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Dry-run should label mode as duration when --duration is set."""
+        bench_main(["--dry-run", "--duration", "30"])
+        out = capsys.readouterr().out
+        assert "duration" in out.lower()
+        assert "prompts cycle" in out.lower()
+
+    def test_no_duration_shows_count_mode(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Without --duration, mode should be count-based."""
+        bench_main(["--dry-run", "--num-prompts", "50"])
+        out = capsys.readouterr().out
+        assert "count-based" in out.lower()
+
+
+class TestDurationModel:
+    """Test BenchmarkResult duration_limit field."""
+
+    def test_duration_limit_default_none(self) -> None:
+        result = BenchmarkResult()
+        assert result.duration_limit is None
+
+    def test_duration_limit_set(self) -> None:
+        result = BenchmarkResult(duration_limit=60.0)
+        assert result.duration_limit == 60.0
+
+    def test_duration_limit_serializes(self) -> None:
+        """duration_limit should appear in dataclass fields."""
+        result = BenchmarkResult(duration_limit=30.0)
+        d = asdict(result)
+        assert d["duration_limit"] == 30.0
+
+
+class TestDurationYAML:
+    """Test YAML config support for duration."""
+
+    def test_yaml_duration(self, capsys: pytest.CaptureFixture[str], tmp_path) -> None:
+        """duration in YAML config should be applied."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("duration: 15\n")
+        bench_main(["--dry-run", "--config", str(cfg)])
+        out = capsys.readouterr().out
+        assert "Duration limit:" in out
+        assert "15" in out


### PR DESCRIPTION
## M46: Duration-based Benchmarking

Closes #149

### Changes
- Add `--duration SECONDS` CLI flag for time-based benchmarking
- Prompts cycle round-robin until duration expires  
- When combined with `--num-prompts`, stops at whichever limit is reached first
- `BenchmarkResult` includes `duration_limit` field
- YAML config support (`duration` key)
- Dry-run shows duration mode info
- 7 new tests covering CLI, model, and YAML integration

### Testing
- All 861 tests pass (7 new + 854 existing)
- Lint clean (ruff + isort)