### PR TITLE
feat(m72): add benchmark fingerprinting

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -592,7 +592,7 @@
 - Useful for understanding rate limiter and concurrency bottlenecks
 - Tests covering queue time measurement, summary stats, and high-concurrency scenarios
 
-## M72: Benchmark Fingerprinting ✗
+## M72: Benchmark Fingerprinting ✅
 - Generate deterministic fingerprint hash from benchmark configuration (CLI args + config)
 - `BenchmarkResult` includes `fingerprint` field (SHA-256 of normalized config)
 - `xpyd-bench history` can group runs by fingerprint to track same-config performance over time

--- a/src/xpyd_bench/aggregate.py
+++ b/src/xpyd_bench/aggregate.py
@@ -168,15 +168,14 @@ def aggregate_main(argv: list[str] | None = None) -> None:
         default=2,
         help="Minimum number of runs required (default: 2)",
     )
+    parser.add_argument(
+        "--by-fingerprint",
+        action="store_true",
+        default=False,
+        help="Auto-group results by benchmark fingerprint before aggregating (M72).",
+    )
 
     args = parser.parse_args(argv)
-
-    if len(args.results) < args.min_runs:
-        print(
-            f"Error: need at least {args.min_runs} result files, got {len(args.results)}.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
 
     results: list[dict] = []
     for path_str in args.results:
@@ -187,11 +186,39 @@ def aggregate_main(argv: list[str] | None = None) -> None:
         with open(path) as f:
             results.append(json.load(f))
 
-    agg = aggregate_results(results)
-    _print_table(agg)
+    if args.by_fingerprint:
+        groups: dict[str, list[dict]] = {}
+        for r in results:
+            fp = r.get("fingerprint", "unknown")
+            groups.setdefault(fp, []).append(r)
 
-    if args.output:
-        out_path = Path(args.output)
-        with open(out_path, "w") as f:
-            json.dump(agg.to_dict(), f, indent=2)
-        print(f"Saved aggregated summary to {out_path}")
+        for fp, group in sorted(groups.items()):
+            short_fp = fp[:12] if fp != "unknown" else "unknown"
+            print(f"\n🔑 Fingerprint: {short_fp}... ({len(group)} run(s))")
+            if len(group) < args.min_runs:
+                print(f"  Skipped: need at least {args.min_runs} runs.")
+                continue
+            agg = aggregate_results(group)
+            _print_table(agg)
+
+            if args.output:
+                out_path = Path(args.output).with_suffix(f".{fp[:12]}.json")
+                with open(out_path, "w") as f:
+                    json.dump(agg.to_dict(), f, indent=2)
+                print(f"  Saved to {out_path}")
+    else:
+        if len(results) < args.min_runs:
+            print(
+                f"Error: need at least {args.min_runs} result files, got {len(results)}.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        agg = aggregate_results(results)
+        _print_table(agg)
+
+        if args.output:
+            out_path = Path(args.output)
+            with open(out_path, "w") as f:
+                json.dump(agg.to_dict(), f, indent=2)
+            print(f"Saved aggregated summary to {out_path}")

--- a/src/xpyd_bench/bench/fingerprint.py
+++ b/src/xpyd_bench/bench/fingerprint.py
@@ -1,0 +1,106 @@
+"""Benchmark configuration fingerprinting (M72).
+
+Generates a deterministic SHA-256 hash from normalized benchmark configuration
+so that runs with identical settings can be grouped and compared over time.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from argparse import Namespace
+from typing import Any
+
+# Keys that do NOT affect benchmark behavior and should be excluded from fingerprint
+_EXCLUDED_KEYS: frozenset[str] = frozenset({
+    # Output / reporting paths (don't affect benchmark execution)
+    "save_result",
+    "result_dir",
+    "result_filename",
+    "json_report",
+    "csv_report",
+    "markdown_report",
+    "html_report",
+    "export_requests",
+    "export_requests_csv",
+    "debug_log",
+    "junit_xml",
+    "prometheus_export",
+    "text_report",
+    # Display options
+    "disable_tqdm",
+    "no_live",
+    "verbose",
+    "quiet",
+    "verbosity",
+    "list_scenarios",
+    "list_backends",
+    "heatmap",
+    # Metadata / annotations (user-provided labels, not config)
+    "note",
+    "tag",
+    "tags",
+    # Webhook / notification
+    "webhook_url",
+    "webhook_secret",
+    # Telemetry export
+    "otlp_endpoint",
+    "metrics_ws_port",
+    # Scheduling
+    "on_complete",
+    # Dry run flag
+    "dry_run",
+    # Archive
+    "archive",
+    # Sweep output
+    "sweep_output",
+    # Config file path itself
+    "config",
+})
+
+
+def _normalize_value(v: Any) -> Any:
+    """Normalize a config value for consistent hashing."""
+    if v is None:
+        return None
+    if isinstance(v, float) and v == float("inf"):
+        return "inf"
+    if isinstance(v, (list, tuple)):
+        return [_normalize_value(item) for item in v]
+    if isinstance(v, dict):
+        return {str(k): _normalize_value(val) for k, val in sorted(v.items())}
+    return v
+
+
+def compute_fingerprint(args: Namespace | dict) -> str:
+    """Compute a deterministic SHA-256 fingerprint from benchmark configuration.
+
+    Parameters
+    ----------
+    args:
+        CLI Namespace or dict of configuration values.
+
+    Returns
+    -------
+    str:
+        Hex-encoded SHA-256 hash string.
+    """
+    if isinstance(args, Namespace):
+        cfg = vars(args)
+    else:
+        cfg = dict(args)
+
+    # Filter out excluded keys and None values (defaults)
+    filtered: dict[str, Any] = {}
+    for key, value in cfg.items():
+        if key.startswith("_"):
+            continue
+        if key in _EXCLUDED_KEYS:
+            continue
+        normalized = _normalize_value(value)
+        if normalized is not None:
+            filtered[key] = normalized
+
+    # Sort keys for deterministic JSON serialization
+    canonical = json.dumps(filtered, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -144,3 +144,6 @@ class BenchmarkResult:
 
     # Queue time summary (M71)
     queue_time_summary: dict | None = None
+
+    # Benchmark fingerprint (M72)
+    fingerprint: str | None = None

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -1299,6 +1299,11 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     if queue_time_summary:
         result.queue_time_summary = queue_time_summary
 
+    # Benchmark fingerprint (M72)
+    from xpyd_bench.bench.fingerprint import compute_fingerprint
+
+    result.fingerprint = compute_fingerprint(args)
+
     if reporter:
         reporter.print_summary_table(result)
     else:
@@ -1546,4 +1551,6 @@ def _to_dict(r: BenchmarkResult) -> dict:
         d["timeout_summary"] = r.timeout_summary
     if r.queue_time_summary:
         d["queue_time_summary"] = r.queue_time_summary
+    if r.fingerprint:
+        d["fingerprint"] = r.fingerprint
     return d

--- a/src/xpyd_bench/history.py
+++ b/src/xpyd_bench/history.py
@@ -75,6 +75,7 @@ def _load_result_summary(path: Path) -> dict | None:
         "total_duration_s": data.get("total_duration_s", 0),
         "tags": data.get("tags", {}),
         "note": data.get("note"),
+        "fingerprint": data.get("fingerprint"),
     }
 
 
@@ -117,6 +118,44 @@ def list_history(
         summaries = summaries[-last_n:]
 
     return summaries
+
+
+def format_history_by_fingerprint(summaries: list[dict]) -> str:
+    """Group history summaries by fingerprint and format as grouped table (M72)."""
+    if not summaries:
+        return "No benchmark results found."
+
+    groups: dict[str, list[dict]] = {}
+    ungrouped: list[dict] = []
+    for s in summaries:
+        fp = s.get("fingerprint")
+        if fp:
+            groups.setdefault(fp, []).append(s)
+        else:
+            ungrouped.append(s)
+
+    lines: list[str] = []
+    for fp, runs in sorted(groups.items(), key=lambda x: x[1][0]["timestamp"]):
+        short_fp = fp[:12]
+        lines.append(f"\n🔑 Fingerprint: {short_fp}... ({len(runs)} run(s))")
+        lines.append(f"   {'Timestamp':<20} {'Model':<16} {'Thr req/s':>10} "
+                     f"{'TTFT ms':>9} {'E2E ms':>9}")
+        lines.append("   " + "-" * 70)
+        for s in runs:
+            ts = s["timestamp"].strftime("%Y-%m-%d %H:%M:%S")
+            model = (s["model"] or "?")[:15]
+            thr = f"{s['request_throughput']:.1f}" if s["request_throughput"] is not None else "-"
+            ttft = f"{s['mean_ttft_ms']:.1f}" if s["mean_ttft_ms"] is not None else "-"
+            e2e = f"{s['mean_e2el_ms']:.1f}" if s["mean_e2el_ms"] is not None else "-"
+            lines.append(f"   {ts:<20} {model:<16} {thr:>10} {ttft:>9} {e2e:>9}")
+
+    if ungrouped:
+        lines.append(f"\n⚠️  No fingerprint ({len(ungrouped)} run(s))")
+        for s in ungrouped:
+            ts = s["timestamp"].strftime("%Y-%m-%d %H:%M:%S")
+            lines.append(f"   {ts} - {s.get('model', '?')}")
+
+    return "\n".join(lines)
 
 
 def format_history_table(summaries: list[dict]) -> str:
@@ -211,6 +250,12 @@ def history_main(argv: list[str] | None = None) -> None:
         metavar="KEY=VALUE",
         help="Filter results by tag (repeatable). E.g. --filter-tag env=prod",
     )
+    parser.add_argument(
+        "--group-by-fingerprint",
+        action="store_true",
+        default=False,
+        help="Group results by benchmark fingerprint (M72).",
+    )
     args = parser.parse_args(argv)
 
     # Parse filter tags
@@ -223,4 +268,8 @@ def history_main(argv: list[str] | None = None) -> None:
                 filter_tags[k.strip()] = v.strip()
 
     summaries = list_history(args.result_dir, last_n=args.last, filter_tags=filter_tags)
-    print(format_history_table(summaries))
+
+    if args.group_by_fingerprint:
+        print(format_history_by_fingerprint(summaries))
+    else:
+        print(format_history_table(summaries))

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,0 +1,195 @@
+"""Tests for M72: Benchmark Fingerprinting."""
+
+from __future__ import annotations
+
+import unittest
+from argparse import Namespace
+
+from xpyd_bench.bench.fingerprint import compute_fingerprint
+from xpyd_bench.bench.models import BenchmarkResult
+
+
+class TestComputeFingerprint(unittest.TestCase):
+    """Test fingerprint computation."""
+
+    def test_deterministic(self):
+        """Same config produces same fingerprint."""
+        args = Namespace(
+            base_url="http://localhost:8000",
+            model="gpt-4",
+            num_prompts=100,
+            request_rate=10.0,
+            endpoint="/v1/completions",
+        )
+        fp1 = compute_fingerprint(args)
+        fp2 = compute_fingerprint(args)
+        assert fp1 == fp2
+        assert len(fp1) == 64  # SHA-256 hex
+
+    def test_different_config_different_fingerprint(self):
+        """Different configs produce different fingerprints."""
+        args1 = Namespace(model="gpt-4", num_prompts=100, request_rate=10.0)
+        args2 = Namespace(model="gpt-3.5", num_prompts=100, request_rate=10.0)
+        assert compute_fingerprint(args1) != compute_fingerprint(args2)
+
+    def test_arg_order_irrelevant(self):
+        """Argument order does not affect fingerprint."""
+        args1 = Namespace(model="gpt-4", num_prompts=100)
+        args2 = Namespace(num_prompts=100, model="gpt-4")
+        assert compute_fingerprint(args1) == compute_fingerprint(args2)
+
+    def test_excluded_keys_ignored(self):
+        """Output/display keys are excluded from fingerprint."""
+        args1 = Namespace(model="gpt-4", num_prompts=100)
+        args2 = Namespace(
+            model="gpt-4",
+            num_prompts=100,
+            save_result="out.json",
+            debug_log="/tmp/debug.log",
+            note="test run",
+            html_report="/tmp/report.html",
+            dry_run=True,
+            verbose=True,
+        )
+        assert compute_fingerprint(args1) == compute_fingerprint(args2)
+
+    def test_dict_input(self):
+        """Works with dict input as well as Namespace."""
+        cfg = {"model": "gpt-4", "num_prompts": 100}
+        fp1 = compute_fingerprint(cfg)
+        fp2 = compute_fingerprint(Namespace(**cfg))
+        assert fp1 == fp2
+
+    def test_none_values_excluded(self):
+        """None values are excluded (they represent defaults)."""
+        args1 = Namespace(model="gpt-4")
+        args2 = Namespace(model="gpt-4", temperature=None, top_p=None)
+        assert compute_fingerprint(args1) == compute_fingerprint(args2)
+
+    def test_inf_normalized(self):
+        """Float inf is normalized to string 'inf'."""
+        args1 = Namespace(model="gpt-4", request_rate=float("inf"))
+        args2 = Namespace(model="gpt-4", request_rate=float("inf"))
+        assert compute_fingerprint(args1) == compute_fingerprint(args2)
+
+    def test_private_keys_excluded(self):
+        """Keys starting with _ are excluded."""
+        args1 = Namespace(model="gpt-4")
+        args2 = Namespace(model="gpt-4", _internal="secret")
+        assert compute_fingerprint(args1) == compute_fingerprint(args2)
+
+    def test_nested_dict_normalized(self):
+        """Nested dicts are sorted by key for determinism."""
+        args1 = Namespace(headers={"X-A": "1", "X-B": "2"})
+        args2 = Namespace(headers={"X-B": "2", "X-A": "1"})
+        assert compute_fingerprint(args1) == compute_fingerprint(args2)
+
+
+class TestBenchmarkResultFingerprint(unittest.TestCase):
+    """Test fingerprint field on BenchmarkResult."""
+
+    def test_default_none(self):
+        """fingerprint defaults to None."""
+        r = BenchmarkResult()
+        assert r.fingerprint is None
+
+    def test_set_fingerprint(self):
+        """fingerprint can be set."""
+        r = BenchmarkResult()
+        r.fingerprint = "abc123"
+        assert r.fingerprint == "abc123"
+
+
+class TestHistoryGroupByFingerprint(unittest.TestCase):
+    """Test history grouping by fingerprint (M72)."""
+
+    def test_group_by_fingerprint(self):
+        """History results can be grouped by fingerprint."""
+        from datetime import datetime
+
+        from xpyd_bench.history import format_history_by_fingerprint
+
+        fp_a = "a" * 64
+        fp_b = "b" * 64
+        summaries = [
+            {
+                "file": "r1.json", "timestamp": datetime(2026, 1, 1, 10, 0),
+                "model": "gpt-4", "num_prompts": 100, "completed": 100,
+                "failed": 0, "request_throughput": 10.0, "output_throughput": 500.0,
+                "mean_ttft_ms": 50.0, "mean_e2el_ms": 200.0, "partial": False,
+                "total_duration_s": 10, "tags": {}, "note": None,
+                "fingerprint": fp_a,
+            },
+            {
+                "file": "r2.json", "timestamp": datetime(2026, 1, 1, 11, 0),
+                "model": "gpt-4", "num_prompts": 100, "completed": 100,
+                "failed": 0, "request_throughput": 12.0, "output_throughput": 600.0,
+                "mean_ttft_ms": 45.0, "mean_e2el_ms": 190.0, "partial": False,
+                "total_duration_s": 10, "tags": {}, "note": None,
+                "fingerprint": fp_a,
+            },
+            {
+                "file": "r3.json", "timestamp": datetime(2026, 1, 1, 12, 0),
+                "model": "gpt-3.5", "num_prompts": 50, "completed": 50,
+                "failed": 0, "request_throughput": 20.0, "output_throughput": 800.0,
+                "mean_ttft_ms": 30.0, "mean_e2el_ms": 100.0, "partial": False,
+                "total_duration_s": 5, "tags": {}, "note": None,
+                "fingerprint": fp_b,
+            },
+        ]
+        output = format_history_by_fingerprint(summaries)
+        assert "aaaaaaaaaaaa" in output  # short fp_a
+        assert "bbbbbbbbbbbb" in output  # short fp_b
+        assert "2 run(s)" in output
+        assert "1 run(s)" in output
+
+    def test_no_fingerprint_group(self):
+        """Results without fingerprint go to ungrouped."""
+        from datetime import datetime
+
+        from xpyd_bench.history import format_history_by_fingerprint
+
+        summaries = [
+            {
+                "file": "r1.json", "timestamp": datetime(2026, 1, 1),
+                "model": "gpt-4", "num_prompts": 100, "completed": 100,
+                "failed": 0, "request_throughput": 10.0, "output_throughput": 500.0,
+                "mean_ttft_ms": 50.0, "mean_e2el_ms": 200.0, "partial": False,
+                "total_duration_s": 10, "tags": {}, "note": None,
+                "fingerprint": None,
+            },
+        ]
+        output = format_history_by_fingerprint(summaries)
+        assert "No fingerprint" in output
+
+    def test_empty_summaries(self):
+        """Empty list returns no results message."""
+        from xpyd_bench.history import format_history_by_fingerprint
+
+        output = format_history_by_fingerprint([])
+        assert "No benchmark results found" in output
+
+
+class TestAggregateByFingerprint(unittest.TestCase):
+    """Test aggregate --by-fingerprint grouping."""
+
+    def test_by_fingerprint_groups(self):
+        """Results are grouped by fingerprint in aggregate."""
+
+        fp = compute_fingerprint(Namespace(model="gpt-4", num_prompts=100))
+
+        r1 = {"fingerprint": fp, "mean_ttft_ms": 50.0, "request_throughput": 10.0}
+        r2 = {"fingerprint": fp, "mean_ttft_ms": 55.0, "request_throughput": 11.0}
+        r3 = {"fingerprint": "other" * 13, "mean_ttft_ms": 30.0, "request_throughput": 20.0}
+
+        # Group by fingerprint
+        groups: dict[str, list[dict]] = {}
+        for r in [r1, r2, r3]:
+            groups.setdefault(r.get("fingerprint", "unknown"), []).append(r)
+
+        assert len(groups) == 2
+        assert len(groups[fp]) == 2
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Generate deterministic SHA-256 fingerprint from normalized benchmark configuration for grouping and comparing runs with identical settings.

## Changes
- `compute_fingerprint()` in `src/xpyd_bench/bench/fingerprint.py` — SHA-256 of sorted, normalized config
- `BenchmarkResult.fingerprint` field auto-populated in runner
- `xpyd-bench history --group-by-fingerprint` groups runs by config
- `xpyd-bench aggregate --by-fingerprint` auto-groups before aggregating
- Excluded keys: output paths, display, metadata, webhooks, dry_run
- Config normalization: sorted keys, None excluded, inf → string
- 15 tests covering determinism, normalization, grouping, edge cases

Closes #202