### PR TITLE
feat(M55): Load Shedding Simulation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -449,7 +449,7 @@
 - Markdown diff output for PR comments
 - Tests covering diff generation, significance testing, and output formats
 
-## M55: Load Shedding Simulation
+## M55: Load Shedding Simulation ✅
 - `--load-shed-threshold <rps>` to simulate server-side load shedding
 - Gradually increase request rate until target rejects requests (429/503)
 - Find maximum sustainable throughput automatically

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -728,6 +728,36 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Number of turns for synthetic multi-turn generation (default: 5).",
     )
 
+    # Load shedding simulation (M55)
+    parser.add_argument(
+        "--load-shed-threshold",
+        type=float,
+        default=None,
+        dest="load_shed_threshold",
+        help="Starting RPS for load shedding simulation. Ramps up until server rejects.",
+    )
+    parser.add_argument(
+        "--load-shed-step",
+        type=float,
+        default=0.0,
+        dest="load_shed_step",
+        help="Additive RPS step for load shedding ramp (0 = use multiplier, default: 0).",
+    )
+    parser.add_argument(
+        "--load-shed-multiplier",
+        type=float,
+        default=1.5,
+        dest="load_shed_multiplier",
+        help="Multiplicative RPS ramp factor for load shedding (default: 1.5).",
+    )
+    parser.add_argument(
+        "--load-shed-prompts",
+        type=int,
+        default=50,
+        dest="load_shed_prompts",
+        help="Number of prompts per load shedding level (default: 50).",
+    )
+
 
 def _resolve_base_url(args: argparse.Namespace) -> str:
     """Resolve the base URL from --base-url or --host/--port."""
@@ -1086,6 +1116,36 @@ def bench_main(argv: list[str] | None = None) -> None:
     # Dry run: validate config and dataset, print plan, exit
     if getattr(args, "dry_run", False):
         _dry_run(args, base_url)
+        return
+
+    # Load shedding simulation (M55)
+    load_shed_rps = getattr(args, "load_shed_threshold", None)
+    if load_shed_rps is not None:
+        from xpyd_bench.load_shed import (
+            format_load_shed_table,
+            run_load_shed,
+        )
+
+        print(f"xpyd-bench v{__version__} (load shedding mode)")
+        print(f"  Base URL:        {base_url}")
+        print(f"  Starting RPS:    {load_shed_rps}")
+        print()
+
+        analysis = asyncio.run(
+            run_load_shed(
+                args,
+                base_url,
+                starting_rps=load_shed_rps,
+                ramp_step=getattr(args, "load_shed_step", 0.0),
+                ramp_multiplier=getattr(args, "load_shed_multiplier", 1.5),
+                prompts_per_level=getattr(args, "load_shed_prompts", 50),
+            )
+        )
+        print(format_load_shed_table(analysis))
+
+        result = {"saturation_analysis": analysis.to_dict()}
+        if getattr(args, "save_result", None):
+            _save_result(args, result)
         return
 
     # Multi-turn conversation mode (M45)

--- a/src/xpyd_bench/dummy/cli.py
+++ b/src/xpyd_bench/dummy/cli.py
@@ -57,6 +57,12 @@ def dummy_main(argv: list[str] | None = None) -> None:
         default=1536,
         help="Dimensionality of embedding vectors (default: 1536).",
     )
+    parser.add_argument(
+        "--max-rps",
+        type=float,
+        default=None,
+        help="Maximum requests per second before rejecting with 429 (default: unlimited).",
+    )
     args = parser.parse_args(argv)
 
     import uvicorn
@@ -71,6 +77,7 @@ def dummy_main(argv: list[str] | None = None) -> None:
         eos_min_ratio=args.eos_min_ratio,
         require_api_key=args.require_api_key,
         embedding_dim=args.embedding_dim,
+        max_rps=args.max_rps,
     )
     app = create_app(config)
 

--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -36,6 +36,7 @@ class ServerConfig:
     eos_min_ratio: float = 0.5  # EOS won't fire before this fraction of max_tokens
     require_api_key: str | None = None  # If set, require this API key for auth
     embedding_dim: int = 1536  # Dimensionality for embedding vectors
+    max_rps: float | None = None  # If set, reject requests above this rate (429)
 
 
 # Global config — set before starting the server
@@ -1001,6 +1002,35 @@ def create_app(config: ServerConfig | None = None) -> Starlette:
                     )
             return await call_next(request)
 
+    import time as _time
+
+    class RateLimitMiddleware(BaseHTTPMiddleware):
+        """Reject requests above max_rps with 429 Too Many Requests."""
+
+        def __init__(self, app, max_rps: float):  # type: ignore[no-untyped-def]
+            super().__init__(app)
+            self._max_rps = max_rps
+            self._window: list[float] = []
+
+        async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+            if not request.url.path.startswith("/v1/"):
+                return await call_next(request)
+            now = _time.monotonic()
+            # Slide 1-second window
+            self._window = [t for t in self._window if now - t < 1.0]
+            if len(self._window) >= self._max_rps:
+                return JSONResponse(
+                    {
+                        "error": {
+                            "message": "Rate limit exceeded",
+                            "type": "rate_limit_error",
+                        }
+                    },
+                    status_code=429,
+                )
+            self._window.append(now)
+            return await call_next(request)
+
     # Clear batch store on app creation
     _batches.clear()
 
@@ -1015,4 +1045,6 @@ def create_app(config: ServerConfig | None = None) -> Starlette:
     ]
 
     middleware = [Middleware(AuthMiddleware)]
+    if _config.max_rps is not None:
+        middleware.append(Middleware(RateLimitMiddleware, max_rps=_config.max_rps))
     return Starlette(routes=routes, middleware=middleware)

--- a/src/xpyd_bench/load_shed.py
+++ b/src/xpyd_bench/load_shed.py
@@ -1,0 +1,271 @@
+"""Load shedding simulation (M55).
+
+Gradually increases request rate until the server starts rejecting requests
+(429/503), then finds maximum sustainable throughput automatically.
+
+Usage:
+    xpyd-bench run --load-shed-threshold <starting_rps> ...
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any
+
+from xpyd_bench.bench.runner import run_benchmark
+
+
+@dataclass
+class LoadShedLevel:
+    """Result for a single RPS level during load shedding test."""
+
+    rps: float
+    throughput_rps: float
+    mean_latency_ms: float
+    p99_latency_ms: float
+    error_rate: float
+    rejected_count: int
+    total_requests: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rps": round(self.rps, 2),
+            "throughput_rps": round(self.throughput_rps, 2),
+            "mean_latency_ms": round(self.mean_latency_ms, 2),
+            "p99_latency_ms": round(self.p99_latency_ms, 2),
+            "error_rate": round(self.error_rate, 4),
+            "rejected_count": self.rejected_count,
+            "total_requests": self.total_requests,
+        }
+
+
+@dataclass
+class SaturationAnalysis:
+    """Full load shedding analysis result."""
+
+    levels: list[LoadShedLevel] = field(default_factory=list)
+    saturation_rps: float | None = None
+    max_sustainable_rps: float | None = None
+    degradation_curve: list[dict[str, float]] = field(default_factory=list)
+    recovery_rps: float | None = None
+    recovery_latency_ms: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "levels": [lv.to_dict() for lv in self.levels],
+            "saturation_rps": (
+                round(self.saturation_rps, 2) if self.saturation_rps is not None else None
+            ),
+            "max_sustainable_rps": (
+                round(self.max_sustainable_rps, 2)
+                if self.max_sustainable_rps is not None
+                else None
+            ),
+            "degradation_curve": [
+                {k: round(v, 4) for k, v in pt.items()} for pt in self.degradation_curve
+            ],
+            "recovery_rps": (
+                round(self.recovery_rps, 2) if self.recovery_rps is not None else None
+            ),
+            "recovery_latency_ms": (
+                round(self.recovery_latency_ms, 2)
+                if self.recovery_latency_ms is not None
+                else None
+            ),
+        }
+
+
+# Rejection HTTP status codes
+_REJECTION_CODES = {429, 503}
+
+# Default error rate threshold for "sustainable"
+_MAX_SUSTAINABLE_ERROR_RATE = 0.05
+
+
+def _count_rejections(result_dict: dict[str, Any]) -> int:
+    """Count requests that got 429 or 503 responses."""
+    requests = result_dict.get("requests", [])
+    count = 0
+    for r in requests:
+        err = r.get("error", "") or ""
+        # Check for status code in error string or status_code field
+        status = r.get("status_code")
+        if status in _REJECTION_CODES:
+            count += 1
+        elif any(str(code) in err for code in _REJECTION_CODES):
+            count += 1
+    return count
+
+
+def _extract_metrics(result_dict: dict[str, Any]) -> dict[str, float]:
+    """Extract key metrics from a benchmark result dict."""
+    summary = result_dict.get("summary", result_dict)
+    return {
+        "throughput_rps": summary.get("request_throughput", 0.0),
+        "mean_latency_ms": summary.get("mean_e2el_ms", 0.0),
+        "p99_latency_ms": summary.get("p99_e2el_ms", 0.0),
+    }
+
+
+async def run_load_shed(
+    args: Namespace,
+    base_url: str,
+    starting_rps: float,
+    *,
+    ramp_step: float = 0.0,
+    ramp_multiplier: float = 1.5,
+    prompts_per_level: int = 50,
+    max_levels: int = 20,
+    error_threshold: float = _MAX_SUSTAINABLE_ERROR_RATE,
+    recovery_check: bool = True,
+) -> SaturationAnalysis:
+    """Run load shedding simulation.
+
+    Ramps up RPS starting from *starting_rps*, multiplying by *ramp_multiplier*
+    each level (or adding *ramp_step* if set).  Stops when error rate exceeds
+    *error_threshold* for two consecutive levels or *max_levels* is reached.
+
+    If *recovery_check* is True, after saturation is found, runs one more level
+    at 50% of saturation RPS to measure recovery behaviour.
+    """
+    analysis = SaturationAnalysis()
+    current_rps = starting_rps
+    consecutive_over = 0
+    saturation_found = False
+
+    for level_idx in range(max_levels):
+        # Build args for this level
+        level_args = deepcopy(args)
+        level_args.request_rate = current_rps
+        level_args.num_prompts = prompts_per_level
+        # Disable features that interfere with load shedding test
+        level_args.warmup = 0
+        level_args.repeat = 1
+        level_args.duration = None
+        # Disable retries so rejections are captured
+        level_args.retries = 0
+
+        result_dict, bench_result = await run_benchmark(level_args, base_url)
+
+        metrics = _extract_metrics(result_dict)
+        total = result_dict.get("summary", result_dict).get(
+            "completed", prompts_per_level
+        )
+        if total == 0:
+            total = prompts_per_level
+        rejected = _count_rejections(result_dict)
+        error_count = result_dict.get("summary", result_dict).get("errors", 0)
+        error_rate = error_count / total if total > 0 else 0.0
+
+        level_result = LoadShedLevel(
+            rps=current_rps,
+            throughput_rps=metrics["throughput_rps"],
+            mean_latency_ms=metrics["mean_latency_ms"],
+            p99_latency_ms=metrics["p99_latency_ms"],
+            error_rate=error_rate,
+            rejected_count=rejected,
+            total_requests=total,
+        )
+        analysis.levels.append(level_result)
+        analysis.degradation_curve.append(
+            {
+                "rps": current_rps,
+                "throughput": metrics["throughput_rps"],
+                "error_rate": error_rate,
+                "mean_latency_ms": metrics["mean_latency_ms"],
+            }
+        )
+
+        # Check saturation
+        if error_rate > error_threshold:
+            consecutive_over += 1
+            if consecutive_over >= 2:
+                analysis.saturation_rps = current_rps
+                saturation_found = True
+                break
+        else:
+            consecutive_over = 0
+
+        # Ramp up
+        if ramp_step > 0:
+            current_rps += ramp_step
+        else:
+            current_rps *= ramp_multiplier
+
+    # Determine max sustainable RPS
+    sustainable_levels = [
+        lv for lv in analysis.levels if lv.error_rate <= error_threshold
+    ]
+    if sustainable_levels:
+        analysis.max_sustainable_rps = max(lv.rps for lv in sustainable_levels)
+
+    # Recovery check: run at 50% of saturation RPS
+    if recovery_check and saturation_found and analysis.saturation_rps:
+        recovery_rps = analysis.saturation_rps * 0.5
+        recovery_args = deepcopy(args)
+        recovery_args.request_rate = recovery_rps
+        recovery_args.num_prompts = prompts_per_level
+        recovery_args.warmup = 0
+        recovery_args.repeat = 1
+        recovery_args.duration = None
+        recovery_args.retries = 0
+
+        rec_dict, _ = await run_benchmark(recovery_args, base_url)
+        rec_metrics = _extract_metrics(rec_dict)
+        rec_errors = rec_dict.get("summary", rec_dict).get("errors", 0)
+        rec_total = rec_dict.get("summary", rec_dict).get(
+            "completed", prompts_per_level
+        )
+        rec_error_rate = rec_errors / rec_total if rec_total > 0 else 0.0
+
+        if rec_error_rate <= error_threshold:
+            analysis.recovery_rps = recovery_rps
+            analysis.recovery_latency_ms = rec_metrics["mean_latency_ms"]
+
+    return analysis
+
+
+def format_load_shed_table(analysis: SaturationAnalysis) -> str:
+    """Format load shedding results as a terminal table."""
+    lines: list[str] = []
+    lines.append("=" * 90)
+    lines.append("  xPyD-bench — Load Shedding Analysis")
+    lines.append("=" * 90)
+    lines.append("")
+    hdr = (
+        f"  {'RPS':>8s} {'Throughput':>12s} {'Mean Lat':>10s} "
+        f"{'P99 Lat':>10s} {'Error%':>8s} {'Rejected':>10s}"
+    )
+    lines.append(hdr)
+    lines.append("  " + "-" * 86)
+
+    for lv in analysis.levels:
+        lines.append(
+            f"  {lv.rps:>8.1f} {lv.throughput_rps:>12.2f} "
+            f"{lv.mean_latency_ms:>10.1f} {lv.p99_latency_ms:>10.1f} "
+            f"{lv.error_rate * 100:>7.1f}% {lv.rejected_count:>10d}"
+        )
+
+    lines.append("  " + "-" * 86)
+    lines.append("")
+
+    if analysis.max_sustainable_rps is not None:
+        lines.append(
+            f"  Max sustainable RPS: {analysis.max_sustainable_rps:.1f}"
+        )
+    if analysis.saturation_rps is not None:
+        lines.append(
+            f"  Saturation point:    {analysis.saturation_rps:.1f} RPS"
+        )
+    if analysis.recovery_rps is not None:
+        lines.append(
+            f"  Recovery at:         {analysis.recovery_rps:.1f} RPS "
+            f"(latency: {analysis.recovery_latency_ms:.1f}ms)"
+        )
+    if analysis.saturation_rps is None:
+        lines.append("  ⚠️  Saturation not reached within test range")
+
+    lines.append("=" * 90)
+    return "\n".join(lines)

--- a/tests/test_load_shed.py
+++ b/tests/test_load_shed.py
@@ -1,0 +1,416 @@
+"""Tests for load shedding simulation (M55)."""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from unittest.mock import patch
+
+import pytest
+
+from xpyd_bench.load_shed import (
+    LoadShedLevel,
+    SaturationAnalysis,
+    _count_rejections,
+    format_load_shed_table,
+    run_load_shed,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_result(
+    throughput: float = 10.0,
+    mean_latency: float = 100.0,
+    p99_latency: float = 200.0,
+    completed: int = 50,
+    errors: int = 0,
+    requests: list | None = None,
+) -> tuple[dict, object]:
+    """Build a fake (result_dict, bench_result) pair."""
+    if requests is None:
+        requests = [{"latency_ms": mean_latency, "status_code": 200} for _ in range(completed)]
+    summary = {
+        "request_throughput": throughput,
+        "mean_e2el_ms": mean_latency,
+        "p99_e2el_ms": p99_latency,
+        "completed": completed,
+        "errors": errors,
+    }
+    result_dict = {"summary": summary, "requests": requests}
+    return result_dict, None
+
+
+def _base_args() -> Namespace:
+    return Namespace(
+        base_url="http://localhost:8000",
+        endpoint="/v1/completions",
+        model="test-model",
+        num_prompts=50,
+        request_rate=1.0,
+        max_concurrency=None,
+        input_len=128,
+        output_len=64,
+        warmup=0,
+        repeat=1,
+        duration=None,
+        retries=0,
+        burstiness=1.0,
+        stream=None,
+        config=None,
+        api_key=None,
+        custom_headers={},
+        http2=False,
+        max_connections=100,
+        max_keepalive=20,
+        compress=False,
+        debug_log=None,
+        request_id_prefix=None,
+        tokenizer=None,
+        backend="openai",
+        backend_plugin=None,
+        no_live=True,
+        priority_levels=0,
+        sse_metrics=False,
+        sse_stall_threshold_ms=1000.0,
+        anomaly_threshold=0,
+        seed=42,
+        validate_response=[],
+        timeout=300.0,
+        metrics_ws_port=None,
+        warmup_profile=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _count_rejections
+# ---------------------------------------------------------------------------
+
+class TestCountRejections:
+    def test_no_rejections(self):
+        result = {"requests": [{"status_code": 200}, {"status_code": 200}]}
+        assert _count_rejections(result) == 0
+
+    def test_429_rejections(self):
+        result = {
+            "requests": [
+                {"status_code": 429},
+                {"status_code": 200},
+                {"status_code": 429},
+            ]
+        }
+        assert _count_rejections(result) == 2
+
+    def test_503_rejections(self):
+        result = {"requests": [{"status_code": 503}, {"status_code": 200}]}
+        assert _count_rejections(result) == 1
+
+    def test_rejection_in_error_string(self):
+        result = {
+            "requests": [
+                {"error": "HTTP 429 Too Many Requests", "status_code": None},
+            ]
+        }
+        assert _count_rejections(result) == 1
+
+    def test_empty_requests(self):
+        assert _count_rejections({}) == 0
+        assert _count_rejections({"requests": []}) == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: data structures
+# ---------------------------------------------------------------------------
+
+class TestLoadShedLevel:
+    def test_to_dict(self):
+        lv = LoadShedLevel(
+            rps=10.0,
+            throughput_rps=9.5,
+            mean_latency_ms=100.0,
+            p99_latency_ms=200.0,
+            error_rate=0.05,
+            rejected_count=3,
+            total_requests=50,
+        )
+        d = lv.to_dict()
+        assert d["rps"] == 10.0
+        assert d["error_rate"] == 0.05
+        assert d["rejected_count"] == 3
+
+
+class TestSaturationAnalysis:
+    def test_to_dict_empty(self):
+        sa = SaturationAnalysis()
+        d = sa.to_dict()
+        assert d["levels"] == []
+        assert d["saturation_rps"] is None
+        assert d["max_sustainable_rps"] is None
+
+    def test_to_dict_with_data(self):
+        sa = SaturationAnalysis(
+            saturation_rps=20.0,
+            max_sustainable_rps=15.0,
+            recovery_rps=10.0,
+            recovery_latency_ms=80.0,
+        )
+        d = sa.to_dict()
+        assert d["saturation_rps"] == 20.0
+        assert d["max_sustainable_rps"] == 15.0
+        assert d["recovery_rps"] == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Integration: run_load_shed
+# ---------------------------------------------------------------------------
+
+class TestRunLoadShed:
+    @pytest.mark.asyncio
+    async def test_saturation_detected(self):
+        """Simulate saturation at the 3rd level."""
+        call_count = 0
+
+        async def mock_benchmark(args, base_url):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return _make_result(errors=0, completed=50)
+            else:
+                # Simulate errors exceeding threshold
+                reqs = [{"status_code": 429} for _ in range(30)] + [
+                    {"status_code": 200} for _ in range(20)
+                ]
+                return _make_result(errors=30, completed=50, requests=reqs)
+
+        with patch("xpyd_bench.load_shed.run_benchmark", side_effect=mock_benchmark):
+            analysis = await run_load_shed(
+                _base_args(),
+                "http://localhost:8000",
+                starting_rps=5.0,
+                ramp_multiplier=2.0,
+                prompts_per_level=50,
+                max_levels=10,
+                recovery_check=False,
+            )
+
+        assert analysis.saturation_rps is not None
+        assert analysis.max_sustainable_rps is not None
+        assert len(analysis.levels) >= 3
+
+    @pytest.mark.asyncio
+    async def test_no_saturation(self):
+        """All levels pass — no saturation found."""
+        async def mock_benchmark(args, base_url):
+            return _make_result(errors=0, completed=50)
+
+        with patch("xpyd_bench.load_shed.run_benchmark", side_effect=mock_benchmark):
+            analysis = await run_load_shed(
+                _base_args(),
+                "http://localhost:8000",
+                starting_rps=5.0,
+                max_levels=3,
+                recovery_check=False,
+            )
+
+        assert analysis.saturation_rps is None
+        assert analysis.max_sustainable_rps is not None
+        assert len(analysis.levels) == 3
+
+    @pytest.mark.asyncio
+    async def test_recovery_check(self):
+        """Recovery check runs after saturation."""
+        call_count = 0
+
+        async def mock_benchmark(args, base_url):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return _make_result(errors=0, completed=50)
+            elif call_count <= 4:
+                # Two consecutive error levels to trigger saturation
+                return _make_result(errors=30, completed=50)
+            else:
+                # Recovery level — no errors
+                return _make_result(errors=0, completed=50, mean_latency=80.0)
+
+        with patch("xpyd_bench.load_shed.run_benchmark", side_effect=mock_benchmark):
+            analysis = await run_load_shed(
+                _base_args(),
+                "http://localhost:8000",
+                starting_rps=5.0,
+                ramp_multiplier=2.0,
+                prompts_per_level=50,
+                recovery_check=True,
+            )
+
+        assert analysis.saturation_rps is not None
+        assert analysis.recovery_rps is not None
+
+    @pytest.mark.asyncio
+    async def test_additive_step(self):
+        """Use additive ramp_step instead of multiplier."""
+        rps_values = []
+
+        async def mock_benchmark(args, base_url):
+            rps_values.append(args.request_rate)
+            return _make_result(errors=0, completed=50)
+
+        with patch("xpyd_bench.load_shed.run_benchmark", side_effect=mock_benchmark):
+            await run_load_shed(
+                _base_args(),
+                "http://localhost:8000",
+                starting_rps=5.0,
+                ramp_step=5.0,
+                max_levels=3,
+                recovery_check=False,
+            )
+
+        assert rps_values == [5.0, 10.0, 15.0]
+
+    @pytest.mark.asyncio
+    async def test_degradation_curve(self):
+        """Degradation curve should have entries for each level."""
+        async def mock_benchmark(args, base_url):
+            return _make_result(errors=0, completed=50)
+
+        with patch("xpyd_bench.load_shed.run_benchmark", side_effect=mock_benchmark):
+            analysis = await run_load_shed(
+                _base_args(),
+                "http://localhost:8000",
+                starting_rps=5.0,
+                max_levels=3,
+                recovery_check=False,
+            )
+
+        assert len(analysis.degradation_curve) == 3
+        for pt in analysis.degradation_curve:
+            assert "rps" in pt
+            assert "throughput" in pt
+            assert "error_rate" in pt
+
+
+# ---------------------------------------------------------------------------
+# Format table
+# ---------------------------------------------------------------------------
+
+class TestFormatTable:
+    def test_format_with_saturation(self):
+        analysis = SaturationAnalysis(
+            levels=[
+                LoadShedLevel(5.0, 4.8, 100.0, 200.0, 0.0, 0, 50),
+                LoadShedLevel(10.0, 8.0, 150.0, 300.0, 0.4, 20, 50),
+            ],
+            saturation_rps=10.0,
+            max_sustainable_rps=5.0,
+            recovery_rps=5.0,
+            recovery_latency_ms=90.0,
+        )
+        table = format_load_shed_table(analysis)
+        assert "Load Shedding" in table
+        assert "Max sustainable" in table
+        assert "Saturation" in table
+        assert "Recovery" in table
+
+    def test_format_no_saturation(self):
+        analysis = SaturationAnalysis(
+            levels=[LoadShedLevel(5.0, 4.8, 100.0, 200.0, 0.0, 0, 50)],
+            max_sustainable_rps=5.0,
+        )
+        table = format_load_shed_table(analysis)
+        assert "not reached" in table
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+class TestCLIIntegration:
+    def test_load_shed_cli_args(self):
+        """Verify CLI accepts load-shed arguments."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([
+            "--base-url", "http://localhost:8000",
+            "--model", "test",
+            "--load-shed-threshold", "5.0",
+            "--load-shed-step", "2.0",
+            "--load-shed-multiplier", "2.0",
+            "--load-shed-prompts", "100",
+        ])
+        assert args.load_shed_threshold == 5.0
+        assert args.load_shed_step == 2.0
+        assert args.load_shed_multiplier == 2.0
+        assert args.load_shed_prompts == 100
+
+
+# ---------------------------------------------------------------------------
+# Dummy server rate limiting
+# ---------------------------------------------------------------------------
+
+class TestDummyServerRateLimit:
+    def test_server_config_max_rps(self):
+        from xpyd_bench.dummy.server import ServerConfig
+
+        config = ServerConfig(max_rps=10.0)
+        assert config.max_rps == 10.0
+
+    def test_server_config_default_no_limit(self):
+        from xpyd_bench.dummy.server import ServerConfig
+
+        config = ServerConfig()
+        assert config.max_rps is None
+
+    def test_create_app_with_rate_limit(self):
+        from xpyd_bench.dummy.server import ServerConfig, create_app
+
+        config = ServerConfig(max_rps=5.0)
+        app = create_app(config)
+        # App should have 2 middleware (auth + rate limit)
+        assert len(app.middleware_stack.__class__.__mro__) > 1  # basic sanity
+
+
+# ---------------------------------------------------------------------------
+# YAML config support
+# ---------------------------------------------------------------------------
+
+class TestYAMLConfig:
+    def test_load_shed_yaml_keys(self):
+        """Ensure load_shed_threshold is a recognized YAML config key."""
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        # Verify the dest names exist in default namespace
+        defaults = parser.parse_args(["--base-url", "http://x", "--model", "m"])
+        assert hasattr(defaults, "load_shed_threshold")
+        assert hasattr(defaults, "load_shed_step")
+        assert hasattr(defaults, "load_shed_multiplier")
+        assert hasattr(defaults, "load_shed_prompts")
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+class TestJSONOutput:
+    def test_saturation_analysis_json(self):
+        analysis = SaturationAnalysis(
+            levels=[
+                LoadShedLevel(5.0, 4.8, 100.0, 200.0, 0.0, 0, 50),
+            ],
+            saturation_rps=10.0,
+            max_sustainable_rps=5.0,
+        )
+        d = analysis.to_dict()
+        # Should be JSON-serializable
+        json_str = json.dumps(d)
+        parsed = json.loads(json_str)
+        assert parsed["saturation_rps"] == 10.0
+        assert len(parsed["levels"]) == 1


### PR DESCRIPTION
## Summary
Add load shedding simulation to automatically find maximum sustainable throughput.

## Changes
- `--load-shed-threshold <rps>` CLI flag to start load shedding ramp
- `--load-shed-step`, `--load-shed-multiplier`, `--load-shed-prompts` for ramp config
- Ramps RPS until server rejects (429/503), finds saturation point
- Reports: max sustainable RPS, saturation point, degradation curve, recovery behavior
- JSON output with `saturation_analysis` section
- Dummy server `--max-rps` flag for configurable 429 rate limiting
- YAML config support for all parameters
- 21 tests covering all features

Closes #167