### PR TITLE
feat(m71): add request queuing time measurement

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -584,7 +584,7 @@
 - JSON output includes `timeout_summary` section
 - Tests covering timeout classification, summary aggregation, and edge cases
 
-## M71: Request Queuing Time Measurement ✗
+## M71: Request Queuing Time Measurement ✅
 - Measure client-side queuing time (time between request creation and actual send)
 - Per-request `queue_time` field in `RequestResult`
 - `BenchmarkResult` includes `queue_time_summary` with mean/P50/P99 stats

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -33,6 +33,7 @@ class RequestResult:
     response_bytes: int | None = None  # Response payload size in bytes (M67)
     generation_tps: float | None = None  # Output tokens/s for this request (M68)
     timeout_detected: bool = False  # Whether request timed out (M70)
+    queue_time_ms: float | None = None  # Client-side queuing time in ms (M71)
 
 
 @dataclass
@@ -140,3 +141,6 @@ class BenchmarkResult:
 
     # Timeout classification summary (M70)
     timeout_summary: dict | None = None
+
+    # Queue time summary (M71)
+    queue_time_summary: dict | None = None

--- a/src/xpyd_bench/bench/queue_time.py
+++ b/src/xpyd_bench/bench/queue_time.py
@@ -1,0 +1,38 @@
+"""Request queuing time measurement and reporting (M71)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from xpyd_bench.bench.models import RequestResult
+
+
+def compute_queue_time_summary(requests: list[RequestResult]) -> dict | None:
+    """Compute queue time summary from request results.
+
+    Queue time is the client-side delay between when a request is scheduled
+    (created/enqueued) and when it is actually sent over the network.
+
+    Returns None if no queue times were recorded.
+    """
+    queue_times = [
+        r.queue_time_ms for r in requests if r.queue_time_ms is not None and r.success
+    ]
+
+    if not queue_times:
+        return None
+
+    arr = np.array(queue_times)
+    return {
+        "count": len(queue_times),
+        "mean_ms": round(float(np.mean(arr)), 2),
+        "p50_ms": round(float(np.percentile(arr, 50)), 2),
+        "p90_ms": round(float(np.percentile(arr, 90)), 2),
+        "p95_ms": round(float(np.percentile(arr, 95)), 2),
+        "p99_ms": round(float(np.percentile(arr, 99)), 2),
+        "min_ms": round(float(np.min(arr)), 2),
+        "max_ms": round(float(np.max(arr)), 2),
+    }

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -909,9 +909,14 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
 
     async def _tracked_task(
         client: httpx.AsyncClient, prompt: str, priority: int | None = None,
+        scheduled_time: float | None = None,
     ) -> RequestResult:
         payload = _mk_payload(prompt)
+        # Record queue time: delay between scheduling and actual execution (M71)
+        _queue_start = time.perf_counter()
         r = await _task(client, prompt)
+        if scheduled_time is not None:
+            r.queue_time_ms = (_queue_start - scheduled_time) * 1000.0
         if debug_logger:
             p_bytes: int | None = None
             c_bytes: int | None = None
@@ -1007,7 +1012,12 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
                     break
                 if deadline and time.perf_counter() >= deadline:
                     break
-            task = asyncio.create_task(_tracked_task(client, prompt, priority=prompt_pri))
+            task = asyncio.create_task(
+                _tracked_task(
+                    client, prompt, priority=prompt_pri,
+                    scheduled_time=time.perf_counter(),
+                )
+            )
             tasks.append(task)
 
             if not reporter and not args.disable_tqdm and (i + 1) % 100 == 0:
@@ -1282,6 +1292,13 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     if timeout_summary:
         result.timeout_summary = timeout_summary
 
+    # Queue time summary (M71)
+    from xpyd_bench.bench.queue_time import compute_queue_time_summary
+
+    queue_time_summary = compute_queue_time_summary(result.requests)
+    if queue_time_summary:
+        result.queue_time_summary = queue_time_summary
+
     if reporter:
         reporter.print_summary_table(result)
     else:
@@ -1377,6 +1394,13 @@ def _print_summary(r: BenchmarkResult) -> None:
                 f"min={ts['min_latency_at_timeout_ms']:.2f} "
                 f"max={ts['max_latency_at_timeout_ms']:.2f} ms"
             )
+    if r.queue_time_summary:
+        qt = r.queue_time_summary
+        print(
+            f"\n  ⏳ Queue Time: mean={qt['mean_ms']:.2f} "
+            f"P50={qt['p50_ms']:.2f} P90={qt['p90_ms']:.2f} "
+            f"P99={qt['p99_ms']:.2f} ms ({qt['count']} requests)"
+        )
     print("=" * 60)
 
 
@@ -1520,4 +1544,6 @@ def _to_dict(r: BenchmarkResult) -> dict:
         d["noise_injection"] = r.noise_injection
     if r.timeout_summary:
         d["timeout_summary"] = r.timeout_summary
+    if r.queue_time_summary:
+        d["queue_time_summary"] = r.queue_time_summary
     return d

--- a/tests/test_queue_time.py
+++ b/tests/test_queue_time.py
@@ -1,0 +1,119 @@
+"""Tests for M71: Request Queuing Time Measurement."""
+
+from __future__ import annotations
+
+import unittest
+
+from xpyd_bench.bench.models import BenchmarkResult, RequestResult
+from xpyd_bench.bench.queue_time import compute_queue_time_summary
+
+
+class TestComputeQueueTimeSummary(unittest.TestCase):
+    """Test queue time summary computation."""
+
+    def test_basic_summary(self):
+        """Queue time summary returns expected stats."""
+        requests = [
+            RequestResult(success=True, queue_time_ms=10.0),
+            RequestResult(success=True, queue_time_ms=20.0),
+            RequestResult(success=True, queue_time_ms=30.0),
+            RequestResult(success=True, queue_time_ms=40.0),
+            RequestResult(success=True, queue_time_ms=50.0),
+        ]
+        summary = compute_queue_time_summary(requests)
+        assert summary is not None
+        assert summary["count"] == 5
+        assert summary["mean_ms"] == 30.0
+        assert summary["min_ms"] == 10.0
+        assert summary["max_ms"] == 50.0
+        assert "p50_ms" in summary
+        assert "p90_ms" in summary
+        assert "p95_ms" in summary
+        assert "p99_ms" in summary
+
+    def test_no_queue_times(self):
+        """Returns None when no queue times recorded."""
+        requests = [
+            RequestResult(success=True, queue_time_ms=None),
+            RequestResult(success=True, queue_time_ms=None),
+        ]
+        assert compute_queue_time_summary(requests) is None
+
+    def test_empty_requests(self):
+        """Returns None for empty request list."""
+        assert compute_queue_time_summary([]) is None
+
+    def test_only_failed_requests_excluded(self):
+        """Failed requests are excluded from summary."""
+        requests = [
+            RequestResult(success=False, queue_time_ms=100.0),
+            RequestResult(success=False, queue_time_ms=200.0),
+        ]
+        assert compute_queue_time_summary(requests) is None
+
+    def test_mixed_success_failure(self):
+        """Only successful requests contribute to summary."""
+        requests = [
+            RequestResult(success=True, queue_time_ms=10.0),
+            RequestResult(success=False, queue_time_ms=999.0),
+            RequestResult(success=True, queue_time_ms=20.0),
+        ]
+        summary = compute_queue_time_summary(requests)
+        assert summary is not None
+        assert summary["count"] == 2
+        assert summary["mean_ms"] == 15.0
+
+    def test_single_request(self):
+        """Summary works with a single request."""
+        requests = [RequestResult(success=True, queue_time_ms=5.0)]
+        summary = compute_queue_time_summary(requests)
+        assert summary is not None
+        assert summary["count"] == 1
+        assert summary["mean_ms"] == 5.0
+        assert summary["min_ms"] == 5.0
+        assert summary["max_ms"] == 5.0
+
+    def test_high_concurrency_scenario(self):
+        """Queue times increase under high concurrency."""
+        # Simulate increasing queue times (as would happen with concurrency limits)
+        requests = [
+            RequestResult(success=True, queue_time_ms=float(i * 10))
+            for i in range(100)
+        ]
+        summary = compute_queue_time_summary(requests)
+        assert summary is not None
+        assert summary["count"] == 100
+        assert summary["p99_ms"] > summary["p50_ms"]
+
+
+class TestRequestResultQueueTimeField(unittest.TestCase):
+    """Test queue_time_ms field on RequestResult."""
+
+    def test_default_none(self):
+        """queue_time_ms defaults to None."""
+        r = RequestResult()
+        assert r.queue_time_ms is None
+
+    def test_set_value(self):
+        """queue_time_ms can be set."""
+        r = RequestResult(queue_time_ms=42.5)
+        assert r.queue_time_ms == 42.5
+
+
+class TestBenchmarkResultQueueTimeSummary(unittest.TestCase):
+    """Test queue_time_summary field on BenchmarkResult."""
+
+    def test_default_none(self):
+        """queue_time_summary defaults to None."""
+        r = BenchmarkResult()
+        assert r.queue_time_summary is None
+
+    def test_set_summary(self):
+        """queue_time_summary can be set."""
+        r = BenchmarkResult()
+        r.queue_time_summary = {"count": 5, "mean_ms": 10.0}
+        assert r.queue_time_summary["count"] == 5
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #200

## Changes
- Add `queue_time_ms` field to `RequestResult` to track client-side queuing delay (time between task scheduling and actual execution)
- Add `queue_time_summary` to `BenchmarkResult` with mean/P50/P90/P95/P99/min/max stats
- Compute queue time in runner by passing `scheduled_time` to tracked tasks
- Display queue time summary in terminal output and JSON result
- Add comprehensive tests (11 test cases) covering summary computation, edge cases, and high-concurrency scenarios
- Mark M71 as complete in ROADMAP.md

## Testing
- All 1334 existing tests pass
- 11 new tests in `tests/test_queue_time.py` pass
- Lint clean (`ruff check` + `isort --check`)