### PR TITLE
feat(M62): OTLP trace export for benchmark request spans

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -505,7 +505,7 @@
 - YAML config support (`webhook_url`, `webhook_secret`)
 - Tests covering delivery, signature, retry, server error, and CLI integration
 
-## M62: Request Trace Export (OpenTelemetry)
+## M62: Request Trace Export (OpenTelemetry) ✅
 - `--otlp-endpoint <url>` to export per-request spans to an OpenTelemetry collector
 - Span attributes: prompt_tokens, completion_tokens, TTFT, TPOT, model, endpoint
 - Parent span for entire benchmark run with child spans per request

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -810,6 +810,15 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Secret for HMAC-SHA256 webhook signature (X-Webhook-Signature header).",
     )
 
+    # OTLP trace export (M62)
+    parser.add_argument(
+        "--otlp-endpoint",
+        type=str,
+        default=None,
+        dest="otlp_endpoint",
+        help="OTLP/HTTP endpoint URL to export request trace spans (e.g. http://localhost:4318).",
+    )
+
 
 def _resolve_base_url(args: argparse.Namespace) -> str:
     """Resolve the base URL from --base-url or --host/--port."""
@@ -1468,6 +1477,15 @@ def bench_main(argv: list[str] | None = None) -> None:
         deliveries = send_webhooks(webhook_urls, result, secret=webhook_secret)
         print()
         print(format_webhook_summary(deliveries))
+
+    # OTLP trace export (M62)
+    otlp_endpoint = getattr(args, "otlp_endpoint", None)
+    if otlp_endpoint:
+        from xpyd_bench.otlp import export_traces, format_otlp_summary
+
+        delivery = export_traces(otlp_endpoint, result)
+        print()
+        print(format_otlp_summary(delivery))
 
     # SLA validation (M20)
     sla_path = getattr(args, "sla", None)

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -111,6 +111,7 @@ _KNOWN_KEYS: set[str] = {
     "inject_payload_corruption",
     "webhook_url",
     "webhook_secret",
+    "otlp_endpoint",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/src/xpyd_bench/otlp.py
+++ b/src/xpyd_bench/otlp.py
@@ -1,0 +1,172 @@
+"""OpenTelemetry trace export support (M62).
+
+Lightweight OTLP/HTTP JSON exporter for benchmark request spans.
+No external OpenTelemetry SDK dependency — uses httpx to POST
+OTLP JSON directly.
+"""
+
+from __future__ import annotations
+
+import random
+import struct
+import time
+from typing import Any
+
+
+def _random_trace_id() -> str:
+    """Generate a random 32-hex-char trace ID."""
+    return struct.pack(">QQ", random.getrandbits(64), random.getrandbits(64)).hex()
+
+
+def _random_span_id() -> str:
+    """Generate a random 16-hex-char span ID."""
+    return struct.pack(">Q", random.getrandbits(64)).hex()
+
+
+def _to_nano(ts: float) -> int:
+    """Convert seconds (float) to nanoseconds (int)."""
+    return int(ts * 1_000_000_000)
+
+
+def build_spans(
+    result: dict,
+    service_name: str = "xpyd-bench",
+) -> dict:
+    """Build OTLP-compatible resource spans from a BenchmarkResult dict.
+
+    Returns the OTLP JSON body ready for POST to /v1/traces.
+    """
+    trace_id = _random_trace_id()
+    root_span_id = _random_span_id()
+
+    # Determine benchmark time range
+    request_results: list[dict] = result.get("request_results", [])
+    start_time = result.get("start_time", time.time())
+    end_time = result.get("end_time", start_time + result.get("total_time", 0))
+
+    # Root span for entire benchmark run
+    root_attrs = _make_attrs({
+        "bench.model": result.get("model", ""),
+        "bench.endpoint": result.get("endpoint", ""),
+        "bench.num_prompts": result.get("completed", 0),
+        "bench.total_time_s": result.get("total_time", 0),
+        "bench.request_throughput": result.get("request_throughput", 0),
+    })
+
+    root_span = {
+        "traceId": trace_id,
+        "spanId": root_span_id,
+        "name": "benchmark-run",
+        "kind": 1,  # SPAN_KIND_INTERNAL
+        "startTimeUnixNano": _to_nano(start_time),
+        "endTimeUnixNano": _to_nano(end_time),
+        "attributes": root_attrs,
+        "status": {"code": 1},  # STATUS_CODE_OK
+    }
+
+    child_spans = []
+    for i, req in enumerate(request_results):
+        span_id = _random_span_id()
+        req_start = req.get("start_time", start_time)
+        req_end = req_start + req.get("latency", 0)
+
+        attrs = _make_attrs({
+            "bench.request.index": i,
+            "bench.request.prompt_tokens": req.get("prompt_tokens", 0),
+            "bench.request.completion_tokens": req.get("completion_tokens", 0),
+            "bench.request.ttft": req.get("ttft", 0),
+            "bench.request.tpot": req.get("tpot", 0),
+            "bench.request.latency": req.get("latency", 0),
+            "bench.request.success": req.get("success", False),
+            "bench.request.error": req.get("error", ""),
+        })
+
+        child_spans.append({
+            "traceId": trace_id,
+            "spanId": span_id,
+            "parentSpanId": root_span_id,
+            "name": f"request-{i}",
+            "kind": 3,  # SPAN_KIND_CLIENT
+            "startTimeUnixNano": _to_nano(req_start),
+            "endTimeUnixNano": _to_nano(req_end),
+            "attributes": attrs,
+            "status": {"code": 1 if req.get("success", False) else 2},
+        })
+
+    resource_attrs = _make_attrs({"service.name": service_name})
+
+    return {
+        "resourceSpans": [
+            {
+                "resource": {"attributes": resource_attrs},
+                "scopeSpans": [
+                    {
+                        "scope": {"name": "xpyd-bench", "version": "0.1.0"},
+                        "spans": [root_span, *child_spans],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _make_attrs(mapping: dict[str, Any]) -> list[dict]:
+    """Convert a flat dict to OTLP attribute list format."""
+    attrs = []
+    for k, v in mapping.items():
+        if v is None or v == "":
+            continue
+        if isinstance(v, bool):
+            attrs.append({"key": k, "value": {"boolValue": v}})
+        elif isinstance(v, int):
+            attrs.append({"key": k, "value": {"intValue": v}})
+        elif isinstance(v, float):
+            attrs.append({"key": k, "value": {"doubleValue": v}})
+        else:
+            attrs.append({"key": k, "value": {"stringValue": str(v)}})
+    return attrs
+
+
+def export_traces(
+    endpoint: str,
+    result: dict,
+    service_name: str = "xpyd-bench",
+    timeout: float = 10.0,
+) -> dict:
+    """Export benchmark spans to an OTLP/HTTP endpoint.
+
+    Posts to ``{endpoint}/v1/traces`` (OTLP/HTTP JSON).
+
+    Returns:
+        {"success": bool, "spans_count": int, "error": str | None}
+    """
+    import httpx
+
+    body = build_spans(result, service_name=service_name)
+    spans_count = sum(
+        len(ss["spans"])
+        for rs in body["resourceSpans"]
+        for ss in rs["scopeSpans"]
+    )
+
+    url = endpoint.rstrip("/") + "/v1/traces"
+    headers = {"Content-Type": "application/json"}
+
+    try:
+        resp = httpx.post(url, json=body, headers=headers, timeout=timeout)
+        if resp.status_code < 400:
+            return {"success": True, "spans_count": spans_count, "error": None}
+        return {
+            "success": False,
+            "spans_count": spans_count,
+            "error": f"HTTP {resp.status_code}",
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {"success": False, "spans_count": spans_count, "error": str(exc)}
+
+
+def format_otlp_summary(delivery: dict) -> str:
+    """Format OTLP export result for terminal output."""
+    if delivery["success"]:
+        return f"OTLP trace export: ✓ {delivery['spans_count']} spans exported"
+    return f"OTLP trace export: ✗ {delivery['error']} ({delivery['spans_count']} spans)"

--- a/tests/test_otlp.py
+++ b/tests/test_otlp.py
@@ -1,0 +1,223 @@
+"""Tests for OTLP trace export support (M62)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from xpyd_bench.otlp import (
+    _make_attrs,
+    _random_span_id,
+    _random_trace_id,
+    _to_nano,
+    build_spans,
+    export_traces,
+    format_otlp_summary,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+class _OTLPHandler(BaseHTTPRequestHandler):
+    received: list[dict] = []
+    status_to_return: int = 200
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        self._cls().received.append(json.loads(body))
+        self.send_response(self._cls().status_to_return)
+        self.end_headers()
+
+    def _cls(self):
+        return type(self)
+
+    def log_message(self, *_args):
+        pass
+
+
+@pytest.fixture()
+def otlp_server():
+    class Handler(_OTLPHandler):
+        received: list[dict] = []
+        status_to_return: int = 200
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{port}", Handler
+    server.shutdown()
+
+
+def _sample_result(n_requests: int = 3) -> dict:
+    return {
+        "model": "test-model",
+        "endpoint": "/v1/completions",
+        "completed": n_requests,
+        "total_time": 10.0,
+        "start_time": 1000.0,
+        "end_time": 1010.0,
+        "request_throughput": float(n_requests) / 10.0,
+        "request_results": [
+            {
+                "start_time": 1000.0 + i,
+                "latency": 0.5,
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "ttft": 0.1,
+                "tpot": 0.02,
+                "success": True,
+                "error": None,
+            }
+            for i in range(n_requests)
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+def test_random_trace_id_length():
+    tid = _random_trace_id()
+    assert len(tid) == 32
+    int(tid, 16)  # valid hex
+
+
+def test_random_span_id_length():
+    sid = _random_span_id()
+    assert len(sid) == 16
+    int(sid, 16)
+
+
+def test_to_nano():
+    assert _to_nano(1.5) == 1_500_000_000
+
+
+def test_make_attrs_types():
+    attrs = _make_attrs({
+        "str_key": "hello",
+        "int_key": 42,
+        "float_key": 3.14,
+        "bool_key": True,
+        "empty": "",
+        "none": None,
+    })
+    keys = {a["key"] for a in attrs}
+    assert "str_key" in keys
+    assert "int_key" in keys
+    assert "float_key" in keys
+    assert "bool_key" in keys
+    assert "empty" not in keys
+    assert "none" not in keys
+
+
+def test_build_spans_structure():
+    result = _sample_result(3)
+    body = build_spans(result)
+
+    assert "resourceSpans" in body
+    rs = body["resourceSpans"]
+    assert len(rs) == 1
+    scope_spans = rs[0]["scopeSpans"]
+    assert len(scope_spans) == 1
+    spans = scope_spans[0]["spans"]
+    # 1 root + 3 child
+    assert len(spans) == 4
+
+    root = spans[0]
+    assert root["name"] == "benchmark-run"
+    assert "parentSpanId" not in root
+
+    for child in spans[1:]:
+        assert child["parentSpanId"] == root["spanId"]
+        assert child["traceId"] == root["traceId"]
+
+
+def test_build_spans_attributes():
+    result = _sample_result(1)
+    body = build_spans(result)
+    child = body["resourceSpans"][0]["scopeSpans"][0]["spans"][1]
+    attr_keys = {a["key"] for a in child["attributes"]}
+    assert "bench.request.prompt_tokens" in attr_keys
+    assert "bench.request.completion_tokens" in attr_keys
+    assert "bench.request.ttft" in attr_keys
+    assert "bench.request.tpot" in attr_keys
+
+
+def test_build_spans_service_name():
+    body = build_spans(_sample_result(1), service_name="my-service")
+    resource_attrs = body["resourceSpans"][0]["resource"]["attributes"]
+    svc = [a for a in resource_attrs if a["key"] == "service.name"]
+    assert len(svc) == 1
+    assert svc[0]["value"]["stringValue"] == "my-service"
+
+
+def test_export_traces_success(otlp_server):
+    url, handler = otlp_server
+    result = _sample_result(2)
+    delivery = export_traces(url, result)
+
+    assert delivery["success"] is True
+    assert delivery["spans_count"] == 3  # 1 root + 2 child
+    assert delivery["error"] is None
+    assert len(handler.received) == 1
+
+    # Verify posted body structure
+    body = handler.received[0]
+    assert "resourceSpans" in body
+
+
+def test_export_traces_server_error(otlp_server):
+    url, handler = otlp_server
+    handler.status_to_return = 500
+    delivery = export_traces(url, _sample_result(1))
+    assert delivery["success"] is False
+    assert "HTTP 500" in delivery["error"]
+
+
+def test_export_traces_unreachable():
+    delivery = export_traces("http://127.0.0.1:1", _sample_result(1), timeout=1.0)
+    assert delivery["success"] is False
+    assert delivery["error"] is not None
+
+
+def test_format_otlp_summary_success():
+    s = format_otlp_summary({"success": True, "spans_count": 5, "error": None})
+    assert "✓" in s
+    assert "5 spans" in s
+
+
+def test_format_otlp_summary_failure():
+    s = format_otlp_summary({"success": False, "spans_count": 5, "error": "timeout"})
+    assert "✗" in s
+    assert "timeout" in s
+
+
+def test_otlp_yaml_config_known_keys():
+    from xpyd_bench.config_cmd import _KNOWN_KEYS
+    assert "otlp_endpoint" in _KNOWN_KEYS
+
+
+def test_otlp_cli_args():
+    import argparse
+
+    from xpyd_bench.cli import _add_vllm_compat_args
+
+    parser = argparse.ArgumentParser()
+    _add_vllm_compat_args(parser)
+    args = parser.parse_args(["--otlp-endpoint", "http://localhost:4318"])
+    assert args.otlp_endpoint == "http://localhost:4318"
+
+
+def test_build_spans_empty_requests():
+    result = _sample_result(0)
+    result["request_results"] = []
+    body = build_spans(result)
+    spans = body["resourceSpans"][0]["scopeSpans"][0]["spans"]
+    assert len(spans) == 1  # root only


### PR DESCRIPTION
## Summary
Add OpenTelemetry-compatible trace export via lightweight OTLP/HTTP JSON protocol.

## Changes
- New `src/xpyd_bench/otlp.py` module with `build_spans()`, `export_traces()`, signature/formatting helpers
- `--otlp-endpoint <url>` CLI flag to export per-request spans to an OTLP collector
- Parent span for entire benchmark run with child spans per request
- Span attributes: prompt_tokens, completion_tokens, TTFT, TPOT, latency, model, endpoint
- YAML config support (`otlp_endpoint`)
- No external OpenTelemetry SDK dependency — uses httpx for HTTP POST
- Graceful fallback when collector is unavailable
- Added to `_KNOWN_KEYS` in config validation
- 15 new test cases covering all functionality

Closes #181