### PR TITLE
feat(m70): request timeout classification and reporting

### DIFF
--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -32,6 +32,7 @@ class RequestResult:
     request_bytes: int | None = None  # Request payload size in bytes (M67)
     response_bytes: int | None = None  # Response payload size in bytes (M67)
     generation_tps: float | None = None  # Output tokens/s for this request (M68)
+    timeout_detected: bool = False  # Whether request timed out (M70)
 
 
 @dataclass
@@ -136,3 +137,6 @@ class BenchmarkResult:
 
     # Generation speed summary (M68)
     generation_speed_summary: dict | None = None
+
+    # Timeout classification summary (M70)
+    timeout_summary: dict | None = None

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -271,6 +271,10 @@ async def _send_request(
             result.success = False
             result.error = str(exc)
 
+            # M70: Classify timeout exceptions
+            if isinstance(exc, (httpx.TimeoutException,)):
+                result.timeout_detected = True
+
             # Retry if applicable
             if attempt < retries and _is_retryable(exc):
                 delay = retry_delay * (2**attempt)
@@ -377,6 +381,10 @@ async def _send_streaming(
     except Exception as exc:  # noqa: BLE001
         result.success = False
         result.error = str(exc)
+
+        # M70: Classify timeout exceptions
+        if isinstance(exc, (httpx.TimeoutException,)):
+            result.timeout_detected = True
 
     end = time.perf_counter()
     result.latency_ms = (end - start) * 1000.0
@@ -1267,6 +1275,13 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
             so_summary = aggregate_structured_output(so_results)
             result.structured_output_metrics = so_summary.to_dict()
 
+    # Timeout classification (M70)
+    from xpyd_bench.bench.timeout_stats import compute_timeout_summary
+
+    timeout_summary = compute_timeout_summary(result.requests)
+    if timeout_summary:
+        result.timeout_summary = timeout_summary
+
     if reporter:
         reporter.print_summary_table(result)
     else:
@@ -1350,6 +1365,18 @@ def _print_summary(r: BenchmarkResult) -> None:
         total = rl.get("total_responses", 0)
         parts.append(f"tracked={tracked}/{total}")
         print(f"\n  🚦 Rate-Limits: {', '.join(parts)}")
+    if r.timeout_summary:
+        ts = r.timeout_summary
+        print(
+            f"\n  ⏱️  Timeouts: {ts['timeout_count']}/{ts['total_requests']} "
+            f"requests timed out ({ts['timeout_percentage']}%)"
+        )
+        if "mean_latency_at_timeout_ms" in ts:
+            print(
+                f"      Latency at timeout: mean={ts['mean_latency_at_timeout_ms']:.2f} "
+                f"min={ts['min_latency_at_timeout_ms']:.2f} "
+                f"max={ts['max_latency_at_timeout_ms']:.2f} ms"
+            )
     print("=" * 60)
 
 
@@ -1491,4 +1518,6 @@ def _to_dict(r: BenchmarkResult) -> dict:
         d["latency_breakdown"] = r.latency_breakdown
     if r.noise_injection:
         d["noise_injection"] = r.noise_injection
+    if r.timeout_summary:
+        d["timeout_summary"] = r.timeout_summary
     return d

--- a/src/xpyd_bench/bench/timeout_stats.py
+++ b/src/xpyd_bench/bench/timeout_stats.py
@@ -1,0 +1,41 @@
+"""Request timeout classification and reporting (M70)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from xpyd_bench.bench.models import RequestResult
+
+
+def compute_timeout_summary(requests: list[RequestResult]) -> dict | None:
+    """Compute timeout classification summary from request results.
+
+    Returns None if no timeouts occurred.
+    """
+    if not requests:
+        return None
+
+    timed_out = [r for r in requests if r.timeout_detected]
+    if not timed_out:
+        return None
+
+    total = len(requests)
+    timeout_count = len(timed_out)
+    timeout_latencies = [r.latency_ms for r in timed_out if r.latency_ms > 0]
+
+    summary: dict = {
+        "timeout_count": timeout_count,
+        "total_requests": total,
+        "timeout_percentage": round(timeout_count / total * 100, 2),
+    }
+
+    if timeout_latencies:
+        timeout_latencies.sort()
+        summary["mean_latency_at_timeout_ms"] = round(
+            sum(timeout_latencies) / len(timeout_latencies), 2,
+        )
+        summary["min_latency_at_timeout_ms"] = round(timeout_latencies[0], 2)
+        summary["max_latency_at_timeout_ms"] = round(timeout_latencies[-1], 2)
+
+    return summary

--- a/tests/test_timeout_stats.py
+++ b/tests/test_timeout_stats.py
@@ -1,0 +1,100 @@
+"""Tests for M70: Request Timeout Classification & Reporting."""
+
+from __future__ import annotations
+
+from xpyd_bench.bench.models import BenchmarkResult, RequestResult
+from xpyd_bench.bench.timeout_stats import compute_timeout_summary
+
+
+class TestComputeTimeoutSummary:
+    """Tests for compute_timeout_summary()."""
+
+    def test_no_requests(self) -> None:
+        assert compute_timeout_summary([]) is None
+
+    def test_no_timeouts(self) -> None:
+        requests = [
+            RequestResult(success=True, latency_ms=100.0),
+            RequestResult(success=True, latency_ms=150.0),
+            RequestResult(success=False, error="server error", latency_ms=200.0),
+        ]
+        assert compute_timeout_summary(requests) is None
+
+    def test_some_timeouts(self) -> None:
+        requests = [
+            RequestResult(success=True, latency_ms=100.0),
+            RequestResult(
+                success=False, error="timeout", latency_ms=300000.0,
+                timeout_detected=True,
+            ),
+            RequestResult(success=True, latency_ms=120.0),
+            RequestResult(
+                success=False, error="timeout", latency_ms=310000.0,
+                timeout_detected=True,
+            ),
+        ]
+        summary = compute_timeout_summary(requests)
+        assert summary is not None
+        assert summary["timeout_count"] == 2
+        assert summary["total_requests"] == 4
+        assert summary["timeout_percentage"] == 50.0
+        assert summary["mean_latency_at_timeout_ms"] == 305000.0
+        assert summary["min_latency_at_timeout_ms"] == 300000.0
+        assert summary["max_latency_at_timeout_ms"] == 310000.0
+
+    def test_all_timeouts(self) -> None:
+        requests = [
+            RequestResult(
+                success=False, error="timeout", latency_ms=300000.0,
+                timeout_detected=True,
+            ),
+            RequestResult(
+                success=False, error="timeout", latency_ms=300000.0,
+                timeout_detected=True,
+            ),
+        ]
+        summary = compute_timeout_summary(requests)
+        assert summary is not None
+        assert summary["timeout_count"] == 2
+        assert summary["timeout_percentage"] == 100.0
+
+    def test_single_timeout(self) -> None:
+        requests = [
+            RequestResult(
+                success=False, error="ReadTimeout", latency_ms=5000.0,
+                timeout_detected=True,
+            ),
+        ]
+        summary = compute_timeout_summary(requests)
+        assert summary is not None
+        assert summary["timeout_count"] == 1
+        assert summary["total_requests"] == 1
+        assert summary["timeout_percentage"] == 100.0
+        assert summary["mean_latency_at_timeout_ms"] == 5000.0
+        assert summary["min_latency_at_timeout_ms"] == 5000.0
+        assert summary["max_latency_at_timeout_ms"] == 5000.0
+
+
+class TestRequestResultTimeoutField:
+    """Tests for timeout_detected field on RequestResult."""
+
+    def test_default_false(self) -> None:
+        r = RequestResult()
+        assert r.timeout_detected is False
+
+    def test_set_true(self) -> None:
+        r = RequestResult(timeout_detected=True)
+        assert r.timeout_detected is True
+
+
+class TestBenchmarkResultTimeoutSummary:
+    """Tests for timeout_summary field on BenchmarkResult."""
+
+    def test_default_none(self) -> None:
+        br = BenchmarkResult()
+        assert br.timeout_summary is None
+
+    def test_set_summary(self) -> None:
+        summary = {"timeout_count": 3, "total_requests": 10, "timeout_percentage": 30.0}
+        br = BenchmarkResult(timeout_summary=summary)
+        assert br.timeout_summary == summary


### PR DESCRIPTION
## Summary
Add explicit timeout classification and reporting to distinguish timed-out requests from other errors.

## Changes
- **`RequestResult.timeout_detected`**: boolean field (default False), set True on timeout
- **`BenchmarkResult.timeout_summary`**: dict with count, percentage, latency stats
- **`compute_timeout_summary()`**: new function in `bench/timeout_stats.py`
- **Runner**: classifies `httpx.TimeoutException` in both streaming and non-streaming paths
- **Terminal summary**: prints timeout breakdown when timeouts > 0
- **JSON output**: includes `timeout_summary` section

## Tests
9 tests covering: no timeouts, some timeouts, all timeouts, single timeout, field defaults, summary aggregation.

Closes #198