### PR TITLE
feat(m68): output token generation speed benchmarking

### DIFF
--- a/src/xpyd_bench/bench/generation_speed.py
+++ b/src/xpyd_bench/bench/generation_speed.py
@@ -1,0 +1,83 @@
+"""Output token generation speed calculation and aggregation (M68)."""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class GenerationSpeedSummary:
+    """Aggregated generation speed statistics across a benchmark run."""
+
+    mean_tps: float = 0.0
+    p50_tps: float = 0.0
+    p90_tps: float = 0.0
+    p99_tps: float = 0.0
+    min_tps: float = 0.0
+    max_tps: float = 0.0
+    tracked_requests: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mean_tps": round(self.mean_tps, 2),
+            "p50_tps": round(self.p50_tps, 2),
+            "p90_tps": round(self.p90_tps, 2),
+            "p99_tps": round(self.p99_tps, 2),
+            "min_tps": round(self.min_tps, 2),
+            "max_tps": round(self.max_tps, 2),
+            "tracked_requests": self.tracked_requests,
+        }
+
+
+def compute_generation_tps(
+    completion_tokens: int,
+    ttft_ms: float | None,
+    latency_ms: float,
+) -> float | None:
+    """Compute output generation tokens per second for a single request.
+
+    Generation time = total latency - TTFT (the decode phase).
+    If TTFT is not available (non-streaming), use total latency as fallback.
+    Returns None if tokens or time is zero/negative.
+    """
+    if completion_tokens <= 0:
+        return None
+
+    if ttft_ms is not None:
+        generation_ms = latency_ms - ttft_ms
+    else:
+        generation_ms = latency_ms
+
+    if generation_ms <= 0:
+        return None
+
+    return completion_tokens / (generation_ms / 1000.0)
+
+
+def aggregate_generation_speeds(
+    tps_values: list[float | None],
+) -> GenerationSpeedSummary:
+    """Aggregate per-request generation TPS into a summary."""
+    vals = [v for v in tps_values if v is not None]
+    summary = GenerationSpeedSummary()
+    summary.tracked_requests = len(vals)
+
+    if not vals:
+        return summary
+
+    summary.mean_tps = statistics.mean(vals)
+    summary.min_tps = min(vals)
+    summary.max_tps = max(vals)
+    summary.p50_tps = float(statistics.median(vals))
+
+    if len(vals) >= 2:
+        quantiles = statistics.quantiles(vals, n=100)
+        summary.p90_tps = float(quantiles[89])
+        summary.p99_tps = float(quantiles[-1])
+    else:
+        summary.p90_tps = float(vals[0])
+        summary.p99_tps = float(vals[0])
+
+    return summary

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -31,6 +31,7 @@ class RequestResult:
     ratelimit_headers: dict | None = None  # Rate-limit headers (M66)
     request_bytes: int | None = None  # Request payload size in bytes (M67)
     response_bytes: int | None = None  # Response payload size in bytes (M67)
+    generation_tps: float | None = None  # Output tokens/s for this request (M68)
 
 
 @dataclass
@@ -129,3 +130,6 @@ class BenchmarkResult:
 
     # Payload size tracking summary (M67)
     payload_summary: dict | None = None
+
+    # Generation speed summary (M68)
+    generation_speed_summary: dict | None = None

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -744,6 +744,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     sse_stall_threshold = float(getattr(args, "sse_stall_threshold_ms", 1000.0) or 1000.0)
     track_ratelimits_enabled = bool(getattr(args, "track_ratelimits", False))
     track_payload_size_enabled = bool(getattr(args, "track_payload_size", False))
+    measure_generation_speed = bool(getattr(args, "measure_generation_speed", False))
 
     async def _do_send(
         client: httpx.AsyncClient, payload: dict[str, Any]
@@ -1152,6 +1153,22 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         resp_bytes = [r.response_bytes for r in result.requests]
         ps_summary = aggregate_payload_sizes(req_bytes, resp_bytes)
         result.payload_summary = ps_summary.to_dict()
+
+    # Generation speed calculation and aggregation (M68)
+    if measure_generation_speed and result.requests:
+        from xpyd_bench.bench.generation_speed import (
+            aggregate_generation_speeds,
+            compute_generation_tps,
+        )
+
+        for req in result.requests:
+            if req.success:
+                req.generation_tps = compute_generation_tps(
+                    req.completion_tokens, req.ttft_ms, req.latency_ms
+                )
+        tps_vals = [r.generation_tps for r in result.requests]
+        gs_summary = aggregate_generation_speeds(tps_vals)
+        result.generation_speed_summary = gs_summary.to_dict()
 
     # Response validation (M47)
     validators_specs = getattr(args, "validate_response", None) or []

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -471,6 +471,15 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Track request/response payload sizes and report bandwidth summary.",
     )
 
+    # Generation speed tracking (M68)
+    parser.add_argument(
+        "--measure-generation-speed",
+        action="store_true",
+        default=False,
+        dest="measure_generation_speed",
+        help="Compute per-request output token generation speed (tokens/s).",
+    )
+
     # Response validation (M47)
     parser.add_argument(
         "--validate-response",

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -115,6 +115,7 @@ _KNOWN_KEYS: set[str] = {
     "on_complete",
     "track_ratelimits",
     "track_payload_size",
+    "measure_generation_speed",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/tests/test_generation_speed.py
+++ b/tests/test_generation_speed.py
@@ -1,0 +1,132 @@
+"""Tests for M68: Output Token Speed Benchmarking & Comparison."""
+
+from __future__ import annotations
+
+from xpyd_bench.bench.generation_speed import (
+    GenerationSpeedSummary,
+    aggregate_generation_speeds,
+    compute_generation_tps,
+)
+
+
+class TestComputeGenerationTps:
+    """Tests for per-request generation TPS calculation."""
+
+    def test_streaming_with_ttft(self):
+        """Streaming: generation_time = latency - ttft."""
+        # 100 tokens, latency=500ms, ttft=100ms => gen_time=400ms => 250 tok/s
+        tps = compute_generation_tps(100, ttft_ms=100.0, latency_ms=500.0)
+        assert tps is not None
+        assert abs(tps - 250.0) < 0.01
+
+    def test_non_streaming_no_ttft(self):
+        """Non-streaming: use full latency as generation time."""
+        # 50 tokens, latency=1000ms => 50 tok/s
+        tps = compute_generation_tps(50, ttft_ms=None, latency_ms=1000.0)
+        assert tps is not None
+        assert abs(tps - 50.0) < 0.01
+
+    def test_zero_tokens_returns_none(self):
+        assert compute_generation_tps(0, ttft_ms=10.0, latency_ms=100.0) is None
+
+    def test_negative_tokens_returns_none(self):
+        assert compute_generation_tps(-5, ttft_ms=10.0, latency_ms=100.0) is None
+
+    def test_zero_generation_time_returns_none(self):
+        """ttft == latency => generation_time = 0 => None."""
+        assert compute_generation_tps(10, ttft_ms=100.0, latency_ms=100.0) is None
+
+    def test_negative_generation_time_returns_none(self):
+        """ttft > latency => negative generation_time => None."""
+        assert compute_generation_tps(10, ttft_ms=200.0, latency_ms=100.0) is None
+
+    def test_zero_latency_returns_none(self):
+        assert compute_generation_tps(10, ttft_ms=None, latency_ms=0.0) is None
+
+    def test_large_token_count(self):
+        # 10000 tokens in 2000ms => 5000 tok/s
+        tps = compute_generation_tps(10000, ttft_ms=None, latency_ms=2000.0)
+        assert tps is not None
+        assert abs(tps - 5000.0) < 0.01
+
+    def test_small_generation_time(self):
+        # 1 token in 1ms generation time
+        tps = compute_generation_tps(1, ttft_ms=99.0, latency_ms=100.0)
+        assert tps is not None
+        assert abs(tps - 1000.0) < 0.01
+
+
+class TestAggregateGenerationSpeeds:
+    """Tests for TPS aggregation."""
+
+    def test_basic_aggregation(self):
+        vals = [100.0, 200.0, 150.0, 250.0, 50.0]
+        summary = aggregate_generation_speeds(vals)
+        assert summary.tracked_requests == 5
+        assert abs(summary.mean_tps - 150.0) < 0.01
+        assert summary.min_tps == 50.0
+        assert summary.max_tps == 250.0
+        assert summary.p50_tps == 150.0
+
+    def test_empty_list(self):
+        summary = aggregate_generation_speeds([])
+        assert summary.tracked_requests == 0
+        assert summary.mean_tps == 0.0
+
+    def test_all_none(self):
+        summary = aggregate_generation_speeds([None, None, None])
+        assert summary.tracked_requests == 0
+
+    def test_mixed_none_and_values(self):
+        vals = [100.0, None, 200.0, None]
+        summary = aggregate_generation_speeds(vals)
+        assert summary.tracked_requests == 2
+        assert abs(summary.mean_tps - 150.0) < 0.01
+
+    def test_single_value(self):
+        summary = aggregate_generation_speeds([42.0])
+        assert summary.tracked_requests == 1
+        assert summary.mean_tps == 42.0
+        assert summary.p50_tps == 42.0
+        assert summary.p90_tps == 42.0
+        assert summary.p99_tps == 42.0
+
+    def test_to_dict(self):
+        summary = aggregate_generation_speeds([100.0, 200.0])
+        d = summary.to_dict()
+        assert "mean_tps" in d
+        assert "p50_tps" in d
+        assert "p90_tps" in d
+        assert "p99_tps" in d
+        assert "min_tps" in d
+        assert "max_tps" in d
+        assert "tracked_requests" in d
+        assert d["tracked_requests"] == 2
+
+
+class TestGenerationSpeedSummaryToDict:
+    """Tests for to_dict rounding."""
+
+    def test_rounding(self):
+        s = GenerationSpeedSummary(
+            mean_tps=123.456789,
+            p50_tps=100.111,
+            p90_tps=200.999,
+            p99_tps=300.005,
+            min_tps=50.123,
+            max_tps=400.789,
+            tracked_requests=10,
+        )
+        d = s.to_dict()
+        assert d["mean_tps"] == 123.46
+        assert d["min_tps"] == 50.12
+        assert d["max_tps"] == 400.79
+
+
+class TestConfigKey:
+    """Test that measure_generation_speed is a known config key."""
+
+    def test_known_key(self):
+        from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+        assert "measure_generation_speed" in _KNOWN_KEYS


### PR DESCRIPTION
## Summary
Add per-request output token generation speed measurement.

- `--measure-generation-speed` CLI flag
- Per-request `generation_tps` = completion_tokens / generation_time
- Generation time = latency - TTFT (streaming) or full latency (non-streaming)
- `generation_speed_summary` in BenchmarkResult: mean, P50, P90, P99, min, max
- YAML config support (`measure_generation_speed: true`)
- 17 tests covering calculation, aggregation, edge cases, config key

Closes #194