### PR TITLE
feat(m52): add request priority & queuing

### DIFF
--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -22,6 +22,7 @@ class RequestResult:
     request_id: str | None = None
     response_text: str | None = None
     validation_errors: list[str] = field(default_factory=list)
+    priority: int | None = None
 
 
 @dataclass
@@ -99,3 +100,6 @@ class BenchmarkResult:
 
     # Warmup profiling results (M51)
     warmup_profile: dict | None = None
+
+    # Priority metrics breakdown (M52)
+    priority_metrics: dict | None = None

--- a/src/xpyd_bench/bench/priority.py
+++ b/src/xpyd_bench/bench/priority.py
@@ -1,0 +1,137 @@
+"""Request priority scheduling and per-priority metrics (M52)."""
+
+from __future__ import annotations
+
+import asyncio
+import heapq
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(order=True)
+class PrioritizedItem:
+    """Wrapper for priority queue ordering. Lower priority value = higher priority."""
+
+    priority: int
+    sequence: int  # tie-breaker for FIFO within same priority
+    item: Any = field(compare=False)
+
+
+class PriorityScheduler:
+    """Async priority queue that dispatches higher-priority requests first.
+
+    Priority 0 is highest. Items are dispatched in priority order,
+    with FIFO ordering within the same priority level.
+    """
+
+    def __init__(self, num_levels: int = 10) -> None:
+        self._num_levels = num_levels
+        self._heap: list[PrioritizedItem] = []
+        self._seq = 0
+        self._event = asyncio.Event()
+
+    @property
+    def num_levels(self) -> int:
+        return self._num_levels
+
+    def put(self, item: Any, priority: int = 0) -> None:
+        """Add an item with given priority (0 = highest)."""
+        priority = max(0, min(priority, self._num_levels - 1))
+        heapq.heappush(self._heap, PrioritizedItem(priority, self._seq, item))
+        self._seq += 1
+        self._event.set()
+
+    async def get(self) -> tuple[int, Any]:
+        """Get the highest-priority item. Returns (priority, item)."""
+        while not self._heap:
+            self._event.clear()
+            await self._event.wait()
+        entry = heapq.heappop(self._heap)
+        if not self._heap:
+            self._event.clear()
+        return entry.priority, entry.item
+
+    def get_nowait(self) -> tuple[int, Any] | None:
+        """Get highest-priority item without waiting. Returns None if empty."""
+        if not self._heap:
+            return None
+        entry = heapq.heappop(self._heap)
+        if not self._heap:
+            self._event.clear()
+        return entry.priority, entry.item
+
+    def empty(self) -> bool:
+        return len(self._heap) == 0
+
+    def qsize(self) -> int:
+        return len(self._heap)
+
+
+def compute_priority_metrics(
+    requests: list[Any],
+    num_levels: int,
+) -> dict[str, Any]:
+    """Compute per-priority-level metrics breakdown.
+
+    Args:
+        requests: List of RequestResult objects with ``priority`` field.
+        num_levels: Number of priority levels configured.
+
+    Returns:
+        Dict with per-level metrics and summary.
+    """
+    from xpyd_bench.bench.models import RequestResult
+
+    # Group by priority
+    by_level: dict[int, list[RequestResult]] = {}
+    for r in requests:
+        p = r.priority if r.priority is not None else 0
+        by_level.setdefault(p, []).append(r)
+
+    levels: dict[str, Any] = {}
+    for level in sorted(by_level.keys()):
+        reqs = by_level[level]
+        successes = [r for r in reqs if r.success]
+        failures = [r for r in reqs if not r.success]
+        latencies = [r.latency_ms for r in successes]
+
+        level_metrics: dict[str, Any] = {
+            "total": len(reqs),
+            "completed": len(successes),
+            "failed": len(failures),
+            "error_rate": round(len(failures) / len(reqs), 4) if reqs else 0.0,
+        }
+
+        if latencies:
+            arr = np.array(latencies)
+            level_metrics["mean_latency_ms"] = round(float(np.mean(arr)), 2)
+            level_metrics["p50_latency_ms"] = round(float(np.percentile(arr, 50)), 2)
+            level_metrics["p90_latency_ms"] = round(float(np.percentile(arr, 90)), 2)
+            level_metrics["p95_latency_ms"] = round(float(np.percentile(arr, 95)), 2)
+            level_metrics["p99_latency_ms"] = round(float(np.percentile(arr, 99)), 2)
+
+            ttfts = [r.ttft_ms for r in successes if r.ttft_ms is not None]
+            if ttfts:
+                tarr = np.array(ttfts)
+                level_metrics["mean_ttft_ms"] = round(float(np.mean(tarr)), 2)
+                level_metrics["p99_ttft_ms"] = round(float(np.percentile(tarr, 99)), 2)
+
+            total_output = sum(r.completion_tokens for r in successes)
+            total_dur = sum(r.latency_ms for r in successes) / 1000.0
+            if total_dur > 0:
+                level_metrics["throughput_tok_s"] = round(total_output / total_dur, 2)
+        else:
+            level_metrics["mean_latency_ms"] = None
+            level_metrics["p50_latency_ms"] = None
+            level_metrics["p90_latency_ms"] = None
+            level_metrics["p95_latency_ms"] = None
+            level_metrics["p99_latency_ms"] = None
+
+        levels[str(level)] = level_metrics
+
+    return {
+        "num_levels": num_levels,
+        "levels": levels,
+    }

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -557,6 +557,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         )
         validate_and_report(entries, dataset_path, tokenizer=getattr(args, "tokenizer", None))
         prompts = [e.prompt for e in entries]
+        prompt_priorities = [e.priority for e in entries]
         # Override num_prompts to match actual dataset size
         args.num_prompts = len(prompts)
     else:
@@ -586,9 +587,11 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
                 entries, f"synthetic ({dataset_name})", tokenizer=tokenizer_arg
             )
             prompts = [e.prompt for e in entries]
+            prompt_priorities = [e.priority for e in entries]
             args.num_prompts = len(prompts)
         else:
             prompts = _generate_random_prompts(args.num_prompts, args.input_len, args.seed)
+            prompt_priorities = [None] * args.num_prompts
 
     # Apply template variable substitution (M37)
     template_vars_path = getattr(args, "template_vars", None)
@@ -794,7 +797,9 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         if not args.disable_tqdm:
             print(f"Metrics WebSocket server started on ws://0.0.0.0:{ws_port}/metrics")
 
-    async def _tracked_task(client: httpx.AsyncClient, prompt: str) -> RequestResult:
+    async def _tracked_task(
+        client: httpx.AsyncClient, prompt: str, priority: int | None = None,
+    ) -> RequestResult:
         payload = _mk_payload(prompt)
         r = await _task(client, prompt)
         if debug_logger:
@@ -821,6 +826,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
                 prompt_tokens=r.prompt_tokens,
                 completion_tokens=r.completion_tokens,
             )
+        r.priority = priority
         return r
 
     grace_period = getattr(args, "shutdown_grace_period", 5.0) or 5.0
@@ -846,6 +852,26 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         i = 0
         deadline = (overall_start + duration_limit) if duration_limit else None
 
+        # Priority scheduling (M52) — sort prompts by priority before dispatch
+        priority_levels = getattr(args, "priority_levels", 0) or 0
+        if priority_levels > 0 and not duration_limit:
+            # Build (priority, original_index) pairs and sort by priority (0=highest)
+            indexed = list(range(len(prompts)))
+            pri_list = [
+                (
+                    prompt_priorities[j]
+                    if prompt_priorities[j] is not None
+                    else priority_levels - 1,
+                    j,
+                )
+                for j in indexed
+            ]
+            pri_list.sort(key=lambda x: x[0])
+            sorted_prompts = [prompts[j] for _, j in pri_list]
+            sorted_priorities = [p for p, _ in pri_list]
+            prompts = sorted_prompts
+            prompt_priorities = sorted_priorities
+
         while True:
             if shutdown_requested:
                 break
@@ -859,6 +885,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
                 break
 
             prompt = prompts[i % prompt_count]
+            prompt_pri = prompt_priorities[i % prompt_count] if prompt_priorities else None
 
             if i > 0:
                 interval_idx = i if i < len(intervals) else i % len(intervals)
@@ -870,7 +897,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
                     break
                 if deadline and time.perf_counter() >= deadline:
                     break
-            task = asyncio.create_task(_tracked_task(client, prompt))
+            task = asyncio.create_task(_tracked_task(client, prompt, priority=prompt_pri))
             tasks.append(task)
 
             if not reporter and not args.disable_tqdm and (i + 1) % 100 == 0:
@@ -934,6 +961,14 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         anomaly_result = detect_anomalies(latencies, multiplier=anomaly_threshold)
         if anomaly_result is not None and anomaly_result.count > 0:
             result.anomalies = anomaly_result.to_dict()
+
+    # Priority metrics breakdown (M52)
+    if priority_levels > 0 and result.requests:
+        from xpyd_bench.bench.priority import compute_priority_metrics
+
+        result.priority_metrics = compute_priority_metrics(
+            result.requests, priority_levels,
+        )
 
     # Response validation (M47)
     validators_specs = getattr(args, "validate_response", None) or []
@@ -1153,4 +1188,6 @@ def _to_dict(r: BenchmarkResult) -> dict:
         d["anomalies"] = r.anomalies
     if r.warmup_profile:
         d["warmup_profile"] = r.warmup_profile
+    if r.priority_metrics:
+        d["priority_metrics"] = r.priority_metrics
     return d

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -393,6 +393,16 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="IQR multiplier for latency anomaly detection (default: 1.5, 0 disables).",
     )
 
+    # Request priority (M52)
+    parser.add_argument(
+        "--priority-levels",
+        type=int,
+        default=0,
+        dest="priority_levels",
+        help="Number of priority levels for request scheduling (0 disables, default: 0). "
+        "Levels range from 0 (highest) to N-1 (lowest).",
+    )
+
     # Response validation (M47)
     parser.add_argument(
         "--validate-response",

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -102,6 +102,7 @@ _KNOWN_KEYS: set[str] = {
     "junit_xml",
     "repeat",
     "repeat_delay",
+    "priority_levels",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/src/xpyd_bench/datasets/loader.py
+++ b/src/xpyd_bench/datasets/loader.py
@@ -29,6 +29,7 @@ class DatasetEntry:
 
     prompt: str
     output_len: int | None = None
+    priority: int | None = None
 
 
 def _estimate_tokens(text: str, tokenizer: str | None = None) -> int:
@@ -93,7 +94,10 @@ def _parse_record(record: dict[str, Any], index: int, source: str) -> DatasetEnt
     output_len = record.get("output_len") or record.get("max_tokens")
     if output_len is not None:
         output_len = int(output_len)
-    return DatasetEntry(prompt=str(prompt), output_len=output_len)
+    priority = record.get("priority")
+    if priority is not None:
+        priority = int(priority)
+    return DatasetEntry(prompt=str(prompt), output_len=output_len, priority=priority)
 
 
 def load_jsonl(path: Path) -> list[DatasetEntry]:

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -1,0 +1,289 @@
+"""Tests for M52: Request Priority & Queuing."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_bench.bench.models import BenchmarkResult, RequestResult
+from xpyd_bench.bench.priority import (
+    PriorityScheduler,
+    compute_priority_metrics,
+)
+
+# ---------------------------------------------------------------------------
+# PriorityScheduler tests
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityScheduler:
+    """Test the async priority queue."""
+
+    def test_basic_ordering(self):
+        """Items are dequeued in priority order (0 = highest)."""
+        scheduler = PriorityScheduler(num_levels=5)
+        scheduler.put("low", priority=4)
+        scheduler.put("high", priority=0)
+        scheduler.put("mid", priority=2)
+
+        items = []
+        while not scheduler.empty():
+            entry = scheduler.get_nowait()
+            assert entry is not None
+            items.append(entry)
+
+        assert [p for p, _ in items] == [0, 2, 4]
+        assert [v for _, v in items] == ["high", "mid", "low"]
+
+    def test_fifo_within_same_priority(self):
+        """Items with the same priority are returned FIFO."""
+        scheduler = PriorityScheduler(num_levels=3)
+        scheduler.put("first", priority=1)
+        scheduler.put("second", priority=1)
+        scheduler.put("third", priority=1)
+
+        items = []
+        while not scheduler.empty():
+            entry = scheduler.get_nowait()
+            assert entry is not None
+            items.append(entry[1])
+
+        assert items == ["first", "second", "third"]
+
+    def test_priority_clamped(self):
+        """Priority is clamped to valid range."""
+        scheduler = PriorityScheduler(num_levels=3)
+        scheduler.put("over", priority=10)  # clamped to 2
+        scheduler.put("under", priority=-5)  # clamped to 0
+
+        items = []
+        while not scheduler.empty():
+            entry = scheduler.get_nowait()
+            assert entry is not None
+            items.append((entry[0], entry[1]))
+
+        assert items == [(0, "under"), (2, "over")]
+
+    def test_empty(self):
+        scheduler = PriorityScheduler(num_levels=3)
+        assert scheduler.empty()
+        assert scheduler.qsize() == 0
+        assert scheduler.get_nowait() is None
+
+    @pytest.mark.asyncio
+    async def test_async_get(self):
+        """Async get waits for items."""
+        scheduler = PriorityScheduler(num_levels=3)
+
+        async def producer():
+            await asyncio.sleep(0.01)
+            scheduler.put("item", priority=1)
+
+        asyncio.create_task(producer())
+        priority, item = await asyncio.wait_for(
+            scheduler.get(), timeout=1.0,
+        )
+        assert item == "item"
+        assert priority == 1
+
+
+# ---------------------------------------------------------------------------
+# compute_priority_metrics tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputePriorityMetrics:
+    """Test per-priority metrics computation."""
+
+    def test_basic_metrics(self):
+        """Verify per-level metric breakdown."""
+        requests = [
+            RequestResult(
+                latency_ms=100.0, success=True, priority=0,
+                completion_tokens=10, prompt_tokens=5,
+            ),
+            RequestResult(
+                latency_ms=120.0, success=True, priority=0,
+                completion_tokens=12, prompt_tokens=5,
+            ),
+            RequestResult(
+                latency_ms=200.0, success=True, priority=1,
+                completion_tokens=8, prompt_tokens=5,
+            ),
+            RequestResult(
+                latency_ms=250.0, success=False, priority=1,
+                error="timeout",
+            ),
+        ]
+
+        result = compute_priority_metrics(requests, num_levels=2)
+        assert result["num_levels"] == 2
+        assert "0" in result["levels"]
+        assert "1" in result["levels"]
+
+        lvl0 = result["levels"]["0"]
+        assert lvl0["total"] == 2
+        assert lvl0["completed"] == 2
+        assert lvl0["failed"] == 0
+        assert lvl0["error_rate"] == 0.0
+        assert lvl0["mean_latency_ms"] == 110.0
+
+        lvl1 = result["levels"]["1"]
+        assert lvl1["total"] == 2
+        assert lvl1["completed"] == 1
+        assert lvl1["failed"] == 1
+        assert lvl1["error_rate"] == 0.5
+
+    def test_none_priority_defaults_to_zero(self):
+        """Requests with no priority default to level 0."""
+        requests = [
+            RequestResult(
+                latency_ms=50.0, success=True, priority=None,
+                completion_tokens=5, prompt_tokens=5,
+            ),
+        ]
+        result = compute_priority_metrics(requests, num_levels=3)
+        assert "0" in result["levels"]
+        assert result["levels"]["0"]["total"] == 1
+
+    def test_empty_requests(self):
+        """Empty requests produce empty levels."""
+        result = compute_priority_metrics([], num_levels=3)
+        assert result["num_levels"] == 3
+        assert result["levels"] == {}
+
+    def test_all_failed(self):
+        """All-failed level has None latencies."""
+        requests = [
+            RequestResult(
+                latency_ms=0.0, success=False, priority=0, error="fail",
+            ),
+        ]
+        result = compute_priority_metrics(requests, num_levels=2)
+        lvl0 = result["levels"]["0"]
+        assert lvl0["completed"] == 0
+        assert lvl0["failed"] == 1
+        assert lvl0["mean_latency_ms"] is None
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityCLI:
+    """Test --priority-levels CLI argument parsing."""
+
+    def test_cli_arg_default(self):
+        """Default priority_levels is 0."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        assert args.priority_levels == 0
+
+    def test_cli_arg_set(self):
+        """--priority-levels sets the value."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--priority-levels", "5"])
+        assert args.priority_levels == 5
+
+
+# ---------------------------------------------------------------------------
+# Dataset priority field tests
+# ---------------------------------------------------------------------------
+
+
+class TestDatasetPriority:
+    """Test priority field in dataset loading."""
+
+    def test_jsonl_with_priority(self, tmp_path: Path):
+        """JSONL entries with priority field are loaded correctly."""
+        from xpyd_bench.datasets.loader import load_jsonl
+
+        jsonl_file = tmp_path / "data.jsonl"
+        jsonl_file.write_text(
+            '{"prompt": "hello", "priority": 0}\n'
+            '{"prompt": "world", "priority": 2}\n'
+            '{"prompt": "test"}\n'
+        )
+        entries = load_jsonl(jsonl_file)
+        assert len(entries) == 3
+        assert entries[0].priority == 0
+        assert entries[1].priority == 2
+        assert entries[2].priority is None
+
+    def test_json_with_priority(self, tmp_path: Path):
+        """JSON array entries with priority field."""
+        from xpyd_bench.datasets.loader import load_json
+
+        json_file = tmp_path / "data.json"
+        json_file.write_text(json.dumps([
+            {"prompt": "a", "priority": 1},
+            {"prompt": "b", "priority": 0},
+        ]))
+        entries = load_json(json_file)
+        assert entries[0].priority == 1
+        assert entries[1].priority == 0
+
+
+# ---------------------------------------------------------------------------
+# YAML config tests
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityYAMLConfig:
+    """Test priority_levels in YAML config."""
+
+    def test_yaml_config_known_key(self):
+        """priority_levels is a known YAML config key."""
+        from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+        assert "priority_levels" in _KNOWN_KEYS
+
+
+# ---------------------------------------------------------------------------
+# RequestResult priority field tests
+# ---------------------------------------------------------------------------
+
+
+class TestRequestResultPriority:
+    """Test priority field on RequestResult."""
+
+    def test_default_none(self):
+        r = RequestResult()
+        assert r.priority is None
+
+    def test_set_priority(self):
+        r = RequestResult(priority=3)
+        assert r.priority == 3
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkResult priority_metrics field tests
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkResultPriorityMetrics:
+    """Test priority_metrics field on BenchmarkResult."""
+
+    def test_default_none(self):
+        r = BenchmarkResult()
+        assert r.priority_metrics is None
+
+    def test_set_priority_metrics(self):
+        r = BenchmarkResult(
+            priority_metrics={"num_levels": 3, "levels": {}},
+        )
+        assert r.priority_metrics["num_levels"] == 3


### PR DESCRIPTION
## Summary

Implements **M52: Request Priority & Queuing** from the roadmap.

### Changes

- **`src/xpyd_bench/bench/priority.py`** (new): `PriorityScheduler` async priority queue and `compute_priority_metrics()` for per-level metrics breakdown
- **`src/xpyd_bench/bench/models.py`**: Added `priority` field to `RequestResult`, `priority_metrics` to `BenchmarkResult`
- **`src/xpyd_bench/datasets/loader.py`**: Added `priority` field to `DatasetEntry`, parsed from JSONL/JSON datasets
- **`src/xpyd_bench/cli.py`**: Added `--priority-levels N` CLI flag
- **`src/xpyd_bench/bench/runner.py`**: Priority-aware dispatch (sort by priority before scheduling), per-priority metrics computation, priority tracking on results
- **`src/xpyd_bench/config_cmd.py`**: Added `priority_levels` to known YAML config keys
- **`tests/test_priority.py`** (new): 18 tests covering scheduler, metrics, CLI, dataset, config

### Features
- `--priority-levels N` CLI flag (0 disables, default 0)
- Priority field in JSONL dataset: `{"prompt": "...", "priority": 0}`
- Priority 0 = highest, N-1 = lowest
- Prompts sorted by priority before dispatch (higher priority sent first)
- Per-priority metrics: latency percentiles, throughput, error rate
- YAML config support (`priority_levels: N`)

### Testing
- 18 new tests, all 954 tests pass
- Lint clean (ruff + isort)

Closes #161