### PR TITLE
feat(discover): add endpoint capability discovery (M64)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -517,3 +517,14 @@
 - `--on-complete <command>` to run shell command after benchmark (e.g., notify, upload)
 - Schedule validation and human-readable next-run preview
 - Tests covering cron generation and on-complete execution
+
+## M64: Endpoint Capability Discovery
+- `xpyd-bench discover --base-url <url>` probes endpoint to auto-detect capabilities
+- Detect: /v1/completions, /v1/chat/completions, /v1/embeddings, /v1/batch, streaming, function calling
+- Auto-discover available models via /v1/models
+- `--api-key` for authenticated endpoints (OPENAI_API_KEY env fallback)
+- `--timeout` for probe timeout configuration
+- `--json` for machine-readable JSON output
+- `--generate-config <path>` writes recommended YAML config based on discovered capabilities
+- Human-readable summary with ✓/✗ indicators
+- Tests covering discovery logic, JSON output, config generation, CLI integration

--- a/src/xpyd_bench/discover.py
+++ b/src/xpyd_bench/discover.py
@@ -1,0 +1,298 @@
+"""Endpoint capability discovery (M64).
+
+Probes an LLM endpoint to auto-detect supported features and generates
+recommended benchmark configurations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+
+import httpx
+import yaml
+
+
+@dataclass
+class EndpointCapabilities:
+    """Discovered capabilities of an LLM endpoint."""
+
+    base_url: str
+    reachable: bool = False
+    models: list[str] = field(default_factory=list)
+    completions: bool = False
+    chat_completions: bool = False
+    embeddings: bool = False
+    streaming: bool = False
+    function_calling: bool = False
+    batch: bool = False
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Return dict representation."""
+        return asdict(self)
+
+
+def _probe_models(
+    client: httpx.Client, base_url: str, caps: EndpointCapabilities
+) -> None:
+    """Probe /v1/models endpoint."""
+    try:
+        resp = client.get(f"{base_url}/v1/models")
+        if resp.status_code == 200:
+            data = resp.json()
+            models = data.get("data", [])
+            caps.models = [m.get("id", "") for m in models if m.get("id")]
+    except Exception as exc:
+        caps.errors.append(f"models probe failed: {exc}")
+
+
+def _probe_completions(
+    client: httpx.Client, base_url: str, model: str, caps: EndpointCapabilities
+) -> None:
+    """Probe /v1/completions endpoint."""
+    try:
+        resp = client.post(
+            f"{base_url}/v1/completions",
+            json={"model": model, "prompt": "test", "max_tokens": 1},
+        )
+        if resp.status_code == 200:
+            caps.completions = True
+    except Exception as exc:
+        caps.errors.append(f"completions probe failed: {exc}")
+
+
+def _probe_chat(
+    client: httpx.Client, base_url: str, model: str, caps: EndpointCapabilities
+) -> None:
+    """Probe /v1/chat/completions endpoint."""
+    try:
+        resp = client.post(
+            f"{base_url}/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "test"}],
+                "max_tokens": 1,
+            },
+        )
+        if resp.status_code == 200:
+            caps.chat_completions = True
+    except Exception as exc:
+        caps.errors.append(f"chat completions probe failed: {exc}")
+
+
+def _probe_streaming(
+    client: httpx.Client, base_url: str, model: str, caps: EndpointCapabilities
+) -> None:
+    """Probe streaming support via /v1/chat/completions."""
+    try:
+        resp = client.post(
+            f"{base_url}/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "test"}],
+                "max_tokens": 1,
+                "stream": True,
+            },
+        )
+        if resp.status_code == 200 and "text/event-stream" in resp.headers.get(
+            "content-type", ""
+        ):
+            caps.streaming = True
+    except Exception as exc:
+        caps.errors.append(f"streaming probe failed: {exc}")
+
+
+def _probe_embeddings(
+    client: httpx.Client, base_url: str, model: str, caps: EndpointCapabilities
+) -> None:
+    """Probe /v1/embeddings endpoint."""
+    try:
+        resp = client.post(
+            f"{base_url}/v1/embeddings",
+            json={"model": model, "input": "test"},
+        )
+        if resp.status_code == 200:
+            caps.embeddings = True
+    except Exception as exc:
+        caps.errors.append(f"embeddings probe failed: {exc}")
+
+
+def _probe_function_calling(
+    client: httpx.Client, base_url: str, model: str, caps: EndpointCapabilities
+) -> None:
+    """Probe function calling / tool support."""
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "test_fn",
+                "description": "test",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    try:
+        resp = client.post(
+            f"{base_url}/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "test"}],
+                "max_tokens": 1,
+                "tools": tools,
+            },
+        )
+        if resp.status_code == 200:
+            caps.function_calling = True
+    except Exception as exc:
+        caps.errors.append(f"function calling probe failed: {exc}")
+
+
+def _probe_batch(
+    client: httpx.Client, base_url: str, caps: EndpointCapabilities
+) -> None:
+    """Probe /v1/batch endpoint availability."""
+    try:
+        # Just check if the endpoint responds (even with 400 = exists)
+        resp = client.post(f"{base_url}/v1/batch", json={})
+        if resp.status_code in (200, 400, 422):
+            caps.batch = True
+    except Exception as exc:
+        caps.errors.append(f"batch probe failed: {exc}")
+
+
+def discover_endpoint(
+    base_url: str,
+    api_key: str | None = None,
+    timeout: float = 10.0,
+) -> EndpointCapabilities:
+    """Probe an endpoint and return discovered capabilities."""
+    base_url = base_url.rstrip("/")
+    caps = EndpointCapabilities(base_url=base_url)
+
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    try:
+        client = httpx.Client(
+            headers=headers, timeout=timeout, follow_redirects=True
+        )
+    except Exception as exc:
+        caps.errors.append(f"client creation failed: {exc}")
+        return caps
+
+    # Check reachability
+    try:
+        resp = client.get(f"{base_url}/v1/models")
+        caps.reachable = resp.status_code < 500
+    except Exception:
+        caps.reachable = False
+        client.close()
+        return caps
+
+    _probe_models(client, base_url, caps)
+
+    model = caps.models[0] if caps.models else "default"
+
+    _probe_completions(client, base_url, model, caps)
+    _probe_chat(client, base_url, model, caps)
+    _probe_streaming(client, base_url, model, caps)
+    _probe_embeddings(client, base_url, model, caps)
+    _probe_function_calling(client, base_url, model, caps)
+    _probe_batch(client, base_url, caps)
+
+    client.close()
+    return caps
+
+
+def generate_config(caps: EndpointCapabilities) -> dict:
+    """Generate a recommended YAML config from discovered capabilities."""
+    config: dict = {"base_url": caps.base_url}
+
+    if caps.models:
+        config["model"] = caps.models[0]
+
+    if caps.chat_completions:
+        config["endpoint"] = "/v1/chat/completions"
+    elif caps.completions:
+        config["endpoint"] = "/v1/completions"
+
+    if caps.streaming:
+        config["stream"] = True
+
+    config["num_prompts"] = 100
+    config["request_rate"] = 10.0
+
+    return config
+
+
+def format_summary(caps: EndpointCapabilities) -> str:
+    """Format capabilities as a human-readable summary."""
+    lines = [f"Endpoint Discovery: {caps.base_url}", ""]
+
+    def _indicator(val: bool) -> str:
+        return "✓" if val else "✗"
+
+    lines.append(f"  Reachable:           {_indicator(caps.reachable)}")
+    if caps.models:
+        lines.append(f"  Models:              {', '.join(caps.models)}")
+    else:
+        lines.append("  Models:              (none detected)")
+    lines.append(f"  /v1/completions:     {_indicator(caps.completions)}")
+    lines.append(f"  /v1/chat/completions:{_indicator(caps.chat_completions)}")
+    lines.append(f"  /v1/embeddings:      {_indicator(caps.embeddings)}")
+    lines.append(f"  Streaming:           {_indicator(caps.streaming)}")
+    lines.append(f"  Function calling:    {_indicator(caps.function_calling)}")
+    lines.append(f"  /v1/batch:           {_indicator(caps.batch)}")
+
+    if caps.errors:
+        lines.append("")
+        lines.append("  Probe errors:")
+        for err in caps.errors:
+            lines.append(f"    - {err}")
+
+    return "\n".join(lines)
+
+
+def discover_main(argv: list[str] | None = None) -> None:
+    """CLI entry point for discover subcommand."""
+    parser = argparse.ArgumentParser(
+        description="Discover endpoint capabilities"
+    )
+    parser.add_argument(
+        "--base-url", required=True, help="Base URL of the LLM endpoint"
+    )
+    parser.add_argument("--api-key", default=None, help="API key for authentication")
+    parser.add_argument(
+        "--timeout", type=float, default=10.0, help="Probe timeout in seconds"
+    )
+    parser.add_argument(
+        "--json", dest="json_output", action="store_true", help="JSON output"
+    )
+    parser.add_argument(
+        "--generate-config", default=None, help="Write recommended YAML config to path"
+    )
+
+    args = parser.parse_args(argv)
+
+    api_key = args.api_key or os.environ.get("OPENAI_API_KEY")
+
+    caps = discover_endpoint(args.base_url, api_key=api_key, timeout=args.timeout)
+
+    if args.json_output:
+        print(json.dumps(caps.to_dict(), indent=2))
+    else:
+        print(format_summary(caps))
+
+    if args.generate_config:
+        config = generate_config(caps)
+        with open(args.generate_config, "w") as f:
+            yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+        print(f"\nRecommended config written to {args.generate_config}")
+
+    if not caps.reachable:
+        sys.exit(1)

--- a/src/xpyd_bench/main.py
+++ b/src/xpyd_bench/main.py
@@ -82,6 +82,7 @@ _SUBCOMMANDS = {
     "archive",
     "chain",
     "schedule",
+    "discover",
 }
 
 
@@ -169,6 +170,10 @@ def main() -> None:
         from xpyd_bench.schedule import schedule_main
 
         schedule_main(rest)
+    elif subcmd == "discover":
+        from xpyd_bench.discover import discover_main
+
+        discover_main(rest)
 
 
 def _config_subcommand(argv: list[str]) -> None:

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,0 +1,322 @@
+"""Tests for endpoint capability discovery (M64)."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import yaml
+
+from xpyd_bench.discover import (
+    EndpointCapabilities,
+    discover_endpoint,
+    discover_main,
+    format_summary,
+    generate_config,
+)
+
+# ---------------------------------------------------------------------------
+# EndpointCapabilities dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestEndpointCapabilities:
+    def test_defaults(self):
+        caps = EndpointCapabilities(base_url="http://localhost:8000")
+        assert caps.reachable is False
+        assert caps.models == []
+        assert caps.completions is False
+        assert caps.chat_completions is False
+        assert caps.embeddings is False
+        assert caps.streaming is False
+        assert caps.function_calling is False
+        assert caps.batch is False
+        assert caps.errors == []
+
+    def test_to_dict(self):
+        caps = EndpointCapabilities(
+            base_url="http://localhost:8000",
+            reachable=True,
+            models=["gpt-4"],
+            chat_completions=True,
+        )
+        d = caps.to_dict()
+        assert d["base_url"] == "http://localhost:8000"
+        assert d["reachable"] is True
+        assert d["models"] == ["gpt-4"]
+        assert d["chat_completions"] is True
+
+
+# ---------------------------------------------------------------------------
+# discover_endpoint — mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(status_code: int = 200, json_data=None, headers=None):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.headers = headers or {}
+    return resp
+
+
+class TestDiscoverEndpoint:
+    def test_unreachable(self):
+        with patch("xpyd_bench.discover.httpx.Client") as MockClient:
+            client = MockClient.return_value
+            client.get.side_effect = httpx.ConnectError("refused")
+            caps = discover_endpoint("http://localhost:9999", timeout=1.0)
+            assert caps.reachable is False
+            assert caps.models == []
+
+    def test_full_capabilities(self):
+        with patch("xpyd_bench.discover.httpx.Client") as MockClient:
+            client = MockClient.return_value
+
+            models_resp = _mock_response(
+                200, {"data": [{"id": "model-a"}, {"id": "model-b"}]}
+            )
+            completions_resp = _mock_response(200)
+            chat_resp = _mock_response(200)
+            streaming_resp = _mock_response(
+                200, headers={"content-type": "text/event-stream"}
+            )
+            embeddings_resp = _mock_response(200)
+            fc_resp = _mock_response(200)
+            batch_resp = _mock_response(400)
+
+            def route_get(url, **kw):
+                return models_resp
+
+            def route_post(url, **kw):
+                json_body = kw.get("json", {})
+                if "/v1/completions" in url and "prompt" in json_body:
+                    return completions_resp
+                if "/v1/chat/completions" in url:
+                    if json_body.get("stream"):
+                        return streaming_resp
+                    if "tools" in json_body:
+                        return fc_resp
+                    return chat_resp
+                if "/v1/embeddings" in url:
+                    return embeddings_resp
+                if "/v1/batch" in url:
+                    return batch_resp
+                return _mock_response(404)
+
+            client.get.side_effect = route_get
+            client.post.side_effect = route_post
+
+            caps = discover_endpoint("http://localhost:8000")
+            assert caps.reachable is True
+            assert caps.models == ["model-a", "model-b"]
+            assert caps.completions is True
+            assert caps.chat_completions is True
+            assert caps.streaming is True
+            assert caps.embeddings is True
+            assert caps.function_calling is True
+            assert caps.batch is True
+
+    def test_partial_capabilities(self):
+        with patch("xpyd_bench.discover.httpx.Client") as MockClient:
+            client = MockClient.return_value
+
+            models_resp = _mock_response(200, {"data": [{"id": "llama"}]})
+
+            def route_get(url, **kw):
+                return models_resp
+
+            def route_post(url, **kw):
+                json_body = kw.get("json", {})
+                if "/v1/chat/completions" in url:
+                    if not json_body.get("stream") and "tools" not in json_body:
+                        return _mock_response(200)
+                    return _mock_response(404)
+                return _mock_response(404)
+
+            client.get.side_effect = route_get
+            client.post.side_effect = route_post
+
+            caps = discover_endpoint("http://localhost:8000")
+            assert caps.reachable is True
+            assert caps.models == ["llama"]
+            assert caps.chat_completions is True
+            assert caps.completions is False
+            assert caps.streaming is False
+            assert caps.embeddings is False
+
+    def test_api_key_passed(self):
+        with patch("xpyd_bench.discover.httpx.Client") as MockClient:
+            client = MockClient.return_value
+            client.get.return_value = _mock_response(200, {"data": []})
+            client.post.return_value = _mock_response(404)
+
+            discover_endpoint("http://localhost:8000", api_key="sk-test")
+            call_kwargs = MockClient.call_args
+            assert call_kwargs[1]["headers"]["Authorization"] == "Bearer sk-test"
+
+    def test_trailing_slash_stripped(self):
+        with patch("xpyd_bench.discover.httpx.Client") as MockClient:
+            client = MockClient.return_value
+            client.get.return_value = _mock_response(200, {"data": []})
+            client.post.return_value = _mock_response(404)
+
+            caps = discover_endpoint("http://localhost:8000/")
+            assert caps.base_url == "http://localhost:8000"
+
+
+# ---------------------------------------------------------------------------
+# generate_config
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateConfig:
+    def test_chat_endpoint_preferred(self):
+        caps = EndpointCapabilities(
+            base_url="http://localhost:8000",
+            models=["gpt-4"],
+            chat_completions=True,
+            completions=True,
+            streaming=True,
+        )
+        config = generate_config(caps)
+        assert config["endpoint"] == "/v1/chat/completions"
+        assert config["stream"] is True
+        assert config["model"] == "gpt-4"
+
+    def test_completions_fallback(self):
+        caps = EndpointCapabilities(
+            base_url="http://localhost:8000",
+            models=["gpt-3"],
+            completions=True,
+            chat_completions=False,
+        )
+        config = generate_config(caps)
+        assert config["endpoint"] == "/v1/completions"
+        assert "stream" not in config
+
+    def test_no_endpoints(self):
+        caps = EndpointCapabilities(base_url="http://localhost:8000")
+        config = generate_config(caps)
+        assert "endpoint" not in config
+        assert config["base_url"] == "http://localhost:8000"
+
+
+# ---------------------------------------------------------------------------
+# format_summary
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSummary:
+    def test_summary_contains_indicators(self):
+        caps = EndpointCapabilities(
+            base_url="http://localhost:8000",
+            reachable=True,
+            models=["gpt-4"],
+            chat_completions=True,
+            completions=False,
+        )
+        summary = format_summary(caps)
+        assert "✓" in summary
+        assert "✗" in summary
+        assert "gpt-4" in summary
+        assert "http://localhost:8000" in summary
+
+    def test_summary_errors(self):
+        caps = EndpointCapabilities(
+            base_url="http://localhost:8000",
+            errors=["something failed"],
+        )
+        summary = format_summary(caps)
+        assert "something failed" in summary
+
+    def test_summary_no_models(self):
+        caps = EndpointCapabilities(base_url="http://localhost:8000")
+        summary = format_summary(caps)
+        assert "none detected" in summary
+
+
+# ---------------------------------------------------------------------------
+# CLI (discover_main)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverMain:
+    def test_json_output(self, capsys):
+        with patch("xpyd_bench.discover.discover_endpoint") as mock_discover:
+            mock_discover.return_value = EndpointCapabilities(
+                base_url="http://localhost:8000",
+                reachable=True,
+                models=["m1"],
+                chat_completions=True,
+            )
+            discover_main(["--base-url", "http://localhost:8000", "--json"])
+            out = capsys.readouterr().out
+            data = json.loads(out)
+            assert data["reachable"] is True
+            assert data["models"] == ["m1"]
+
+    def test_human_output(self, capsys):
+        with patch("xpyd_bench.discover.discover_endpoint") as mock_discover:
+            mock_discover.return_value = EndpointCapabilities(
+                base_url="http://localhost:8000",
+                reachable=True,
+                chat_completions=True,
+            )
+            discover_main(["--base-url", "http://localhost:8000"])
+            out = capsys.readouterr().out
+            assert "Endpoint Discovery" in out
+
+    def test_generate_config_file(self, tmp_path, capsys):
+        config_path = str(tmp_path / "bench.yaml")
+        with patch("xpyd_bench.discover.discover_endpoint") as mock_discover:
+            mock_discover.return_value = EndpointCapabilities(
+                base_url="http://localhost:8000",
+                reachable=True,
+                models=["gpt-4"],
+                chat_completions=True,
+                streaming=True,
+            )
+            discover_main([
+                "--base-url", "http://localhost:8000",
+                "--generate-config", config_path,
+            ])
+            assert os.path.exists(config_path)
+            with open(config_path) as f:
+                config = yaml.safe_load(f)
+            assert config["model"] == "gpt-4"
+            assert config["stream"] is True
+
+    def test_unreachable_exit_code(self):
+        with patch("xpyd_bench.discover.discover_endpoint") as mock_discover:
+            mock_discover.return_value = EndpointCapabilities(
+                base_url="http://localhost:8000", reachable=False
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                discover_main(["--base-url", "http://localhost:8000"])
+            assert exc_info.value.code == 1
+
+    def test_api_key_env_fallback(self, monkeypatch, capsys):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-key")
+        with patch("xpyd_bench.discover.discover_endpoint") as mock_discover:
+            mock_discover.return_value = EndpointCapabilities(
+                base_url="http://localhost:8000", reachable=True
+            )
+            discover_main(["--base-url", "http://localhost:8000"])
+            call_kwargs = mock_discover.call_args
+            assert call_kwargs[1]["api_key"] == "sk-env-key"
+
+    def test_timeout_passed(self, capsys):
+        with patch("xpyd_bench.discover.discover_endpoint") as mock_discover:
+            mock_discover.return_value = EndpointCapabilities(
+                base_url="http://localhost:8000", reachable=True
+            )
+            discover_main([
+                "--base-url", "http://localhost:8000",
+                "--timeout", "5.0",
+            ])
+            call_kwargs = mock_discover.call_args
+            assert call_kwargs[1]["timeout"] == 5.0


### PR DESCRIPTION
## Summary
Add `xpyd-bench discover --base-url <url>` subcommand that probes an LLM endpoint to auto-detect supported features and generates recommended benchmark configurations.

## Changes
- **New module**: `src/xpyd_bench/discover.py` — endpoint probing, config generation, CLI
- **CLI integration**: `discover` subcommand added to unified CLI router in `main.py`
- **Tests**: 19 tests in `tests/test_discover.py` covering all functionality
- **ROADMAP.md**: M64 milestone added

## Features
- Probes: /v1/completions, /v1/chat/completions, /v1/embeddings, /v1/batch
- Detects streaming support, function calling, available models
- `--json` for machine-readable output
- `--generate-config <path>` writes recommended YAML config
- `--api-key` with `OPENAI_API_KEY` env fallback
- `--timeout` for probe timeout

Closes #185