### PR TITLE
feat(m66): rate-limit header tracking & backpressure reporting

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -538,3 +538,13 @@
 - YAML config support (`verbosity: quiet|normal|verbose`)
 - CLI flags override YAML config
 - Tests covering all three verbosity levels, CLI flags, and YAML config
+
+## M66: Rate-Limit Header Tracking & Backpressure Reporting
+- `--track-ratelimits` CLI flag to parse `X-RateLimit-*` and standard `RateLimit-*` response headers
+- Track remaining quota, reset time, and limit values from each response
+- Per-request `ratelimit_headers` field in `RequestResult`
+- `BenchmarkResult` includes `ratelimit_summary` with min remaining, throttle events (429 count), time under pressure
+- Terminal summary prints rate-limit pressure indicators when tracking enabled
+- Dummy server returns configurable rate-limit headers (`--ratelimit-rpm N`)
+- YAML config support (`track_ratelimits: true`)
+- Tests covering header parsing, summary aggregation, dummy server headers, and CLI integration

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -28,6 +28,7 @@ class RequestResult:
     tool_calls_found: int = 0  # Number of tool calls extracted (M56)
     schema_valid: bool | None = None  # JSON schema conformance (M56)
     latency_breakdown: dict | None = None  # Network latency decomposition (M57)
+    ratelimit_headers: dict | None = None  # Rate-limit headers (M66)
 
 
 @dataclass
@@ -120,3 +121,6 @@ class BenchmarkResult:
 
     # Noise injection stats (M60)
     noise_injection: dict | None = None
+
+    # Rate-limit tracking summary (M66)
+    ratelimit_summary: dict | None = None

--- a/src/xpyd_bench/bench/ratelimit.py
+++ b/src/xpyd_bench/bench/ratelimit.py
@@ -1,0 +1,115 @@
+"""Rate-limit header tracking and aggregation (M66)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# Common rate-limit header names (case-insensitive lookup)
+_HEADER_MAP = {
+    "x-ratelimit-limit": "limit",
+    "x-ratelimit-remaining": "remaining",
+    "x-ratelimit-reset": "reset",
+    "ratelimit-limit": "limit",
+    "ratelimit-remaining": "remaining",
+    "ratelimit-reset": "reset",
+    "retry-after": "retry_after",
+    "x-ratelimit-limit-requests": "limit_requests",
+    "x-ratelimit-limit-tokens": "limit_tokens",
+    "x-ratelimit-remaining-requests": "remaining_requests",
+    "x-ratelimit-remaining-tokens": "remaining_tokens",
+    "x-ratelimit-reset-requests": "reset_requests",
+    "x-ratelimit-reset-tokens": "reset_tokens",
+}
+
+
+def parse_ratelimit_headers(headers: dict[str, str] | Any) -> dict[str, str]:
+    """Extract rate-limit related headers from an HTTP response headers mapping.
+
+    Returns a dict with normalised keys (e.g. ``remaining``, ``limit``).
+    """
+    result: dict[str, str] = {}
+    for raw_name, value in headers.items():
+        key = raw_name.lower()
+        mapped = _HEADER_MAP.get(key)
+        if mapped is not None:
+            result[mapped] = value
+    return result
+
+
+@dataclass
+class RatelimitSummary:
+    """Aggregated rate-limit statistics across a benchmark run."""
+
+    min_remaining: int | None = None
+    min_remaining_tokens: int | None = None
+    max_limit: int | None = None
+    throttle_count: int = 0  # number of 429 responses
+    tracked_responses: int = 0  # responses that had any ratelimit header
+    total_responses: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "min_remaining": self.min_remaining,
+            "min_remaining_tokens": self.min_remaining_tokens,
+            "max_limit": self.max_limit,
+            "throttle_count": self.throttle_count,
+            "tracked_responses": self.tracked_responses,
+            "total_responses": self.total_responses,
+        }
+
+
+def aggregate_ratelimit(
+    per_request_headers: list[dict[str, str] | None],
+    error_messages: list[str | None] | None = None,
+) -> RatelimitSummary:
+    """Aggregate per-request rate-limit headers into a summary.
+
+    *per_request_headers* is a list aligned with request order.
+    *error_messages* (optional) is checked for 429 status indicators.
+    """
+    summary = RatelimitSummary()
+    summary.total_responses = len(per_request_headers)
+
+    for i, hdrs in enumerate(per_request_headers):
+        if not hdrs:
+            continue
+        summary.tracked_responses += 1
+
+        # remaining (requests)
+        raw_rem = hdrs.get("remaining") or hdrs.get("remaining_requests")
+        if raw_rem is not None:
+            try:
+                val = int(raw_rem)
+                if summary.min_remaining is None or val < summary.min_remaining:
+                    summary.min_remaining = val
+            except (ValueError, TypeError):
+                pass
+
+        # remaining tokens
+        raw_rem_tok = hdrs.get("remaining_tokens")
+        if raw_rem_tok is not None:
+            try:
+                val = int(raw_rem_tok)
+                if summary.min_remaining_tokens is None or val < summary.min_remaining_tokens:
+                    summary.min_remaining_tokens = val
+            except (ValueError, TypeError):
+                pass
+
+        # limit
+        raw_lim = hdrs.get("limit") or hdrs.get("limit_requests")
+        if raw_lim is not None:
+            try:
+                val = int(raw_lim)
+                if summary.max_limit is None or val > summary.max_limit:
+                    summary.max_limit = val
+            except (ValueError, TypeError):
+                pass
+
+    # Count 429 throttle events from error strings
+    if error_messages:
+        for err in error_messages:
+            if err and "429" in err:
+                summary.throttle_count += 1
+
+    return summary

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -188,6 +188,7 @@ async def _send_request(
     compress: bool = False,
     request_id: str | None = None,
     sse_metrics: bool = False,
+    track_ratelimits: bool = False,
 ) -> RequestResult:
     """Send one request and collect metrics, with optional retry."""
     last_result = RequestResult()
@@ -207,6 +208,7 @@ async def _send_request(
                     client, url, payload, start, request_timeout=request_timeout,
                     compress=compress, extra_headers=_extra_hdrs,
                     sse_metrics=sse_metrics,
+                    track_ratelimits=track_ratelimits,
                 )
                 result.request_id = request_id
             else:
@@ -215,6 +217,13 @@ async def _send_request(
                 resp.raise_for_status()
                 end = time.perf_counter()
                 result.latency_ms = (end - start) * 1000.0
+
+                # Rate-limit header tracking (M66)
+                if track_ratelimits:
+                    from xpyd_bench.bench.ratelimit import parse_ratelimit_headers
+                    rl = parse_ratelimit_headers(resp.headers)
+                    if rl:
+                        result.ratelimit_headers = rl
 
                 body = resp.json()
                 usage = body.get("usage", {})
@@ -269,6 +278,7 @@ async def _send_streaming(
     compress: bool = False,
     extra_headers: dict[str, str] | None = None,
     sse_metrics: bool = False,
+    track_ratelimits: bool = False,
 ) -> RequestResult:
     """Send a streaming request, measure TTFT / ITL."""
     result = RequestResult()
@@ -285,6 +295,12 @@ async def _send_streaming(
         req_kw = _compressed_request_kwargs(payload, compress, extra_headers=extra_headers)
         async with client.stream("POST", url, **req_kw, timeout=request_timeout) as resp:
             resp.raise_for_status()
+            # Rate-limit header tracking (M66)
+            if track_ratelimits:
+                from xpyd_bench.bench.ratelimit import parse_ratelimit_headers
+                rl = parse_ratelimit_headers(resp.headers)
+                if rl:
+                    result.ratelimit_headers = rl
             async for line in resp.aiter_lines():
                 if not line.startswith("data: "):
                     continue
@@ -702,6 +718,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     # SSE metrics flag (M53)
     sse_metrics_enabled = bool(getattr(args, "sse_metrics", False))
     sse_stall_threshold = float(getattr(args, "sse_stall_threshold_ms", 1000.0) or 1000.0)
+    track_ratelimits_enabled = bool(getattr(args, "track_ratelimits", False))
 
     async def _do_send(
         client: httpx.AsyncClient, payload: dict[str, Any]
@@ -725,6 +742,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
             compress=req_compress,
             request_id=rid,
             sse_metrics=sse_metrics_enabled,
+            track_ratelimits=track_ratelimits_enabled,
         )
 
     # Noise injection (M60)
@@ -1091,6 +1109,15 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         if per_request_sse:
             result.sse_metrics = compute_sse_aggregate(per_request_sse)
 
+    # Rate-limit header aggregation (M66)
+    if track_ratelimits_enabled and result.requests:
+        from xpyd_bench.bench.ratelimit import aggregate_ratelimit
+
+        rl_headers = [r.ratelimit_headers for r in result.requests]
+        error_msgs = [r.error for r in result.requests]
+        rl_summary = aggregate_ratelimit(rl_headers, error_msgs)
+        result.ratelimit_summary = rl_summary.to_dict()
+
     # Response validation (M47)
     validators_specs = getattr(args, "validate_response", None) or []
     if validators_specs:
@@ -1256,6 +1283,21 @@ def _print_summary(r: BenchmarkResult) -> None:
         from xpyd_bench.bench.latency_breakdown import print_breakdown_summary
 
         print_breakdown_summary(r.latency_breakdown)
+    if r.ratelimit_summary:
+        rl = r.ratelimit_summary
+        parts: list[str] = []
+        if rl.get("max_limit") is not None:
+            parts.append(f"limit={rl['max_limit']}")
+        if rl.get("min_remaining") is not None:
+            parts.append(f"min_remaining={rl['min_remaining']}")
+        if rl.get("min_remaining_tokens") is not None:
+            parts.append(f"min_remaining_tokens={rl['min_remaining_tokens']}")
+        if rl.get("throttle_count", 0) > 0:
+            parts.append(f"throttled={rl['throttle_count']}")
+        tracked = rl.get("tracked_responses", 0)
+        total = rl.get("total_responses", 0)
+        parts.append(f"tracked={tracked}/{total}")
+        print(f"\n  🚦 Rate-Limits: {', '.join(parts)}")
     print("=" * 60)
 
 
@@ -1383,6 +1425,8 @@ def _to_dict(r: BenchmarkResult) -> dict:
         d["tags"] = r.tags
     if r.anomalies:
         d["anomalies"] = r.anomalies
+    if r.ratelimit_summary:
+        d["ratelimit_summary"] = r.ratelimit_summary
     if r.warmup_profile:
         d["warmup_profile"] = r.warmup_profile
     if r.priority_metrics:

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -453,6 +453,15 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         ),
     )
 
+    # Rate-limit header tracking (M66)
+    parser.add_argument(
+        "--track-ratelimits",
+        action="store_true",
+        default=False,
+        dest="track_ratelimits",
+        help="Track rate-limit response headers and report backpressure summary.",
+    )
+
     # Response validation (M47)
     parser.add_argument(
         "--validate-response",

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -113,6 +113,7 @@ _KNOWN_KEYS: set[str] = {
     "webhook_secret",
     "otlp_endpoint",
     "on_complete",
+    "track_ratelimits",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/src/xpyd_bench/dummy/cli.py
+++ b/src/xpyd_bench/dummy/cli.py
@@ -63,6 +63,12 @@ def dummy_main(argv: list[str] | None = None) -> None:
         default=None,
         help="Maximum requests per second before rejecting with 429 (default: unlimited).",
     )
+    parser.add_argument(
+        "--ratelimit-rpm",
+        type=int,
+        default=None,
+        help="Include rate-limit headers in responses with this RPM limit.",
+    )
     args = parser.parse_args(argv)
 
     import uvicorn
@@ -78,6 +84,7 @@ def dummy_main(argv: list[str] | None = None) -> None:
         require_api_key=args.require_api_key,
         embedding_dim=args.embedding_dim,
         max_rps=args.max_rps,
+        ratelimit_rpm=args.ratelimit_rpm,
     )
     app = create_app(config)
 

--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -37,6 +37,12 @@ class ServerConfig:
     require_api_key: str | None = None  # If set, require this API key for auth
     embedding_dim: int = 1536  # Dimensionality for embedding vectors
     max_rps: float | None = None  # If set, reject requests above this rate (429)
+    ratelimit_rpm: int | None = None  # If set, include rate-limit headers in responses
+
+
+# Rate-limit tracking state for dummy server
+_ratelimit_remaining: int = 0
+_ratelimit_window_start: float = 0.0
 
 
 # Global config — set before starting the server
@@ -47,6 +53,29 @@ def set_config(config: ServerConfig) -> None:
     """Set server configuration."""
     global _config  # noqa: PLW0603
     _config = config
+    if config.ratelimit_rpm is not None:
+        global _ratelimit_remaining, _ratelimit_window_start  # noqa: PLW0603
+        _ratelimit_remaining = config.ratelimit_rpm
+        _ratelimit_window_start = time.time()
+
+
+def _ratelimit_headers() -> dict[str, str]:
+    """Generate rate-limit response headers if ratelimit_rpm is configured."""
+    if _config.ratelimit_rpm is None:
+        return {}
+    global _ratelimit_remaining, _ratelimit_window_start  # noqa: PLW0603
+    now = time.time()
+    # Reset window every 60 seconds
+    if now - _ratelimit_window_start >= 60.0:
+        _ratelimit_remaining = _config.ratelimit_rpm
+        _ratelimit_window_start = now
+    _ratelimit_remaining = max(_ratelimit_remaining - 1, 0)
+    reset_at = int(_ratelimit_window_start + 60)
+    return {
+        "X-RateLimit-Limit": str(_config.ratelimit_rpm),
+        "X-RateLimit-Remaining": str(_ratelimit_remaining),
+        "X-RateLimit-Reset": str(reset_at),
+    }
 
 
 # Standard headers to exclude from echo
@@ -300,10 +329,11 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
                 seed=seed,
                 ignore_eos=ignore_eos,
             ),
-            media_type="text/event-stream", headers=_echo_headers_dict(request),
+            media_type="text/event-stream",
+            headers={**_echo_headers_dict(request), **_ratelimit_headers()},
         )
 
-    # Non-streaming: simulate full latency
+    # Non-streaming: simulate full latency (completions)
     total_ms = _config.prefill_ms + _config.decode_ms * max_tokens
     await asyncio.sleep(total_ms / 1000.0)
 
@@ -358,7 +388,9 @@ async def _handle_completions(request: Request) -> JSONResponse | StreamingRespo
     }
     if seed is not None:
         resp_body["system_fingerprint"] = f"fp_seed_{seed}"
-    return JSONResponse(resp_body, headers=_echo_headers_dict(request))
+    hdrs = _echo_headers_dict(request)
+    hdrs.update(_ratelimit_headers())
+    return JSONResponse(resp_body, headers=hdrs)
 
 
 async def _stream_completions(
@@ -636,7 +668,8 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
                 seed=seed,
                 ignore_eos=ignore_eos,
             ),
-            media_type="text/event-stream", headers=_echo_headers_dict(request),
+            media_type="text/event-stream",
+            headers={**_echo_headers_dict(request), **_ratelimit_headers()},
         )
 
     # Non-streaming
@@ -720,7 +753,9 @@ async def _handle_chat_completions(request: Request) -> JSONResponse | Streaming
     }
     if seed is not None:
         resp_body["system_fingerprint"] = f"fp_seed_{seed}"
-    return JSONResponse(resp_body, headers=_echo_headers_dict(request))
+    hdrs = _echo_headers_dict(request)
+    hdrs.update(_ratelimit_headers())
+    return JSONResponse(resp_body, headers=hdrs)
 
 
 async def _stream_chat_completions(

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,0 +1,276 @@
+"""Tests for M66: Rate-Limit Header Tracking & Backpressure Reporting."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from xpyd_bench.bench.ratelimit import (
+    RatelimitSummary,
+    aggregate_ratelimit,
+    parse_ratelimit_headers,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests — header parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseRatelimitHeaders:
+    def test_standard_headers(self):
+        headers = {
+            "X-RateLimit-Limit": "100",
+            "X-RateLimit-Remaining": "42",
+            "X-RateLimit-Reset": "1700000000",
+        }
+        parsed = parse_ratelimit_headers(headers)
+        assert parsed["limit"] == "100"
+        assert parsed["remaining"] == "42"
+        assert parsed["reset"] == "1700000000"
+
+    def test_openai_style_headers(self):
+        headers = {
+            "x-ratelimit-limit-requests": "60",
+            "x-ratelimit-remaining-requests": "59",
+            "x-ratelimit-limit-tokens": "100000",
+            "x-ratelimit-remaining-tokens": "99500",
+            "x-ratelimit-reset-requests": "1s",
+            "x-ratelimit-reset-tokens": "200ms",
+        }
+        parsed = parse_ratelimit_headers(headers)
+        assert parsed["limit_requests"] == "60"
+        assert parsed["remaining_requests"] == "59"
+        assert parsed["limit_tokens"] == "100000"
+        assert parsed["remaining_tokens"] == "99500"
+
+    def test_retry_after(self):
+        headers = {"Retry-After": "30"}
+        parsed = parse_ratelimit_headers(headers)
+        assert parsed["retry_after"] == "30"
+
+    def test_no_ratelimit_headers(self):
+        headers = {"Content-Type": "application/json", "X-Custom": "foo"}
+        parsed = parse_ratelimit_headers(headers)
+        assert parsed == {}
+
+    def test_case_insensitive(self):
+        # httpx headers are case-insensitive by default
+        headers = httpx.Headers({"x-ratelimit-remaining": "5"})
+        parsed = parse_ratelimit_headers(headers)
+        assert parsed["remaining"] == "5"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateRatelimit:
+    def test_basic_aggregation(self):
+        per_request = [
+            {"limit": "100", "remaining": "99"},
+            {"limit": "100", "remaining": "98"},
+            {"limit": "100", "remaining": "97"},
+        ]
+        summary = aggregate_ratelimit(per_request)
+        assert summary.min_remaining == 97
+        assert summary.max_limit == 100
+        assert summary.tracked_responses == 3
+        assert summary.total_responses == 3
+        assert summary.throttle_count == 0
+
+    def test_with_none_entries(self):
+        per_request = [
+            {"remaining": "50"},
+            None,
+            {"remaining": "48"},
+        ]
+        summary = aggregate_ratelimit(per_request)
+        assert summary.min_remaining == 48
+        assert summary.tracked_responses == 2
+        assert summary.total_responses == 3
+
+    def test_throttle_detection(self):
+        per_request = [None, None, None]
+        errors = [None, "Client error '429 Too Many Requests'", None]
+        summary = aggregate_ratelimit(per_request, errors)
+        assert summary.throttle_count == 1
+
+    def test_token_remaining(self):
+        per_request = [
+            {"remaining_tokens": "10000"},
+            {"remaining_tokens": "9500"},
+        ]
+        summary = aggregate_ratelimit(per_request)
+        assert summary.min_remaining_tokens == 9500
+
+    def test_empty_input(self):
+        summary = aggregate_ratelimit([])
+        assert summary.total_responses == 0
+        assert summary.min_remaining is None
+        assert summary.throttle_count == 0
+
+    def test_to_dict(self):
+        summary = RatelimitSummary(
+            min_remaining=5, max_limit=100, throttle_count=2,
+            tracked_responses=10, total_responses=12,
+        )
+        d = summary.to_dict()
+        assert d["min_remaining"] == 5
+        assert d["max_limit"] == 100
+        assert d["throttle_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration test — dummy server with ratelimit headers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _dummy_server_with_ratelimit(unused_tcp_port_factory):
+    """Start dummy server with ratelimit_rpm configured."""
+    import uvicorn
+
+    from xpyd_bench.dummy.server import ServerConfig, create_app
+
+    port = unused_tcp_port_factory()
+    config = ServerConfig(
+        prefill_ms=1,
+        decode_ms=1,
+        model_name="test-model",
+        max_tokens_default=5,
+        ratelimit_rpm=60,
+    )
+    app = create_app(config)
+
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error"))
+
+    loop = asyncio.new_event_loop()
+    import threading
+
+    thread = threading.Thread(target=loop.run_until_complete, args=(server.serve(),), daemon=True)
+    thread.start()
+
+    # Wait for server to start
+    import time as _time
+
+    for _ in range(50):
+        try:
+            httpx.get(f"http://127.0.0.1:{port}/health", timeout=0.5)
+            break
+        except Exception:
+            _time.sleep(0.1)
+
+    yield port
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+def test_dummy_server_ratelimit_headers(_dummy_server_with_ratelimit):
+    """Dummy server returns X-RateLimit-* headers when ratelimit_rpm is set."""
+    port = _dummy_server_with_ratelimit
+    resp = httpx.post(
+        f"http://127.0.0.1:{port}/v1/completions",
+        json={"model": "test-model", "prompt": "hello", "max_tokens": 3},
+        timeout=10,
+    )
+    assert resp.status_code == 200
+    assert "x-ratelimit-limit" in resp.headers
+    assert "x-ratelimit-remaining" in resp.headers
+    assert "x-ratelimit-reset" in resp.headers
+    assert resp.headers["x-ratelimit-limit"] == "60"
+
+
+def test_dummy_server_chat_ratelimit_headers(_dummy_server_with_ratelimit):
+    """Chat completions also returns rate-limit headers."""
+    port = _dummy_server_with_ratelimit
+    resp = httpx.post(
+        f"http://127.0.0.1:{port}/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 3,
+        },
+        timeout=10,
+    )
+    assert resp.status_code == 200
+    assert "x-ratelimit-limit" in resp.headers
+
+
+def test_dummy_server_no_ratelimit_without_config(unused_tcp_port_factory):
+    """Without ratelimit_rpm, no rate-limit headers are present."""
+    import uvicorn
+
+    from xpyd_bench.dummy.server import ServerConfig, create_app
+
+    port = unused_tcp_port_factory()
+    config = ServerConfig(prefill_ms=1, decode_ms=1, max_tokens_default=3)
+    app = create_app(config)
+
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error"))
+
+    loop = asyncio.new_event_loop()
+    import threading
+
+    thread = threading.Thread(target=loop.run_until_complete, args=(server.serve(),), daemon=True)
+    thread.start()
+
+    import time as _time
+
+    for _ in range(50):
+        try:
+            httpx.get(f"http://127.0.0.1:{port}/health", timeout=0.5)
+            break
+        except Exception:
+            _time.sleep(0.1)
+
+    try:
+        resp = httpx.post(
+            f"http://127.0.0.1:{port}/v1/completions",
+            json={"model": "dummy-model", "prompt": "hello", "max_tokens": 3},
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        assert "x-ratelimit-limit" not in resp.headers
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# CLI integration test
+# ---------------------------------------------------------------------------
+
+
+def test_cli_track_ratelimits_flag():
+    """--track-ratelimits flag is parsed correctly."""
+    import argparse
+
+    from xpyd_bench.cli import _add_vllm_compat_args
+
+    parser = argparse.ArgumentParser()
+    _add_vllm_compat_args(parser)
+    ns = parser.parse_args(["--track-ratelimits", "--base-url", "http://localhost:8000"])
+    assert ns.track_ratelimits is True
+
+
+def test_cli_track_ratelimits_default():
+    """--track-ratelimits defaults to False."""
+    import argparse
+
+    from xpyd_bench.cli import _add_vllm_compat_args
+
+    parser = argparse.ArgumentParser()
+    _add_vllm_compat_args(parser)
+    ns = parser.parse_args(["--base-url", "http://localhost:8000"])
+    assert ns.track_ratelimits is False
+
+
+def test_config_known_keys_includes_track_ratelimits():
+    """track_ratelimits is in the known config keys set."""
+    from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+    assert "track_ratelimits" in _KNOWN_KEYS


### PR DESCRIPTION
## Summary
Add `--track-ratelimits` CLI flag to parse rate-limit response headers from LLM endpoints and aggregate them into a backpressure summary.

## Changes
- New module `src/xpyd_bench/bench/ratelimit.py` with header parsing and aggregation
- `RequestResult.ratelimit_headers` dict field for per-request tracking
- `BenchmarkResult.ratelimit_summary` with min remaining, throttle count, limit values
- Terminal summary prints rate-limit pressure indicators (🚦)
- Dummy server `--ratelimit-rpm N` returns configurable `X-RateLimit-*` headers
- YAML config support (`track_ratelimits: true`)
- CLI flag `--track-ratelimits` (default off)
- 17 tests covering parsing, aggregation, dummy server headers, CLI integration

## Files Changed
- `ROADMAP.md` — added M66
- `src/xpyd_bench/bench/ratelimit.py` — new module
- `src/xpyd_bench/bench/models.py` — new fields
- `src/xpyd_bench/bench/runner.py` — integration
- `src/xpyd_bench/cli.py` — CLI flag
- `src/xpyd_bench/config_cmd.py` — known key
- `src/xpyd_bench/dummy/server.py` — rate-limit header support
- `src/xpyd_bench/dummy/cli.py` — --ratelimit-rpm flag
- `tests/test_ratelimit.py` — 17 tests

Closes #189