### PR TITLE
feat: add response validation & content checking (M47)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -373,3 +373,13 @@
 - Works with all rate patterns, token bucket, adaptive concurrency
 - Dry-run shows duration mode info
 - Tests covering CLI parsing, dry-run output, YAML config, model serialization
+
+## M47: Response Validation & Content Checking ✅
+- `--validate-response <mode>` CLI flag (repeatable) for response content validation
+- Modes: `non-empty`, `json`, `regex:<pattern>`, `min-tokens:<N>`
+- Multiple validators can be chained
+- `RequestResult` includes `response_text` and `validation_errors` fields
+- `BenchmarkResult` includes `validation_summary` with pass/fail counts and pass rate
+- Terminal summary shows validation pass rate
+- YAML config support (`validate_response: ["non-empty", "min-tokens:10"]`)
+- Tests covering all validation modes, aggregation, CLI integration, and YAML config

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -20,6 +20,8 @@ class RequestResult:
     success: bool = True
     error: str | None = None
     request_id: str | None = None
+    response_text: str | None = None
+    validation_errors: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -91,3 +93,6 @@ class BenchmarkResult:
 
     # Anomaly detection results (M43)
     anomalies: dict | None = None
+
+    # Validation summary (M47)
+    validation_summary: dict | None = None

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -218,6 +218,16 @@ async def _send_request(
                 usage = body.get("usage", {})
                 result.prompt_tokens = usage.get("prompt_tokens", 0)
                 result.completion_tokens = usage.get("completion_tokens", 0)
+
+                # Extract response text for validation (M47)
+                choices = body.get("choices", [])
+                if choices:
+                    c = choices[0]
+                    result.response_text = (
+                        c.get("text")
+                        or (c.get("message") or {}).get("content")
+                        or ""
+                    )
                 # Non-streaming: TPOT cannot be accurately measured because
                 # latency includes prefill time. Leave as None for consistency
                 # with streaming TPOT which correctly excludes TTFT/prefill.
@@ -259,6 +269,7 @@ async def _send_streaming(
     first_token_time: float | None = None
     last_token_time: float = start
     token_count = 0
+    collected_text_parts: list[str] = []  # M47: collect response text for validation
     stream_usage: dict[str, Any] | None = None
 
     try:
@@ -295,6 +306,7 @@ async def _send_streaming(
                     if text:
                         token_count += 1
                         has_content = True
+                        collected_text_parts.append(text)
                 if not has_content:
                     continue
                 if first_token_time is None:
@@ -321,6 +333,9 @@ async def _send_streaming(
     if token_count > 1 and first_token_time is not None:
         generation_time_ms = (last_token_time - first_token_time) * 1000.0
         result.tpot_ms = generation_time_ms / (token_count - 1)
+
+    # M47: Store collected response text for validation
+    result.response_text = "".join(collected_text_parts)
 
     return result
 
@@ -904,6 +919,33 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         if anomaly_result is not None and anomaly_result.count > 0:
             result.anomalies = anomaly_result.to_dict()
 
+    # Response validation (M47)
+    validators_specs = getattr(args, "validate_response", None) or []
+    if validators_specs:
+        from xpyd_bench.bench.validation import ValidationResult as VResult
+        from xpyd_bench.bench.validation import (
+            aggregate_validations,
+            parse_validators,
+            validate_response,
+        )
+
+        validators = parse_validators(validators_specs)
+        v_results: list[VResult] = []
+        for req in result.requests:
+            if req.success and req.response_text is not None:
+                vr = validate_response(req.response_text, validators)
+                req.validation_errors = vr.errors
+                v_results.append(vr)
+        if v_results:
+            summary = aggregate_validations(v_results)
+            result.validation_summary = {
+                "total": summary.total,
+                "passed": summary.passed,
+                "failed": summary.failed,
+                "pass_rate": round(summary.pass_rate, 2),
+                "error_counts": summary.error_counts,
+            }
+
     if shutdown_requested:
         print(
             f"\n⚠️  Partial results: {result.completed} completed, "
@@ -953,6 +995,15 @@ def _print_summary(r: BenchmarkResult) -> None:
             lat = a["latency_ms"]
             dev = a["deviation_factor"]
             print(f"      Request #{idx}: {lat:.2f} ms ({dev:.1f}x IQR above Q3)")
+    if r.validation_summary:
+        vs = r.validation_summary
+        print(
+            f"\n  🔍 Validation: {vs['passed']}/{vs['total']} passed "
+            f"({vs['pass_rate']}%)"
+        )
+        if vs["failed"] > 0:
+            for err_type, cnt in vs["error_counts"].items():
+                print(f"      {err_type}: {cnt}")
     print("=" * 60)
 
 

--- a/src/xpyd_bench/bench/validation.py
+++ b/src/xpyd_bench/bench/validation.py
@@ -1,0 +1,125 @@
+"""Response validation for benchmark requests (M47)."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ValidationResult:
+    """Result of validating a single response."""
+
+    passed: bool = True
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ValidationSummary:
+    """Aggregated validation results across all requests."""
+
+    total: int = 0
+    passed: int = 0
+    failed: int = 0
+    error_counts: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def pass_rate(self) -> float:
+        """Return pass rate as a percentage."""
+        return (self.passed / self.total * 100) if self.total > 0 else 0.0
+
+
+def parse_validators(specs: list[str]) -> list[tuple[str, str | None]]:
+    """Parse validator specs into (type, param) tuples.
+
+    Supported formats:
+        - "non-empty"
+        - "json"
+        - "regex:<pattern>"
+        - "min-tokens:<N>"
+    """
+    validators: list[tuple[str, str | None]] = []
+    for spec in specs:
+        if spec == "non-empty":
+            validators.append(("non-empty", None))
+        elif spec == "json":
+            validators.append(("json", None))
+        elif spec.startswith("regex:"):
+            pattern = spec[len("regex:"):]
+            if not pattern:
+                raise ValueError(f"Invalid validator spec '{spec}': regex pattern is empty")
+            # Validate the regex compiles
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                raise ValueError(f"Invalid regex pattern in '{spec}': {exc}") from exc
+            validators.append(("regex", pattern))
+        elif spec.startswith("min-tokens:"):
+            param = spec[len("min-tokens:"):]
+            try:
+                n = int(param)
+                if n < 0:
+                    raise ValueError("must be non-negative")
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid validator spec '{spec}': "
+                    f"min-tokens requires a non-negative integer ({exc})"
+                ) from exc
+            validators.append(("min-tokens", str(n)))
+        else:
+            raise ValueError(
+                f"Unknown validator '{spec}'. "
+                "Supported: non-empty, json, regex:<pattern>, min-tokens:<N>"
+            )
+    return validators
+
+
+def validate_response(
+    text: str,
+    validators: list[tuple[str, str | None]],
+) -> ValidationResult:
+    """Validate a response string against a list of validators."""
+    result = ValidationResult()
+    for vtype, param in validators:
+        if vtype == "non-empty":
+            if not text or not text.strip():
+                result.passed = False
+                result.errors.append("Response is empty")
+        elif vtype == "json":
+            try:
+                json.loads(text)
+            except (json.JSONDecodeError, TypeError):
+                result.passed = False
+                result.errors.append("Response is not valid JSON")
+        elif vtype == "regex":
+            assert param is not None
+            if not re.search(param, text):
+                result.passed = False
+                result.errors.append(f"Response does not match regex: {param}")
+        elif vtype == "min-tokens":
+            assert param is not None
+            min_count = int(param)
+            # Simple whitespace-based token count approximation
+            token_count = len(text.split()) if text else 0
+            if token_count < min_count:
+                result.passed = False
+                result.errors.append(
+                    f"Response has {token_count} tokens, minimum required: {min_count}"
+                )
+    return result
+
+
+def aggregate_validations(results: list[ValidationResult]) -> ValidationSummary:
+    """Aggregate individual validation results into a summary."""
+    summary = ValidationSummary(total=len(results))
+    for r in results:
+        if r.passed:
+            summary.passed += 1
+        else:
+            summary.failed += 1
+            for err in r.errors:
+                # Use the error prefix as the key
+                key = err.split(":")[0] if ":" in err else err
+                summary.error_counts[key] = summary.error_counts.get(key, 0) + 1
+    return summary

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -372,6 +372,20 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="IQR multiplier for latency anomaly detection (default: 1.5, 0 disables).",
     )
 
+    # Response validation (M47)
+    parser.add_argument(
+        "--validate-response",
+        type=str,
+        action="append",
+        default=None,
+        dest="validate_response",
+        metavar="MODE",
+        help=(
+            "Validate response content (repeatable). Modes: non-empty, json, "
+            "regex:<pattern>, min-tokens:<N>."
+        ),
+    )
+
     # Custom headers
     parser.add_argument(
         "--header",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,183 @@
+"""Tests for M47: Response Validation & Content Checking."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+import pytest
+
+from xpyd_bench.bench.models import BenchmarkResult, RequestResult
+from xpyd_bench.bench.validation import (
+    ValidationResult,
+    aggregate_validations,
+    parse_validators,
+    validate_response,
+)
+from xpyd_bench.cli import bench_main
+
+
+class TestParseValidators:
+    """Test validator spec parsing."""
+
+    def test_non_empty(self) -> None:
+        result = parse_validators(["non-empty"])
+        assert result == [("non-empty", None)]
+
+    def test_json(self) -> None:
+        result = parse_validators(["json"])
+        assert result == [("json", None)]
+
+    def test_regex(self) -> None:
+        result = parse_validators(["regex:hello.*world"])
+        assert result == [("regex", "hello.*world")]
+
+    def test_min_tokens(self) -> None:
+        result = parse_validators(["min-tokens:5"])
+        assert result == [("min-tokens", "5")]
+
+    def test_multiple(self) -> None:
+        result = parse_validators(["non-empty", "json", "min-tokens:3"])
+        assert len(result) == 3
+
+    def test_unknown_validator(self) -> None:
+        with pytest.raises(ValueError, match="Unknown validator"):
+            parse_validators(["foobar"])
+
+    def test_empty_regex(self) -> None:
+        with pytest.raises(ValueError, match="regex pattern is empty"):
+            parse_validators(["regex:"])
+
+    def test_invalid_regex(self) -> None:
+        with pytest.raises(ValueError, match="Invalid regex"):
+            parse_validators(["regex:[invalid"])
+
+    def test_invalid_min_tokens(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            parse_validators(["min-tokens:abc"])
+
+
+class TestValidateResponse:
+    """Test response validation logic."""
+
+    def test_non_empty_pass(self) -> None:
+        result = validate_response("hello world", [("non-empty", None)])
+        assert result.passed
+        assert not result.errors
+
+    def test_non_empty_fail_empty(self) -> None:
+        result = validate_response("", [("non-empty", None)])
+        assert not result.passed
+        assert "empty" in result.errors[0].lower()
+
+    def test_non_empty_fail_whitespace(self) -> None:
+        result = validate_response("   \n  ", [("non-empty", None)])
+        assert not result.passed
+
+    def test_json_pass(self) -> None:
+        result = validate_response('{"key": "value"}', [("json", None)])
+        assert result.passed
+
+    def test_json_fail(self) -> None:
+        result = validate_response("not json at all", [("json", None)])
+        assert not result.passed
+        assert "not valid JSON" in result.errors[0]
+
+    def test_regex_pass(self) -> None:
+        result = validate_response("hello world", [("regex", r"hello\s+\w+")])
+        assert result.passed
+
+    def test_regex_fail(self) -> None:
+        result = validate_response("goodbye", [("regex", r"^hello")])
+        assert not result.passed
+        assert "regex" in result.errors[0].lower()
+
+    def test_min_tokens_pass(self) -> None:
+        result = validate_response("one two three four five", [("min-tokens", "3")])
+        assert result.passed
+
+    def test_min_tokens_fail(self) -> None:
+        result = validate_response("one two", [("min-tokens", "5")])
+        assert not result.passed
+        assert "2 tokens" in result.errors[0]
+
+    def test_multiple_validators_all_pass(self) -> None:
+        validators = [("non-empty", None), ("min-tokens", "2")]
+        result = validate_response("hello world", validators)
+        assert result.passed
+
+    def test_multiple_validators_partial_fail(self) -> None:
+        validators = [("non-empty", None), ("json", None)]
+        result = validate_response("not json", validators)
+        assert not result.passed
+        assert len(result.errors) == 1  # non-empty passes, json fails
+
+
+class TestAggregateValidations:
+    """Test validation aggregation."""
+
+    def test_all_pass(self) -> None:
+        results = [ValidationResult(passed=True), ValidationResult(passed=True)]
+        summary = aggregate_validations(results)
+        assert summary.total == 2
+        assert summary.passed == 2
+        assert summary.failed == 0
+        assert summary.pass_rate == 100.0
+
+    def test_mixed(self) -> None:
+        results = [
+            ValidationResult(passed=True),
+            ValidationResult(passed=False, errors=["Response is empty"]),
+            ValidationResult(passed=False, errors=["Response is not valid JSON"]),
+        ]
+        summary = aggregate_validations(results)
+        assert summary.total == 3
+        assert summary.passed == 1
+        assert summary.failed == 2
+        assert summary.pass_rate == pytest.approx(33.33, abs=0.01)
+
+    def test_empty(self) -> None:
+        summary = aggregate_validations([])
+        assert summary.total == 0
+        assert summary.pass_rate == 0.0
+
+
+class TestModels:
+    """Test model field additions for M47."""
+
+    def test_request_result_has_validation_errors(self) -> None:
+        r = RequestResult()
+        assert r.validation_errors == []
+        assert r.response_text is None
+
+    def test_request_result_validation_errors_set(self) -> None:
+        r = RequestResult(validation_errors=["Response is empty"])
+        assert len(r.validation_errors) == 1
+
+    def test_benchmark_result_has_validation_summary(self) -> None:
+        r = BenchmarkResult()
+        assert r.validation_summary is None
+
+    def test_benchmark_result_validation_summary_serializes(self) -> None:
+        r = BenchmarkResult(validation_summary={"total": 10, "passed": 8, "failed": 2})
+        d = asdict(r)
+        assert d["validation_summary"]["total"] == 10
+
+
+class TestCLI:
+    """Test CLI flag parsing."""
+
+    def test_validate_response_flag_parsed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """--validate-response should be accepted in dry-run."""
+        bench_main([
+            "--dry-run",
+            "--validate-response", "non-empty",
+            "--validate-response", "min-tokens:5",
+        ])
+        # Should not raise
+
+    def test_validate_response_yaml(self, capsys: pytest.CaptureFixture[str], tmp_path) -> None:
+        """validate_response in YAML config should be applied."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text('validate_response: ["non-empty", "json"]\n')
+        bench_main(["--dry-run", "--config", str(cfg)])
+        # Should not raise


### PR DESCRIPTION
## M47: Response Validation & Content Checking

Closes #151

### Changes
- Add `--validate-response` CLI flag (repeatable) with modes: `non-empty`, `json`, `regex:<pattern>`, `min-tokens:<N>`
- Capture response text in `RequestResult` for both streaming and non-streaming requests
- Track `validation_errors` per request and `validation_summary` in `BenchmarkResult`
- Terminal summary shows validation pass rate with error breakdown
- YAML config support (`validate_response` key)
- 29 new tests covering all validation modes, aggregation, CLI integration, and YAML config

### Testing
- All 890 tests pass (29 new + 861 existing)
- Lint clean (ruff + isort)