### PR TITLE
feat(m50): add benchmark repeat mode implementation and tests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -405,7 +405,7 @@
 - Compatible with Jenkins, GitHub Actions, GitLab CI JUnit report parsers
 - Tests covering XML structure, request failures, SLA integration, and CLI integration
 
-## M49: Benchmark Repeat Mode ✅
+## M50: Benchmark Repeat Mode ✅
 - `--repeat N` CLI flag to run the benchmark N times (default 1)
 - `--repeat-delay SECONDS` CLI flag for pause between runs (default 0)
 - YAML config support (`repeat`, `repeat_delay`)

--- a/src/xpyd_bench/repeat.py
+++ b/src/xpyd_bench/repeat.py
@@ -1,0 +1,114 @@
+"""Benchmark Repeat Mode (M49).
+
+Run the same benchmark N times with optional delay between runs,
+then produce an aggregated summary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from argparse import Namespace
+from dataclasses import dataclass, field
+from typing import Any
+
+from xpyd_bench.aggregate import AggregateResult, aggregate_results
+
+
+@dataclass
+class RepeatResult:
+    """Result of a repeated benchmark run."""
+
+    num_runs: int = 0
+    completed_runs: int = 0
+    repeat_delay: float = 0.0
+    partial: bool = False
+    per_run_results: list[dict] = field(default_factory=list)
+    aggregate: AggregateResult | None = None
+
+    def to_dict(self) -> dict:
+        """Serialize to plain dict for JSON output."""
+        d: dict[str, Any] = {
+            "repeat_runs": self.num_runs,
+            "completed_runs": self.completed_runs,
+            "repeat_delay": self.repeat_delay,
+        }
+        if self.partial:
+            d["partial"] = True
+        d["repeat_results"] = self.per_run_results
+        if self.aggregate is not None:
+            d["repeat_summary"] = self.aggregate.to_dict()
+        return d
+
+
+async def run_repeated_benchmark(
+    args: Namespace,
+    base_url: str,
+) -> RepeatResult:
+    """Run the benchmark multiple times and return aggregated results."""
+    from xpyd_bench.bench.runner import run_benchmark
+
+    repeat_count: int = getattr(args, "repeat", 1)
+    repeat_delay: float = getattr(args, "repeat_delay", 0.0)
+
+    rr = RepeatResult(
+        num_runs=repeat_count,
+        repeat_delay=repeat_delay,
+    )
+
+    interrupted = False
+    for i in range(repeat_count):
+        if interrupted:
+            break
+        print(f"\n{'='*60}")
+        print(f"  Repeat run {i + 1}/{repeat_count}")
+        print(f"{'='*60}")
+        try:
+            result_dict, _bench_result = await run_benchmark(args, base_url)
+            rr.per_run_results.append(result_dict)
+            rr.completed_runs += 1
+        except KeyboardInterrupt:
+            interrupted = True
+            rr.partial = True
+            break
+
+        if repeat_delay > 0 and i < repeat_count - 1:
+            print(f"\n  Waiting {repeat_delay}s before next run...")
+            try:
+                await asyncio.sleep(repeat_delay)
+            except (KeyboardInterrupt, asyncio.CancelledError):
+                interrupted = True
+                rr.partial = True
+                break
+
+    if interrupted:
+        rr.partial = True
+
+    if rr.completed_runs >= 2:
+        rr.aggregate = aggregate_results(rr.per_run_results)
+
+    return rr
+
+
+def print_repeat_summary(rr: RepeatResult) -> None:
+    """Print a human-readable summary of repeated benchmark runs."""
+    print(f"\n{'='*60}")
+    print(f"  Repeat Summary ({rr.completed_runs}/{rr.num_runs} runs)")
+    if rr.partial:
+        print("  ⚠ Interrupted — results are partial")
+    print(f"{'='*60}")
+
+    print(f"\n{'Run':>4} {'Throughput':>12} {'Mean TTFT':>12} {'Mean Latency':>14}")
+    print("-" * 46)
+    for i, r in enumerate(rr.per_run_results):
+        tp = r.get("request_throughput", 0.0)
+        ttft = r.get("mean_ttft_ms", 0.0) or 0.0
+        lat = r.get("mean_e2el_ms", 0.0) or 0.0
+        print(f"{i+1:>4} {tp:>11.2f}  {ttft:>11.2f}  {lat:>13.2f}")
+
+    if rr.aggregate is not None:
+        from xpyd_bench.aggregate import _print_table
+
+        _print_table(rr.aggregate)
+    elif rr.completed_runs < 2:
+        print("\n  (Need at least 2 completed runs for aggregation)")
+    print()

--- a/tests/test_repeat.py
+++ b/tests/test_repeat.py
@@ -1,0 +1,165 @@
+"""Tests for Benchmark Repeat Mode (M49)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from argparse import Namespace
+from unittest.mock import patch
+
+from xpyd_bench.repeat import RepeatResult, print_repeat_summary, run_repeated_benchmark
+
+
+def _make_result_dict(throughput=10.0, ttft=50.0):
+    """Create a minimal benchmark result dict."""
+    return {
+        "completed": 100,
+        "failed": 0,
+        "request_throughput": throughput,
+        "output_throughput": throughput * 10,
+        "total_token_throughput": throughput * 15,
+        "mean_ttft_ms": ttft,
+        "mean_tpot_ms": 5.0,
+        "mean_e2el_ms": 200.0,
+        "total_duration_s": 10.0,
+    }
+
+
+def _make_args(repeat=3, repeat_delay=0.0):
+    return Namespace(
+        repeat=repeat,
+        repeat_delay=repeat_delay,
+        model="test-model",
+        num_prompts=10,
+        request_rate=float("inf"),
+    )
+
+
+class TestRepeatResult:
+    def test_to_dict_basic(self):
+        rr = RepeatResult(num_runs=3, completed_runs=3, repeat_delay=1.0)
+        rr.per_run_results = [_make_result_dict(i * 5 + 5) for i in range(3)]
+        d = rr.to_dict()
+        assert d["repeat_runs"] == 3
+        assert d["completed_runs"] == 3
+        assert d["repeat_delay"] == 1.0
+        assert "partial" not in d
+        assert len(d["repeat_results"]) == 3
+
+    def test_to_dict_partial(self):
+        rr = RepeatResult(num_runs=5, completed_runs=2, partial=True)
+        d = rr.to_dict()
+        assert d["partial"] is True
+        assert d["completed_runs"] == 2
+
+
+class TestRunRepeatedBenchmark:
+    def test_repeat_three_times(self):
+        args = _make_args(repeat=3, repeat_delay=0.0)
+        mock_results = [
+            (_make_result_dict(10.0), None),
+            (_make_result_dict(12.0), None),
+            (_make_result_dict(11.0), None),
+        ]
+        call_count = 0
+
+        async def fake_run(a, b):
+            nonlocal call_count
+            r = mock_results[call_count]
+            call_count += 1
+            return r
+
+        with patch("xpyd_bench.bench.runner.run_benchmark", side_effect=fake_run):
+            rr = asyncio.run(run_repeated_benchmark(args, "http://localhost:8000"))
+
+        assert rr.completed_runs == 3
+        assert rr.num_runs == 3
+        assert not rr.partial
+        assert rr.aggregate is not None
+        assert rr.aggregate.num_runs == 3
+
+    def test_repeat_with_delay(self):
+        args = _make_args(repeat=2, repeat_delay=0.1)
+        mock_results = [
+            (_make_result_dict(10.0), None),
+            (_make_result_dict(12.0), None),
+        ]
+        call_count = 0
+
+        async def fake_run(a, b):
+            nonlocal call_count
+            r = mock_results[call_count]
+            call_count += 1
+            return r
+
+        with patch("xpyd_bench.bench.runner.run_benchmark", side_effect=fake_run):
+            start = time.monotonic()
+            rr = asyncio.run(run_repeated_benchmark(args, "http://localhost:8000"))
+            elapsed = time.monotonic() - start
+
+        assert rr.completed_runs == 2
+        assert elapsed >= 0.08
+
+    def test_single_run_no_aggregate(self):
+        args = _make_args(repeat=1)
+
+        async def fake_run(a, b):
+            return (_make_result_dict(), None)
+
+        with patch("xpyd_bench.bench.runner.run_benchmark", side_effect=fake_run):
+            rr = asyncio.run(run_repeated_benchmark(args, "http://localhost:8000"))
+
+        assert rr.completed_runs == 1
+        assert rr.aggregate is None
+
+
+class TestPrintRepeatSummary:
+    def test_prints_without_error(self, capsys):
+        rr = RepeatResult(num_runs=2, completed_runs=2)
+        rr.per_run_results = [_make_result_dict(10.0), _make_result_dict(12.0)]
+        from xpyd_bench.aggregate import aggregate_results
+
+        rr.aggregate = aggregate_results(rr.per_run_results)
+        print_repeat_summary(rr)
+        out = capsys.readouterr().out
+        assert "Repeat Summary" in out
+        assert "2/2 runs" in out
+
+    def test_prints_partial(self, capsys):
+        rr = RepeatResult(num_runs=5, completed_runs=1, partial=True)
+        rr.per_run_results = [_make_result_dict()]
+        print_repeat_summary(rr)
+        out = capsys.readouterr().out
+        assert "Interrupted" in out
+
+
+class TestCLIArgs:
+    def test_repeat_arg_parsed(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--repeat", "5", "--repeat-delay", "2.5"])
+        assert args.repeat == 5
+        assert args.repeat_delay == 2.5
+
+    def test_repeat_default(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        assert args.repeat == 1
+        assert args.repeat_delay == 0.0
+
+
+class TestYAMLConfig:
+    def test_repeat_in_known_keys(self):
+        from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+        assert "repeat" in _KNOWN_KEYS
+        assert "repeat_delay" in _KNOWN_KEYS


### PR DESCRIPTION
## Summary
Add the missing `repeat.py` module and `test_repeat.py` that complete the Benchmark Repeat Mode feature. The CLI args (`--repeat`, `--repeat-delay`) and YAML config keys were already added in a prior commit but the implementation module was never created.

## Changes
- `src/xpyd_bench/repeat.py`: `RepeatResult` dataclass, `run_repeated_benchmark()` async orchestrator, `print_repeat_summary()` terminal output
- `tests/test_repeat.py`: 10 tests covering repeat execution, delay, aggregation, CLI parsing, YAML config
- `ROADMAP.md`: Fix duplicate M49 numbering → rename Repeat Mode to M50

## Test Results
- All 918 tests pass (including 10 new tests)
- `ruff check` and `isort --check` clean

Closes #156