### PR TITLE
feat(m73): Custom Percentile Configuration

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -598,3 +598,12 @@
 - `xpyd-bench history` can group runs by fingerprint to track same-config performance over time
 - `xpyd-bench aggregate --by-fingerprint` to auto-group results by config
 - Tests covering fingerprint determinism, config normalization, and grouping
+
+## M73: Custom Percentile Configuration
+- `--percentiles 50,90,95,99,99.9` CLI flag to specify which latency percentiles to compute
+- Default: `50,90,95,99` (preserves current behavior)
+- BenchmarkResult includes `custom_percentiles` dict mapping metric prefix to {pN: value}
+- JSON output includes `custom_percentiles` section
+- Terminal summary shows all requested percentiles
+- YAML config support (`percentiles: [50, 90, 95, 99, 99.9]`)
+- Tests covering custom percentile computation, CLI parsing, YAML config, edge cases

--- a/src/xpyd_bench/bench/custom_percentiles.py
+++ b/src/xpyd_bench/bench/custom_percentiles.py
@@ -1,0 +1,77 @@
+"""Custom percentile configuration (M73)."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+import numpy as np
+
+from xpyd_bench.bench.models import BenchmarkResult
+
+DEFAULT_PERCENTILES: list[float] = [50, 90, 95, 99]
+
+
+def parse_percentiles(raw: str | list | None) -> list[float]:
+    """Parse percentile spec from CLI string or YAML list.
+
+    Accepts comma-separated string (``"50,90,99.9"``) or list of
+    numbers.  Returns sorted, deduplicated list of floats.
+    """
+    if raw is None:
+        return list(DEFAULT_PERCENTILES)
+    if isinstance(raw, str):
+        parts = [p.strip() for p in raw.split(",") if p.strip()]
+    elif isinstance(raw, (list, tuple)):
+        parts = [str(p) for p in raw]
+    else:
+        return list(DEFAULT_PERCENTILES)
+
+    result: list[float] = []
+    for p in parts:
+        val = float(p)
+        if not (0 < val < 100):
+            raise ValueError(f"Percentile must be between 0 and 100 exclusive, got {val}")
+        result.append(val)
+
+    return sorted(set(result))
+
+
+def compute_custom_percentiles(
+    result: BenchmarkResult, args: Namespace
+) -> None:
+    """Compute custom percentiles and store in ``result.custom_percentiles``."""
+    raw = getattr(args, "percentiles", None)
+    pcts = parse_percentiles(raw)
+
+    successful = [r for r in result.requests if r.success]
+    if not successful:
+        return
+
+    metrics: dict[str, list[float]] = {}
+
+    e2els = [r.latency_ms for r in successful]
+    if e2els:
+        metrics["e2el_ms"] = e2els
+
+    ttfts = [r.ttft_ms for r in successful if r.ttft_ms is not None]
+    if ttfts:
+        metrics["ttft_ms"] = ttfts
+
+    tpots = [r.tpot_ms for r in successful if r.tpot_ms is not None]
+    if tpots:
+        metrics["tpot_ms"] = tpots
+
+    all_itls = [itl for r in successful for itl in r.itl_ms]
+    if all_itls:
+        metrics["itl_ms"] = all_itls
+
+    custom: dict[str, dict[str, float]] = {}
+    for prefix, values in metrics.items():
+        arr = np.array(values)
+        entry: dict[str, float] = {}
+        for p in pcts:
+            key = f"p{p:g}"
+            entry[key] = float(np.percentile(arr, p))
+        custom[prefix] = entry
+
+    result.custom_percentiles = custom

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -147,3 +147,6 @@ class BenchmarkResult:
 
     # Benchmark fingerprint (M72)
     fingerprint: str | None = None
+
+    # Custom percentile results (M73)
+    custom_percentiles: dict | None = None

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -1072,6 +1072,10 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
 
     _compute_metrics(result)
 
+    # Custom percentile configuration (M73)
+    from xpyd_bench.bench.custom_percentiles import compute_custom_percentiles
+    compute_custom_percentiles(result, args)
+
     # Network latency decomposition (M57)
     latency_breakdown_enabled = getattr(args, "latency_breakdown", False)
     if latency_breakdown_enabled and result.requests:
@@ -1406,6 +1410,14 @@ def _print_summary(r: BenchmarkResult) -> None:
             f"P50={qt['p50_ms']:.2f} P90={qt['p90_ms']:.2f} "
             f"P99={qt['p99_ms']:.2f} ms ({qt['count']} requests)"
         )
+    if r.custom_percentiles:
+        print()
+        print("  📊 Custom Percentiles:")
+        label_map = {"e2el_ms": "E2EL", "ttft_ms": "TTFT", "tpot_ms": "TPOT", "itl_ms": "ITL"}
+        for prefix, pcts in r.custom_percentiles.items():
+            label = label_map.get(prefix, prefix)
+            parts_cp = [f"{k}={v:.2f}" for k, v in pcts.items()]
+            print(f"      {label:5s}  {', '.join(parts_cp)} ms")
     print("=" * 60)
 
 
@@ -1553,4 +1565,6 @@ def _to_dict(r: BenchmarkResult) -> dict:
         d["queue_time_summary"] = r.queue_time_summary
     if r.fingerprint:
         d["fingerprint"] = r.fingerprint
+    if r.custom_percentiles:
+        d["custom_percentiles"] = r.custom_percentiles
     return d

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -726,6 +726,17 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Attach a human-readable note/description to this benchmark run",
     )
 
+    # Custom percentiles (M73)
+    parser.add_argument(
+        "--percentiles",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated percentiles to compute, e.g. '50,90,95,99,99.9'. "
+            "Default: 50,90,95,99"
+        ),
+    )
+
     # Tags (M36)
     parser.add_argument(
         "--tag",

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -117,6 +117,7 @@ _KNOWN_KEYS: set[str] = {
     "track_payload_size",
     "measure_generation_speed",
     "note",
+    "percentiles",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/tests/test_custom_percentiles.py
+++ b/tests/test_custom_percentiles.py
@@ -1,0 +1,154 @@
+"""Tests for M73: Custom Percentile Configuration."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+import numpy as np
+import pytest
+
+from xpyd_bench.bench.custom_percentiles import (
+    DEFAULT_PERCENTILES,
+    compute_custom_percentiles,
+    parse_percentiles,
+)
+from xpyd_bench.bench.models import BenchmarkResult, RequestResult
+
+# ---------------------------------------------------------------------------
+# parse_percentiles
+# ---------------------------------------------------------------------------
+
+class TestParsePercentiles:
+    def test_none_returns_defaults(self):
+        assert parse_percentiles(None) == DEFAULT_PERCENTILES
+
+    def test_string_input(self):
+        assert parse_percentiles("50,90,99.9") == [50.0, 90.0, 99.9]
+
+    def test_list_input(self):
+        assert parse_percentiles([50, 95, 99]) == [50.0, 95.0, 99.0]
+
+    def test_dedup_and_sort(self):
+        assert parse_percentiles("99,50,50,90") == [50.0, 90.0, 99.0]
+
+    def test_invalid_zero_raises(self):
+        with pytest.raises(ValueError, match="between 0 and 100"):
+            parse_percentiles("0,50")
+
+    def test_invalid_100_raises(self):
+        with pytest.raises(ValueError, match="between 0 and 100"):
+            parse_percentiles("50,100")
+
+    def test_non_string_non_list_returns_defaults(self):
+        assert parse_percentiles(42) == DEFAULT_PERCENTILES
+
+
+# ---------------------------------------------------------------------------
+# compute_custom_percentiles
+# ---------------------------------------------------------------------------
+
+def _make_result(latencies: list[float], ttfts: list[float] | None = None) -> BenchmarkResult:
+    """Build a minimal BenchmarkResult with given latencies."""
+    result = BenchmarkResult()
+    for i, lat in enumerate(latencies):
+        rr = RequestResult(latency_ms=lat, success=True)
+        if ttfts and i < len(ttfts):
+            rr.ttft_ms = ttfts[i]
+        result.requests.append(rr)
+    return result
+
+
+class TestComputeCustomPercentiles:
+    def test_default_percentiles(self):
+        result = _make_result([10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
+        args = Namespace(percentiles=None)
+        compute_custom_percentiles(result, args)
+
+        assert result.custom_percentiles is not None
+        assert "e2el_ms" in result.custom_percentiles
+        pcts = result.custom_percentiles["e2el_ms"]
+        assert "p50" in pcts
+        assert "p90" in pcts
+        assert "p95" in pcts
+        assert "p99" in pcts
+
+    def test_custom_percentiles_string(self):
+        result = _make_result([10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
+        args = Namespace(percentiles="50,99.9")
+        compute_custom_percentiles(result, args)
+
+        pcts = result.custom_percentiles["e2el_ms"]
+        assert "p50" in pcts
+        assert "p99.9" in pcts
+        assert len(pcts) == 2
+
+    def test_custom_percentiles_list(self):
+        result = _make_result([10, 20, 30, 40, 50])
+        args = Namespace(percentiles=[25, 75])
+        compute_custom_percentiles(result, args)
+
+        pcts = result.custom_percentiles["e2el_ms"]
+        assert "p25" in pcts
+        assert "p75" in pcts
+
+    def test_includes_ttft_when_present(self):
+        result = _make_result([10, 20, 30], ttfts=[1.0, 2.0, 3.0])
+        args = Namespace(percentiles="50")
+        compute_custom_percentiles(result, args)
+
+        assert "ttft_ms" in result.custom_percentiles
+
+    def test_no_successful_requests(self):
+        result = BenchmarkResult()
+        result.requests.append(RequestResult(success=False))
+        args = Namespace(percentiles="50")
+        compute_custom_percentiles(result, args)
+        assert result.custom_percentiles is None
+
+    def test_no_percentiles_attr(self):
+        """When args has no 'percentiles' attr, use defaults."""
+        result = _make_result([10, 20, 30])
+        args = Namespace()
+        compute_custom_percentiles(result, args)
+        assert result.custom_percentiles is not None
+
+    def test_values_correctness(self):
+        """Verify computed values match numpy directly."""
+        data = list(range(1, 101))  # 1..100
+        result = _make_result(data)
+        args = Namespace(percentiles="50,99")
+        compute_custom_percentiles(result, args)
+
+        pcts = result.custom_percentiles["e2el_ms"]
+        assert pcts["p50"] == pytest.approx(np.percentile(data, 50))
+        assert pcts["p99"] == pytest.approx(np.percentile(data, 99))
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+class TestCLIIntegration:
+    def test_cli_flag_parsed(self):
+        """Verify --percentiles flag is accepted by the CLI parser."""
+        import argparse
+
+        # We can't easily run bench_main, but we test the parser accepts the flag
+        # by importing and parsing
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--percentiles", "50,90,99.9"])
+        assert args.percentiles == "50,90,99.9"
+
+
+# ---------------------------------------------------------------------------
+# Config known keys
+# ---------------------------------------------------------------------------
+
+class TestConfigKnownKeys:
+    def test_percentiles_in_known_keys(self):
+        from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+        assert "percentiles" in _KNOWN_KEYS


### PR DESCRIPTION
## Summary
Add `--percentiles` CLI flag to configure which latency percentiles to compute beyond the hardcoded P50/P90/P95/P99.

## Changes
- **New module:** `src/xpyd_bench/bench/custom_percentiles.py` — parsing and computation logic
- **Models:** Added `custom_percentiles` field to `BenchmarkResult`
- **Runner:** Compute custom percentiles after standard metrics, include in JSON output and terminal summary
- **CLI:** `--percentiles` flag accepting comma-separated values (e.g. `50,90,95,99,99.9`)
- **Config:** Added `percentiles` to known YAML config keys
- **ROADMAP:** Added M73 milestone
- **Tests:** 16 tests covering parsing, computation, CLI integration, config keys

## Usage
```bash
# Default (same as current behavior)
xpyd-bench run --base-url http://localhost:8000

# Custom percentiles including P99.9
xpyd-bench run --base-url http://localhost:8000 --percentiles 50,90,99,99.9

# Via YAML config
# percentiles: [50, 90, 95, 99, 99.9]
```

Closes #204