### PR TITLE
feat(m69): Benchmark Metadata & Notes

### DIFF
--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -101,6 +101,9 @@ class BenchmarkResult:
     # User-defined tags for annotation (M36)
     tags: dict[str, str] = field(default_factory=dict)
 
+    # Human-readable note/description for the run (M69)
+    note: str | None = None
+
     # Anomaly detection results (M43)
     anomalies: dict | None = None
 

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -718,6 +718,14 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Display a latency heatmap in the terminal after the benchmark.",
     )
 
+    # Note (M69)
+    parser.add_argument(
+        "--note",
+        type=str,
+        default=None,
+        help="Attach a human-readable note/description to this benchmark run",
+    )
+
     # Tags (M36)
     parser.add_argument(
         "--tag",
@@ -1423,6 +1431,12 @@ def bench_main(argv: list[str] | None = None) -> None:
     if parsed_tags:
         bench_result.tags = parsed_tags
         result["tags"] = parsed_tags
+
+    # Inject note (M69)
+    note = getattr(args, "note", None)
+    if note:
+        bench_result.note = note
+        result["note"] = note
 
     # Export reports (M6)
     if args.export_requests:

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -116,6 +116,7 @@ _KNOWN_KEYS: set[str] = {
     "track_ratelimits",
     "track_payload_size",
     "measure_generation_speed",
+    "note",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/src/xpyd_bench/history.py
+++ b/src/xpyd_bench/history.py
@@ -74,6 +74,7 @@ def _load_result_summary(path: Path) -> dict | None:
         "partial": data.get("partial", False),
         "total_duration_s": data.get("total_duration_s", 0),
         "tags": data.get("tags", {}),
+        "note": data.get("note"),
     }
 
 
@@ -126,8 +127,8 @@ def format_history_table(summaries: list[dict]) -> str:
     lines: list[str] = []
     lines.append(f"{'#':>3}  {'Timestamp':<20} {'Model':<16} {'Reqs':>5} "
                  f"{'OK':>5} {'Fail':>4} {'Thr req/s':>10} {'TTFT ms':>9} "
-                 f"{'E2E ms':>9} {'Partial':>7}")
-    lines.append("-" * 110)
+                 f"{'E2E ms':>9} {'Partial':>7}  {'Note'}")
+    lines.append("-" * 130)
 
     for i, s in enumerate(summaries, 1):
         ts = s["timestamp"].strftime("%Y-%m-%d %H:%M:%S")
@@ -136,10 +137,11 @@ def format_history_table(summaries: list[dict]) -> str:
         ttft = f"{s['mean_ttft_ms']:.1f}" if s["mean_ttft_ms"] is not None else "-"
         e2e = f"{s['mean_e2el_ms']:.1f}" if s["mean_e2el_ms"] is not None else "-"
         partial = "yes" if s["partial"] else ""
+        note = s.get("note") or ""
         lines.append(
             f"{i:>3}  {ts:<20} {model:<16} {s['num_prompts']:>5} "
             f"{s['completed']:>5} {s['failed']:>4} {thr:>10} {ttft:>9} "
-            f"{e2e:>9} {partial:>7}"
+            f"{e2e:>9} {partial:>7}  {note}"
         )
 
     # Sparkline trends (if ≥2 runs)

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -1,0 +1,183 @@
+"""Tests for M69: Benchmark Metadata & Notes."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+from xpyd_bench.bench.models import BenchmarkResult
+
+
+class TestBenchmarkResultNote:
+    """Test that BenchmarkResult has a note field."""
+
+    def test_default_none(self):
+        br = BenchmarkResult()
+        assert br.note is None
+
+    def test_set_note(self):
+        br = BenchmarkResult(note="baseline A100")
+        assert br.note == "baseline A100"
+
+
+class TestCLINoteFlag:
+    """Test --note CLI argument parsing."""
+
+    def _make_parser(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        return parser
+
+    def test_parse_note_flag(self):
+        parser = self._make_parser()
+        args = parser.parse_args(["--note", "my test run"])
+        assert args.note == "my test run"
+
+    def test_note_default_none(self):
+        parser = self._make_parser()
+        args = parser.parse_args([])
+        assert args.note is None
+
+
+class TestHistoryNote:
+    """Test that history includes note in summaries and table output."""
+
+    def _write_result(self, d: Path, data: dict, name: str = "r.json"):
+        p = d / name
+        p.write_text(json.dumps(data))
+        return p
+
+    def test_summary_includes_note(self):
+        from xpyd_bench.history import _load_result_summary
+
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "result.json"
+            p.write_text(json.dumps({
+                "model": "gpt-4",
+                "num_prompts": 10,
+                "completed": 10,
+                "failed": 0,
+                "note": "after optimization",
+            }))
+            summary = _load_result_summary(p)
+            assert summary["note"] == "after optimization"
+
+    def test_summary_note_missing(self):
+        from xpyd_bench.history import _load_result_summary
+
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "result.json"
+            p.write_text(json.dumps({
+                "model": "gpt-4",
+                "num_prompts": 10,
+                "completed": 10,
+                "failed": 0,
+            }))
+            summary = _load_result_summary(p)
+            assert summary["note"] is None
+
+    def test_history_table_contains_note(self):
+        from xpyd_bench.history import format_history_table
+
+        summaries = [
+            {
+                "file": "r.json",
+                "timestamp": datetime(2025, 1, 1, 12, 0, 0),
+                "model": "gpt-4",
+                "num_prompts": 10,
+                "completed": 10,
+                "failed": 0,
+                "request_throughput": 5.0,
+                "output_throughput": 100.0,
+                "mean_ttft_ms": 50.0,
+                "mean_e2el_ms": 200.0,
+                "partial": False,
+                "total_duration_s": 2.0,
+                "tags": {},
+                "note": "baseline run",
+            }
+        ]
+        table = format_history_table(summaries)
+        assert "Note" in table
+        assert "baseline run" in table
+
+    def test_history_table_no_note(self):
+        from xpyd_bench.history import format_history_table
+
+        summaries = [
+            {
+                "file": "r.json",
+                "timestamp": datetime(2025, 1, 1, 12, 0, 0),
+                "model": "gpt-4",
+                "num_prompts": 10,
+                "completed": 10,
+                "failed": 0,
+                "request_throughput": 5.0,
+                "output_throughput": 100.0,
+                "mean_ttft_ms": 50.0,
+                "mean_e2el_ms": 200.0,
+                "partial": False,
+                "total_duration_s": 2.0,
+                "tags": {},
+                "note": None,
+            }
+        ]
+        table = format_history_table(summaries)
+        assert "Note" in table
+
+
+class TestYAMLConfigNote:
+    """Test that note can be set via YAML config."""
+
+    def test_yaml_note_known_key(self):
+        from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+        assert "note" in _KNOWN_KEYS
+
+    def test_yaml_config_sets_note(self):
+        import argparse
+
+        from xpyd_bench.cli import _load_yaml_config
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("note: yaml note value\n")
+            f.flush()
+            args = argparse.Namespace(note=None)
+            result = _load_yaml_config(f.name, args)
+            assert result.note == "yaml note value"
+
+    def test_cli_note_overrides_yaml(self):
+        import argparse
+
+        from xpyd_bench.cli import _load_yaml_config
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("note: yaml note\n")
+            f.flush()
+            args = argparse.Namespace(note="cli note")
+            result = _load_yaml_config(f.name, args, explicit_keys={"note"})
+            assert result.note == "cli note"
+
+
+class TestNoteInJSONOutput:
+    """Test that note appears in serialized JSON result dict."""
+
+    def test_note_in_result_dict(self):
+        import dataclasses
+
+        br = BenchmarkResult(note="test note")
+        d = dataclasses.asdict(br)
+        assert d["note"] == "test note"
+
+    def test_note_none_in_result_dict(self):
+        import dataclasses
+
+        br = BenchmarkResult()
+        d = dataclasses.asdict(br)
+        assert d["note"] is None


### PR DESCRIPTION
## Summary
Add `--note "description"` CLI flag to attach human-readable annotations to benchmark runs.

## Changes
- `BenchmarkResult.note` field (str | None)
- `--note` CLI flag on `run` subcommand
- Note included in JSON output
- History table displays note column
- YAML config support (`note: "description"`)
- `note` added to known config keys for validation
- 13 new tests

## Acceptance Criteria
- [x] `--note "text"` CLI flag accepted
- [x] `BenchmarkResult` has `note: str | None = None` field
- [x] JSON output includes `note` field when set
- [x] History listing shows note column
- [x] YAML config `note` key works
- [x] Tests cover: CLI parsing, JSON output, history display, YAML config

Closes #196