### PR TITLE
feat(m75): add multi-model comparison mode

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -618,7 +618,7 @@
 - YAML config support (`checkpoint_dir`, `checkpoint_interval`)
 - Tests covering checkpoint creation, resume logic, config mismatch detection, and CLI integration
 
-## M75: Multi-Model Comparison Mode ⬜
+## M75: Multi-Model Comparison Mode ✅
 - `xpyd-bench model-compare --models model1,model2 --base-url <url>` CLI subcommand
 - Benchmark same prompts against multiple models on same endpoint
 - Side-by-side per-model metrics (TTFT, TPOT, throughput, latency percentiles)

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -2025,3 +2025,96 @@ def batch_main(argv: list[str] | None = None) -> None:
         with open(p, "w") as f:
             json.dump(result_dict, f, indent=2, default=str)
         print(f"\nResult saved to {p}")
+
+
+def model_compare_main(argv: list[str] | None = None) -> None:
+    """Entry point for ``xpyd-bench model-compare`` subcommand (M75)."""
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench-model-compare",
+        description="Benchmark same prompts against multiple models on same endpoint",
+    )
+    _add_vllm_compat_args(parser)
+    parser.add_argument(
+        "--models",
+        type=str,
+        nargs="+",
+        required=True,
+        help="Model names to benchmark (at least 2).",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=5.0,
+        help="Regression threshold percentage (default: 5.0).",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Export all results and comparisons to a JSON file.",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Export comparison as a Markdown table.",
+    )
+    args = parser.parse_args(argv)
+
+    if len(args.models) < 2:
+        parser.error("--models requires at least 2 model names")
+
+    # Resolve base_url from host/port if not set
+    if not args.base_url:
+        args.base_url = f"http://{args.host}:{args.port}"
+
+    # Merge YAML config if provided
+    if args.config:
+        explicit = _get_explicit_keys(parser, args)
+        args = _load_yaml_config(args.config, args, explicit_keys=explicit)
+
+    # Resolve API key
+    import os
+
+    if args.api_key is None:
+        args.api_key = os.environ.get("OPENAI_API_KEY")
+
+    # Resolve custom headers
+    args.custom_headers = _resolve_custom_headers(args)
+
+    from xpyd_bench import __version__
+    from xpyd_bench.model_compare import (
+        export_model_compare_json,
+        export_model_compare_markdown,
+        format_model_compare_summary,
+        run_model_compare,
+    )
+
+    print(f"xpyd-bench-model-compare v{__version__}")
+    print(f"  Base URL: {args.base_url}")
+    print(f"  Models:   {', '.join(args.models)}")
+    print(f"  Threshold: {args.threshold}%")
+    print()
+
+    multi = asyncio.run(
+        run_model_compare(args, args.models, threshold_pct=args.threshold)
+    )
+
+    print(format_model_compare_summary(multi))
+
+    if args.json_output:
+        p = export_model_compare_json(multi, args.json_output)
+        print(f"\nJSON output saved to {p}")
+
+    if args.markdown_output:
+        p = export_model_compare_markdown(multi, args.markdown_output)
+        print(f"\nMarkdown output saved to {p}")
+
+    # Exit code 1 if any regression detected
+    if any(
+        mc.comparison and mc.comparison.has_regression
+        for mc in multi.comparisons
+    ):
+        raise SystemExit(1)

--- a/src/xpyd_bench/main.py
+++ b/src/xpyd_bench/main.py
@@ -84,6 +84,7 @@ _SUBCOMMANDS = {
     "schedule",
     "discover",
     "resume",
+    "model-compare",
 }
 
 
@@ -179,6 +180,10 @@ def main() -> None:
         from xpyd_bench.checkpoint import resume_main
 
         resume_main(rest)
+    elif subcmd == "model-compare":
+        from xpyd_bench.cli import model_compare_main
+
+        model_compare_main(rest)
 
 
 def _config_subcommand(argv: list[str]) -> None:

--- a/src/xpyd_bench/model_compare.py
+++ b/src/xpyd_bench/model_compare.py
@@ -1,0 +1,323 @@
+"""Multi-model comparison mode (M75).
+
+Benchmarks the same prompts against multiple models on the same endpoint,
+producing side-by-side metrics with statistical significance testing.
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from xpyd_bench.bench.models import BenchmarkResult
+from xpyd_bench.bench.runner import run_benchmark
+from xpyd_bench.compare import (
+    ComparisonResult,
+    compare,
+)
+from xpyd_bench.diff import _mann_whitney_u
+
+
+@dataclass
+class ModelSignificance:
+    """Statistical significance result for a metric between two models."""
+
+    metric: str = ""
+    u_stat: float = 0.0
+    p_value: float = 1.0
+    significant: bool = False  # p < 0.05
+
+
+@dataclass
+class ModelComparisonResult:
+    """Pairwise comparison between two models with significance testing."""
+
+    baseline_model: str = ""
+    candidate_model: str = ""
+    comparison: ComparisonResult | None = None
+    significance: list[ModelSignificance] = field(default_factory=list)
+
+
+@dataclass
+class MultiModelResult:
+    """Results from benchmarking multiple models."""
+
+    models: list[str] = field(default_factory=list)
+    base_url: str = ""
+    results: list[BenchmarkResult] = field(default_factory=list)
+    raw_dicts: list[dict[str, Any]] = field(default_factory=list)
+    comparisons: list[ModelComparisonResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-friendly dict."""
+        d: dict[str, Any] = {
+            "models": self.models,
+            "base_url": self.base_url,
+            "results": self.raw_dicts,
+        }
+        if self.comparisons:
+            d["comparisons"] = []
+            for mc in self.comparisons:
+                mc_dict: dict[str, Any] = {
+                    "baseline_model": mc.baseline_model,
+                    "candidate_model": mc.candidate_model,
+                }
+                if mc.comparison:
+                    mc_dict["comparison"] = mc.comparison.to_dict()
+                if mc.significance:
+                    mc_dict["significance"] = [
+                        {
+                            "metric": s.metric,
+                            "u_stat": s.u_stat,
+                            "p_value": s.p_value,
+                            "significant": s.significant,
+                        }
+                        for s in mc.significance
+                    ]
+                d["comparisons"].append(mc_dict)
+        return d
+
+
+_LATENCY_METRICS = ["ttft_ms", "tpot_ms", "latency_ms"]
+
+
+def _compute_significance(
+    baseline: BenchmarkResult,
+    candidate: BenchmarkResult,
+) -> list[ModelSignificance]:
+    """Run Mann-Whitney U test on per-request latency metrics."""
+    results: list[ModelSignificance] = []
+    for metric in _LATENCY_METRICS:
+        baseline_vals = [
+            getattr(r, metric) for r in baseline.requests
+            if getattr(r, metric, None) is not None
+        ]
+        candidate_vals = [
+            getattr(r, metric) for r in candidate.requests
+            if getattr(r, metric, None) is not None
+        ]
+        if len(baseline_vals) < 2 or len(candidate_vals) < 2:
+            continue
+        u_stat, p_value = _mann_whitney_u(baseline_vals, candidate_vals)
+        results.append(ModelSignificance(
+            metric=metric,
+            u_stat=u_stat,
+            p_value=p_value,
+            significant=p_value < 0.05,
+        ))
+    return results
+
+
+async def run_model_compare(
+    args: Namespace,
+    models: list[str],
+    threshold_pct: float = 5.0,
+) -> MultiModelResult:
+    """Run benchmarks against multiple models on the same endpoint.
+
+    The same prompts and parameters are used for each model to ensure
+    fair comparison. The first model is treated as the baseline for
+    pairwise regression detection and significance testing.
+
+    Args:
+        args: Parsed CLI arguments.
+        models: List of model names to benchmark.
+        threshold_pct: Regression detection threshold.
+
+    Returns:
+        MultiModelResult with per-model results and comparisons.
+    """
+    multi = MultiModelResult(
+        models=list(models),
+        base_url=getattr(args, "base_url", ""),
+    )
+
+    for model in models:
+        model_args = deepcopy(args)
+        model_args.model = model
+        result_dict, bench_result = await run_benchmark(model_args, model_args.base_url)
+        multi.results.append(bench_result)
+        multi.raw_dicts.append(result_dict)
+
+    # Pairwise comparison: first model is baseline
+    if len(multi.results) >= 2:
+        baseline_dict = multi.raw_dicts[0]
+        baseline_result = multi.results[0]
+        for i in range(1, len(multi.results)):
+            cmp = compare(
+                baseline_dict, multi.raw_dicts[i], threshold_pct=threshold_pct,
+            )
+            sig = _compute_significance(baseline_result, multi.results[i])
+            multi.comparisons.append(ModelComparisonResult(
+                baseline_model=models[0],
+                candidate_model=models[i],
+                comparison=cmp,
+                significance=sig,
+            ))
+
+    return multi
+
+
+def format_model_compare_summary(multi: MultiModelResult) -> str:
+    """Format a side-by-side summary table for multiple models."""
+    lines: list[str] = []
+    lines.append("=" * 100)
+    lines.append("  xPyD-bench — Multi-Model Comparison")
+    lines.append(f"  Base URL: {multi.base_url}")
+    lines.append("=" * 100)
+
+    if not multi.results:
+        lines.append("  No results.")
+        return "\n".join(lines)
+
+    # Header
+    header_parts = [f"{'Metric':<28s}"]
+    for model in multi.models:
+        header_parts.append(f"{model:>20s}")
+    lines.append("  " + " ".join(header_parts))
+    lines.append("  " + "-" * (28 + 21 * len(multi.models)))
+
+    display_metrics = [
+        "completed",
+        "failed",
+        "total_duration_s",
+        "request_throughput",
+        "output_throughput",
+        "total_token_throughput",
+        "mean_ttft_ms",
+        "p50_ttft_ms",
+        "p90_ttft_ms",
+        "p99_ttft_ms",
+        "mean_tpot_ms",
+        "p50_tpot_ms",
+        "p90_tpot_ms",
+        "p99_tpot_ms",
+        "mean_e2el_ms",
+        "p50_e2el_ms",
+        "p90_e2el_ms",
+        "p99_e2el_ms",
+    ]
+
+    for metric in display_metrics:
+        row = [f"{metric:<28s}"]
+        for r in multi.results:
+            val = getattr(r, metric, None)
+            if val is None:
+                row.append(f"{'N/A':>20s}")
+            elif isinstance(val, float):
+                row.append(f"{val:>20.2f}")
+            else:
+                row.append(f"{val!s:>20s}")
+        lines.append("  " + " ".join(row))
+
+    lines.append("  " + "-" * (28 + 21 * len(multi.models)))
+
+    # Regression and significance summary
+    for mc in multi.comparisons:
+        cmp = mc.comparison
+        if cmp and cmp.has_regression:
+            lines.append(
+                f"  ⚠️  {mc.candidate_model} has regressions vs {mc.baseline_model}"
+            )
+        else:
+            lines.append(
+                f"  ✅  {mc.candidate_model} — no regressions vs {mc.baseline_model}"
+            )
+        for sig in mc.significance:
+            marker = "***" if sig.significant else ""
+            lines.append(
+                f"      {sig.metric}: U={sig.u_stat:.1f}, "
+                f"p={sig.p_value:.4f} {marker}"
+            )
+
+    lines.append("=" * 100)
+    return "\n".join(lines)
+
+
+def format_model_compare_markdown(multi: MultiModelResult) -> str:
+    """Format multi-model results as a Markdown table."""
+    if not multi.results:
+        return "No results.\n"
+
+    display_metrics = [
+        "completed",
+        "failed",
+        "request_throughput",
+        "output_throughput",
+        "mean_ttft_ms",
+        "p50_ttft_ms",
+        "p90_ttft_ms",
+        "p99_ttft_ms",
+        "mean_tpot_ms",
+        "p50_tpot_ms",
+        "p90_tpot_ms",
+        "p99_tpot_ms",
+        "mean_e2el_ms",
+        "p50_e2el_ms",
+        "p90_e2el_ms",
+        "p99_e2el_ms",
+    ]
+
+    headers = ["Metric"] + list(multi.models)
+    header_line = "| " + " | ".join(headers) + " |"
+    sep_line = "| " + " | ".join("---" for _ in headers) + " |"
+
+    rows = [header_line, sep_line]
+    for metric in display_metrics:
+        cells = [metric]
+        for r in multi.results:
+            val = getattr(r, metric, None)
+            if val is None:
+                cells.append("N/A")
+            elif isinstance(val, float):
+                cells.append(f"{val:.2f}")
+            else:
+                cells.append(str(val))
+        rows.append("| " + " | ".join(cells) + " |")
+
+    # Significance section
+    rows.append("")
+    rows.append("### Statistical Significance")
+    rows.append("")
+    for mc in multi.comparisons:
+        rows.append(
+            f"**{mc.candidate_model} vs {mc.baseline_model}**"
+        )
+        if mc.significance:
+            rows.append("| Metric | U-stat | p-value | Significant |")
+            rows.append("| --- | --- | --- | --- |")
+            for sig in mc.significance:
+                rows.append(
+                    f"| {sig.metric} | {sig.u_stat:.1f} | "
+                    f"{sig.p_value:.4f} | {'Yes' if sig.significant else 'No'} |"
+                )
+        else:
+            rows.append("Not enough data for significance testing.")
+        rows.append("")
+
+    return "\n".join(rows) + "\n"
+
+
+def export_model_compare_json(
+    multi: MultiModelResult, path: str | Path,
+) -> Path:
+    """Export multi-model results to JSON."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "w") as f:
+        json.dump(multi.to_dict(), f, indent=2, default=str)
+    return p
+
+
+def export_model_compare_markdown(
+    multi: MultiModelResult, path: str | Path,
+) -> Path:
+    """Export multi-model Markdown table to a file."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(format_model_compare_markdown(multi))
+    return p

--- a/tests/test_model_compare.py
+++ b/tests/test_model_compare.py
@@ -1,0 +1,316 @@
+"""Tests for multi-model comparison mode (M75)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from argparse import Namespace
+from unittest.mock import patch
+
+import pytest
+
+from xpyd_bench.bench.models import BenchmarkResult, RequestResult
+from xpyd_bench.model_compare import (
+    ModelComparisonResult,
+    ModelSignificance,
+    MultiModelResult,
+    _compute_significance,
+    export_model_compare_json,
+    export_model_compare_markdown,
+    format_model_compare_markdown,
+    format_model_compare_summary,
+    run_model_compare,
+)
+
+
+def _make_result(model: str, latencies: list[float]) -> tuple[dict, BenchmarkResult]:
+    """Create a fake benchmark result for testing."""
+    requests = []
+    for lat in latencies:
+        requests.append(RequestResult(
+            latency_ms=lat,
+            ttft_ms=lat * 0.3,
+            tpot_ms=lat * 0.05,
+            prompt_tokens=10,
+            completion_tokens=20,
+            success=True,
+        ))
+    br = BenchmarkResult(
+        model=model,
+        base_url="http://localhost:8000",
+        completed=len(latencies),
+        failed=0,
+        total_duration_s=5.0,
+        request_throughput=len(latencies) / 5.0,
+        output_throughput=20.0 * len(latencies) / 5.0,
+        total_token_throughput=30.0 * len(latencies) / 5.0,
+        mean_ttft_ms=sum(lat * 0.3 for lat in latencies) / len(latencies),
+        p50_ttft_ms=sorted(lat * 0.3 for lat in latencies)[len(latencies) // 2],
+        p90_ttft_ms=sorted(lat * 0.3 for lat in latencies)[int(len(latencies) * 0.9)],
+        p99_ttft_ms=sorted(lat * 0.3 for lat in latencies)[-1],
+        mean_tpot_ms=sum(lat * 0.05 for lat in latencies) / len(latencies),
+        mean_e2el_ms=sum(latencies) / len(latencies),
+        p50_e2el_ms=sorted(latencies)[len(latencies) // 2],
+        p90_e2el_ms=sorted(latencies)[int(len(latencies) * 0.9)],
+        p99_e2el_ms=sorted(latencies)[-1],
+        requests=requests,
+    )
+    rd = {
+        "model": model,
+        "completed": br.completed,
+        "failed": br.failed,
+        "request_throughput": br.request_throughput,
+        "output_throughput": br.output_throughput,
+        "total_token_throughput": br.total_token_throughput,
+        "mean_ttft_ms": br.mean_ttft_ms,
+        "p50_ttft_ms": br.p50_ttft_ms,
+        "p90_ttft_ms": br.p90_ttft_ms,
+        "p99_ttft_ms": br.p99_ttft_ms,
+        "mean_tpot_ms": br.mean_tpot_ms,
+        "mean_e2el_ms": br.mean_e2el_ms,
+        "p50_e2el_ms": br.p50_e2el_ms,
+        "p90_e2el_ms": br.p90_e2el_ms,
+        "p99_e2el_ms": br.p99_e2el_ms,
+    }
+    return rd, br
+
+
+class TestMultiModelResult:
+    """Tests for MultiModelResult dataclass."""
+
+    def test_to_dict_empty(self):
+        r = MultiModelResult()
+        d = r.to_dict()
+        assert d["models"] == []
+        assert d["results"] == []
+        assert "comparisons" not in d
+
+    def test_to_dict_with_comparisons(self):
+        from xpyd_bench.compare import ComparisonResult
+        cmp = ComparisonResult(metrics=[], has_regression=False, threshold_pct=5.0)
+        mc = ModelComparisonResult(
+            baseline_model="a",
+            candidate_model="b",
+            comparison=cmp,
+            significance=[
+                ModelSignificance(metric="ttft_ms", u_stat=10.0, p_value=0.03, significant=True),
+            ],
+        )
+        r = MultiModelResult(
+            models=["a", "b"],
+            base_url="http://localhost",
+            comparisons=[mc],
+        )
+        d = r.to_dict()
+        assert len(d["comparisons"]) == 1
+        assert d["comparisons"][0]["baseline_model"] == "a"
+        assert d["comparisons"][0]["significance"][0]["significant"] is True
+
+
+class TestRunModelCompare:
+    """Tests for run_model_compare."""
+
+    def test_basic_comparison(self):
+        latencies_a = [100.0, 110.0, 105.0, 102.0, 108.0]
+        latencies_b = [200.0, 210.0, 205.0, 202.0, 208.0]
+        rd_a, br_a = _make_result("model-a", latencies_a)
+        rd_b, br_b = _make_result("model-b", latencies_b)
+
+        call_count = 0
+
+        async def fake_run(args, base_url):
+            nonlocal call_count
+            if call_count == 0:
+                call_count += 1
+                return rd_a, br_a
+            call_count += 1
+            return rd_b, br_b
+
+        args = Namespace(base_url="http://localhost:8000", model="x")
+
+        with patch("xpyd_bench.model_compare.run_benchmark", side_effect=fake_run):
+            result = asyncio.run(
+                run_model_compare(args, ["model-a", "model-b"], threshold_pct=5.0)
+            )
+
+        assert len(result.models) == 2
+        assert len(result.results) == 2
+        assert len(result.comparisons) == 1
+        assert result.comparisons[0].baseline_model == "model-a"
+        assert result.comparisons[0].candidate_model == "model-b"
+
+    def test_single_model_no_comparison(self):
+        rd, br = _make_result("model-a", [100.0, 110.0])
+
+        async def fake_run(args, base_url):
+            return rd, br
+
+        args = Namespace(base_url="http://localhost:8000", model="x")
+
+        with patch("xpyd_bench.model_compare.run_benchmark", side_effect=fake_run):
+            result = asyncio.run(
+                run_model_compare(args, ["model-a"], threshold_pct=5.0)
+            )
+
+        assert len(result.comparisons) == 0
+
+    def test_three_models(self):
+        results_data = []
+        for name in ["a", "b", "c"]:
+            results_data.append(_make_result(name, [100.0, 110.0, 105.0]))
+
+        idx = 0
+
+        async def fake_run(args, base_url):
+            nonlocal idx
+            rd, br = results_data[idx]
+            idx += 1
+            return rd, br
+
+        args = Namespace(base_url="http://localhost:8000", model="x")
+
+        with patch("xpyd_bench.model_compare.run_benchmark", side_effect=fake_run):
+            result = asyncio.run(
+                run_model_compare(args, ["a", "b", "c"], threshold_pct=5.0)
+            )
+
+        assert len(result.comparisons) == 2
+        assert result.comparisons[0].baseline_model == "a"
+        assert result.comparisons[0].candidate_model == "b"
+        assert result.comparisons[1].baseline_model == "a"
+        assert result.comparisons[1].candidate_model == "c"
+
+
+class TestSignificance:
+    """Tests for statistical significance computation."""
+
+    def test_identical_distributions(self):
+        br1 = BenchmarkResult(requests=[
+            RequestResult(latency_ms=100.0, ttft_ms=30.0, tpot_ms=5.0)
+            for _ in range(10)
+        ])
+        br2 = BenchmarkResult(requests=[
+            RequestResult(latency_ms=100.0, ttft_ms=30.0, tpot_ms=5.0)
+            for _ in range(10)
+        ])
+        sigs = _compute_significance(br1, br2)
+        assert len(sigs) == 3
+        for s in sigs:
+            assert not s.significant  # identical → not significant
+
+    def test_very_different_distributions(self):
+        br1 = BenchmarkResult(requests=[
+            RequestResult(latency_ms=float(i), ttft_ms=float(i), tpot_ms=float(i))
+            for i in range(1, 21)
+        ])
+        br2 = BenchmarkResult(requests=[
+            RequestResult(latency_ms=float(i + 100), ttft_ms=float(i + 100), tpot_ms=float(i + 100))
+            for i in range(1, 21)
+        ])
+        sigs = _compute_significance(br1, br2)
+        for s in sigs:
+            assert s.significant
+
+    def test_insufficient_data(self):
+        br1 = BenchmarkResult(requests=[RequestResult(latency_ms=100.0)])
+        br2 = BenchmarkResult(requests=[RequestResult(latency_ms=200.0)])
+        sigs = _compute_significance(br1, br2)
+        assert len(sigs) == 0  # not enough data
+
+
+class TestFormatting:
+    """Tests for summary and markdown formatting."""
+
+    def test_format_summary_empty(self):
+        r = MultiModelResult()
+        s = format_model_compare_summary(r)
+        assert "No results" in s
+
+    def test_format_summary_with_results(self):
+        rd, br = _make_result("test-model", [100.0, 110.0, 105.0])
+        r = MultiModelResult(
+            models=["test-model"],
+            base_url="http://localhost",
+            results=[br],
+            raw_dicts=[rd],
+        )
+        s = format_model_compare_summary(r)
+        assert "test-model" in s
+        assert "Multi-Model Comparison" in s
+
+    def test_format_markdown_empty(self):
+        r = MultiModelResult()
+        md = format_model_compare_markdown(r)
+        assert "No results" in md
+
+    def test_format_markdown_with_results(self):
+        rd_a, br_a = _make_result("model-a", [100.0, 110.0])
+        rd_b, br_b = _make_result("model-b", [200.0, 210.0])
+        from xpyd_bench.compare import ComparisonResult
+        mc = ModelComparisonResult(
+            baseline_model="model-a",
+            candidate_model="model-b",
+            comparison=ComparisonResult(metrics=[], has_regression=True, threshold_pct=5.0),
+            significance=[
+                ModelSignificance(metric="latency_ms", u_stat=0.0, p_value=0.001, significant=True),
+            ],
+        )
+        r = MultiModelResult(
+            models=["model-a", "model-b"],
+            base_url="http://localhost",
+            results=[br_a, br_b],
+            raw_dicts=[rd_a, rd_b],
+            comparisons=[mc],
+        )
+        md = format_model_compare_markdown(r)
+        assert "model-a" in md
+        assert "model-b" in md
+        assert "Statistical Significance" in md
+
+
+class TestExport:
+    """Tests for JSON and Markdown export."""
+
+    def test_export_json(self, tmp_path):
+        rd, br = _make_result("test", [100.0])
+        r = MultiModelResult(
+            models=["test"],
+            base_url="http://localhost",
+            results=[br],
+            raw_dicts=[rd],
+        )
+        p = export_model_compare_json(r, tmp_path / "out.json")
+        assert p.exists()
+        data = json.loads(p.read_text())
+        assert data["models"] == ["test"]
+
+    def test_export_markdown(self, tmp_path):
+        rd, br = _make_result("test", [100.0])
+        r = MultiModelResult(
+            models=["test"],
+            base_url="http://localhost",
+            results=[br],
+            raw_dicts=[rd],
+        )
+        p = export_model_compare_markdown(r, tmp_path / "out.md")
+        assert p.exists()
+        content = p.read_text()
+        assert "test" in content
+
+
+class TestCLIIntegration:
+    """Tests for CLI integration."""
+
+    def test_model_compare_in_subcommands(self):
+        from xpyd_bench.main import _SUBCOMMANDS
+        assert "model-compare" in _SUBCOMMANDS
+
+    def test_cli_requires_models(self):
+        from xpyd_bench.cli import model_compare_main
+        with pytest.raises(SystemExit):
+            model_compare_main(["--base-url", "http://localhost"])
+
+    def test_cli_requires_at_least_two_models(self):
+        from xpyd_bench.cli import model_compare_main
+        with pytest.raises(SystemExit):
+            model_compare_main(["--models", "a", "--base-url", "http://localhost"])


### PR DESCRIPTION
## Summary
Add `xpyd-bench model-compare` CLI subcommand for benchmarking same prompts against multiple models on the same endpoint with side-by-side metrics and statistical significance testing.

## Changes
- **`src/xpyd_bench/model_compare.py`**: Core module with `run_model_compare()`, formatting, JSON/Markdown export, Mann-Whitney U significance testing
- **`src/xpyd_bench/main.py`**: Register `model-compare` subcommand
- **`src/xpyd_bench/cli.py`**: Add `model_compare_main()` CLI entry point
- **`tests/test_model_compare.py`**: 17 tests covering orchestration, significance, formatting, export, CLI integration
- **`ROADMAP.md`**: Mark M75 ✅

## Features
- `--models model1 model2 ...` — benchmark multiple models sequentially
- Same prompts/parameters for fair comparison; first model = baseline
- Mann-Whitney U statistical significance testing on latency metrics
- `--json-output` / `--markdown-output` for export
- Exit code 1 when regression detected
- All 1398 tests pass, lint clean

Closes #208