### PR TITLE
feat(m76): add streaming vs non-streaming overhead analysis

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -626,7 +626,7 @@
 - JSON and Markdown comparison output
 - Tests covering multi-model orchestration, result comparison, and CLI integration
 
-## M76: Streaming vs Non-Streaming Overhead Analysis ⬜
+## M76: Streaming vs Non-Streaming Overhead Analysis ✅
 - `xpyd-bench stream-compare --base-url <url> --model <model>` CLI subcommand
 - Auto-run same prompts in streaming and non-streaming modes
 - Report streaming overhead: TTFT delta, total latency delta, throughput impact

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -2118,3 +2118,83 @@ def model_compare_main(argv: list[str] | None = None) -> None:
         for mc in multi.comparisons
     ):
         raise SystemExit(1)
+
+
+def stream_compare_main(argv: list[str] | None = None) -> None:
+    """Entry point for ``xpyd-bench stream-compare`` subcommand (M76)."""
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench-stream-compare",
+        description="Compare streaming vs non-streaming performance on same endpoint",
+    )
+    _add_vllm_compat_args(parser)
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=5.0,
+        help="Regression threshold percentage (default: 5.0).",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Export results and comparison to a JSON file.",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Export comparison as a Markdown table.",
+    )
+    args = parser.parse_args(argv)
+
+    # Resolve base_url from host/port if not set
+    if not args.base_url:
+        args.base_url = f"http://{args.host}:{args.port}"
+
+    # Merge YAML config if provided
+    if args.config:
+        explicit = _get_explicit_keys(parser, args)
+        args = _load_yaml_config(args.config, args, explicit_keys=explicit)
+
+    # Resolve API key
+    import os
+
+    if args.api_key is None:
+        args.api_key = os.environ.get("OPENAI_API_KEY")
+
+    # Resolve custom headers
+    args.custom_headers = _resolve_custom_headers(args)
+
+    from xpyd_bench import __version__
+    from xpyd_bench.stream_compare import (
+        export_stream_compare_json,
+        export_stream_compare_markdown,
+        format_stream_compare_summary,
+        run_stream_compare,
+    )
+
+    print(f"xpyd-bench-stream-compare v{__version__}")
+    print(f"  Base URL: {args.base_url}")
+    print(f"  Model:    {args.model}")
+    print(f"  Threshold: {args.threshold}%")
+    print()
+
+    result = asyncio.run(
+        run_stream_compare(args, threshold_pct=args.threshold)
+    )
+
+    print(format_stream_compare_summary(result))
+
+    if args.json_output:
+        p = export_stream_compare_json(result, args.json_output)
+        print(f"\nJSON output saved to {p}")
+
+    if args.markdown_output:
+        p = export_stream_compare_markdown(result, args.markdown_output)
+        print(f"\nMarkdown output saved to {p}")
+
+    # Exit code 1 if regression detected
+    if result.comparison and result.comparison.has_regression:
+        raise SystemExit(1)

--- a/src/xpyd_bench/main.py
+++ b/src/xpyd_bench/main.py
@@ -85,6 +85,7 @@ _SUBCOMMANDS = {
     "discover",
     "resume",
     "model-compare",
+    "stream-compare",
 }
 
 
@@ -184,6 +185,10 @@ def main() -> None:
         from xpyd_bench.cli import model_compare_main
 
         model_compare_main(rest)
+    elif subcmd == "stream-compare":
+        from xpyd_bench.cli import stream_compare_main
+
+        stream_compare_main(rest)
 
 
 def _config_subcommand(argv: list[str]) -> None:

--- a/src/xpyd_bench/stream_compare.py
+++ b/src/xpyd_bench/stream_compare.py
@@ -1,0 +1,282 @@
+"""Streaming vs Non-Streaming Overhead Analysis (M76).
+
+Runs the same prompts in both streaming and non-streaming modes on the same
+endpoint, then reports the overhead of streaming (TTFT delta, total latency
+delta, throughput impact).
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from xpyd_bench.bench.models import BenchmarkResult
+from xpyd_bench.bench.runner import run_benchmark
+from xpyd_bench.compare import ComparisonResult, compare
+
+
+@dataclass
+class StreamOverhead:
+    """Overhead metrics comparing streaming vs non-streaming."""
+
+    ttft_delta_ms: float | None = None  # streaming TTFT - non-streaming TTFT
+    mean_latency_delta_ms: float = 0.0  # streaming mean - non-streaming mean
+    p99_latency_delta_ms: float = 0.0
+    throughput_delta_pct: float = 0.0  # (streaming - non_streaming) / non_streaming * 100
+    streaming_beneficial: bool = False  # True if streaming has lower TTFT
+
+
+@dataclass
+class StreamCompareResult:
+    """Results from streaming vs non-streaming comparison."""
+
+    base_url: str = ""
+    model: str = ""
+    streaming_result: BenchmarkResult | None = None
+    non_streaming_result: BenchmarkResult | None = None
+    streaming_dict: dict[str, Any] = field(default_factory=dict)
+    non_streaming_dict: dict[str, Any] = field(default_factory=dict)
+    overhead: StreamOverhead = field(default_factory=StreamOverhead)
+    comparison: ComparisonResult | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-friendly dict."""
+        d: dict[str, Any] = {
+            "base_url": self.base_url,
+            "model": self.model,
+            "streaming": self.streaming_dict,
+            "non_streaming": self.non_streaming_dict,
+            "overhead": {
+                "ttft_delta_ms": self.overhead.ttft_delta_ms,
+                "mean_latency_delta_ms": self.overhead.mean_latency_delta_ms,
+                "p99_latency_delta_ms": self.overhead.p99_latency_delta_ms,
+                "throughput_delta_pct": self.overhead.throughput_delta_pct,
+                "streaming_beneficial": self.overhead.streaming_beneficial,
+            },
+        }
+        if self.comparison:
+            d["comparison"] = self.comparison.to_dict()
+        return d
+
+
+def _compute_overhead(
+    streaming: BenchmarkResult,
+    non_streaming: BenchmarkResult,
+) -> StreamOverhead:
+    """Compute streaming overhead from two benchmark results."""
+    overhead = StreamOverhead()
+
+    # TTFT delta
+    s_ttft = getattr(streaming, "mean_ttft_ms", None)
+    ns_ttft = getattr(non_streaming, "mean_ttft_ms", None)
+    if s_ttft is not None and ns_ttft is not None:
+        overhead.ttft_delta_ms = s_ttft - ns_ttft
+        overhead.streaming_beneficial = s_ttft < ns_ttft
+
+    # Mean latency delta
+    s_lat = getattr(streaming, "mean_e2el_ms", None) or 0.0
+    ns_lat = getattr(non_streaming, "mean_e2el_ms", None) or 0.0
+    overhead.mean_latency_delta_ms = s_lat - ns_lat
+
+    # P99 latency delta
+    s_p99 = getattr(streaming, "p99_e2el_ms", None) or 0.0
+    ns_p99 = getattr(non_streaming, "p99_e2el_ms", None) or 0.0
+    overhead.p99_latency_delta_ms = s_p99 - ns_p99
+
+    # Throughput delta
+    s_tp = getattr(streaming, "request_throughput", None) or 0.0
+    ns_tp = getattr(non_streaming, "request_throughput", None) or 0.0
+    if ns_tp > 0:
+        overhead.throughput_delta_pct = (s_tp - ns_tp) / ns_tp * 100.0
+
+    return overhead
+
+
+async def run_stream_compare(
+    args: Namespace,
+    threshold_pct: float = 5.0,
+) -> StreamCompareResult:
+    """Run benchmarks in streaming and non-streaming modes.
+
+    Args:
+        args: Parsed CLI arguments.
+        threshold_pct: Regression detection threshold.
+
+    Returns:
+        StreamCompareResult with both results and overhead analysis.
+    """
+    result = StreamCompareResult(
+        base_url=getattr(args, "base_url", ""),
+        model=getattr(args, "model", ""),
+    )
+
+    # Run non-streaming first
+    ns_args = deepcopy(args)
+    ns_args.stream = False
+    ns_dict, ns_bench = await run_benchmark(ns_args, ns_args.base_url)
+    result.non_streaming_result = ns_bench
+    result.non_streaming_dict = ns_dict
+
+    # Run streaming
+    s_args = deepcopy(args)
+    s_args.stream = True
+    s_dict, s_bench = await run_benchmark(s_args, s_args.base_url)
+    result.streaming_result = s_bench
+    result.streaming_dict = s_dict
+
+    # Compute overhead (non-streaming is baseline)
+    result.overhead = _compute_overhead(s_bench, ns_bench)
+
+    # Run comparison (non-streaming as baseline)
+    result.comparison = compare(ns_dict, s_dict, threshold_pct=threshold_pct)
+
+    return result
+
+
+def format_stream_compare_summary(result: StreamCompareResult) -> str:
+    """Format a human-readable summary of streaming vs non-streaming comparison."""
+    lines: list[str] = []
+    lines.append("=" * 80)
+    lines.append("  xPyD-bench — Streaming vs Non-Streaming Overhead Analysis")
+    lines.append(f"  Base URL: {result.base_url}")
+    lines.append(f"  Model:    {result.model}")
+    lines.append("=" * 80)
+
+    if not result.streaming_result or not result.non_streaming_result:
+        lines.append("  No results.")
+        return "\n".join(lines)
+
+    sr = result.streaming_result
+    nr = result.non_streaming_result
+
+    display_metrics = [
+        ("completed", "Completed Requests"),
+        ("failed", "Failed Requests"),
+        ("total_duration_s", "Total Duration (s)"),
+        ("request_throughput", "Request Throughput (req/s)"),
+        ("output_throughput", "Output Throughput (tok/s)"),
+        ("mean_ttft_ms", "Mean TTFT (ms)"),
+        ("p50_ttft_ms", "P50 TTFT (ms)"),
+        ("p99_ttft_ms", "P99 TTFT (ms)"),
+        ("mean_tpot_ms", "Mean TPOT (ms)"),
+        ("mean_e2el_ms", "Mean E2E Latency (ms)"),
+        ("p50_e2el_ms", "P50 E2E Latency (ms)"),
+        ("p99_e2el_ms", "P99 E2E Latency (ms)"),
+    ]
+
+    header = f"  {'Metric':<30s} {'Non-Streaming':>15s} {'Streaming':>15s} {'Delta':>15s}"
+    lines.append(header)
+    lines.append("  " + "-" * 78)
+
+    for attr, label in display_metrics:
+        ns_val = getattr(nr, attr, None)
+        s_val = getattr(sr, attr, None)
+        ns_str = f"{ns_val:.2f}" if isinstance(ns_val, float) else str(ns_val or "N/A")
+        s_str = f"{s_val:.2f}" if isinstance(s_val, float) else str(s_val or "N/A")
+        if isinstance(ns_val, (int, float)) and isinstance(s_val, (int, float)):
+            delta = s_val - ns_val
+            delta_str = f"{delta:+.2f}"
+        else:
+            delta_str = "N/A"
+        lines.append(f"  {label:<30s} {ns_str:>15s} {s_str:>15s} {delta_str:>15s}")
+
+    lines.append("  " + "-" * 78)
+    lines.append("")
+    lines.append("  Overhead Summary:")
+    o = result.overhead
+    if o.ttft_delta_ms is not None:
+        lines.append(f"    TTFT Delta:       {o.ttft_delta_ms:+.2f} ms")
+    lines.append(f"    Latency Delta:    {o.mean_latency_delta_ms:+.2f} ms (mean)")
+    lines.append(f"    P99 Latency Delta: {o.p99_latency_delta_ms:+.2f} ms")
+    lines.append(f"    Throughput Delta:  {o.throughput_delta_pct:+.1f}%")
+    if o.streaming_beneficial:
+        lines.append("    ✅ Streaming has lower TTFT — beneficial for interactive use")
+    else:
+        lines.append("    ℹ️  Non-streaming has lower or equal TTFT")
+
+    if result.comparison and result.comparison.has_regression:
+        lines.append("    ⚠️  Regression detected in streaming mode")
+
+    lines.append("=" * 80)
+    return "\n".join(lines)
+
+
+def format_stream_compare_markdown(result: StreamCompareResult) -> str:
+    """Format streaming comparison as Markdown."""
+    if not result.streaming_result or not result.non_streaming_result:
+        return "No results.\n"
+
+    sr = result.streaming_result
+    nr = result.non_streaming_result
+
+    display_metrics = [
+        ("completed", "Completed"),
+        ("failed", "Failed"),
+        ("request_throughput", "Request Throughput"),
+        ("output_throughput", "Output Throughput"),
+        ("mean_ttft_ms", "Mean TTFT (ms)"),
+        ("p50_ttft_ms", "P50 TTFT (ms)"),
+        ("p99_ttft_ms", "P99 TTFT (ms)"),
+        ("mean_tpot_ms", "Mean TPOT (ms)"),
+        ("mean_e2el_ms", "Mean E2E Latency (ms)"),
+        ("p50_e2el_ms", "P50 E2E Latency (ms)"),
+        ("p99_e2el_ms", "P99 E2E Latency (ms)"),
+    ]
+
+    rows = [
+        "| Metric | Non-Streaming | Streaming | Delta |",
+        "| --- | --- | --- | --- |",
+    ]
+    for attr, label in display_metrics:
+        ns_val = getattr(nr, attr, None)
+        s_val = getattr(sr, attr, None)
+        ns_str = f"{ns_val:.2f}" if isinstance(ns_val, float) else str(ns_val or "N/A")
+        s_str = f"{s_val:.2f}" if isinstance(s_val, float) else str(s_val or "N/A")
+        if isinstance(ns_val, (int, float)) and isinstance(s_val, (int, float)):
+            delta_str = f"{s_val - ns_val:+.2f}"
+        else:
+            delta_str = "N/A"
+        rows.append(f"| {label} | {ns_str} | {s_str} | {delta_str} |")
+
+    rows.append("")
+    o = result.overhead
+    rows.append("### Overhead Summary")
+    rows.append("")
+    if o.ttft_delta_ms is not None:
+        rows.append(f"- **TTFT Delta:** {o.ttft_delta_ms:+.2f} ms")
+    rows.append(f"- **Mean Latency Delta:** {o.mean_latency_delta_ms:+.2f} ms")
+    rows.append(f"- **P99 Latency Delta:** {o.p99_latency_delta_ms:+.2f} ms")
+    rows.append(f"- **Throughput Delta:** {o.throughput_delta_pct:+.1f}%")
+    if o.streaming_beneficial:
+        verdict = "Streaming beneficial (lower TTFT)"
+    else:
+        verdict = "Non-streaming has lower or equal TTFT"
+    rows.append(f"- **Verdict:** {verdict}")
+    rows.append("")
+
+    return "\n".join(rows) + "\n"
+
+
+def export_stream_compare_json(
+    result: StreamCompareResult, path: str | Path,
+) -> Path:
+    """Export stream comparison results to JSON."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "w") as f:
+        json.dump(result.to_dict(), f, indent=2, default=str)
+    return p
+
+
+def export_stream_compare_markdown(
+    result: StreamCompareResult, path: str | Path,
+) -> Path:
+    """Export stream comparison Markdown to a file."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(format_stream_compare_markdown(result))
+    return p

--- a/tests/test_stream_compare.py
+++ b/tests/test_stream_compare.py
@@ -1,0 +1,280 @@
+"""Tests for streaming vs non-streaming overhead analysis (M76)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from argparse import Namespace
+from unittest.mock import patch
+
+from xpyd_bench.bench.models import BenchmarkResult, RequestResult
+from xpyd_bench.stream_compare import (
+    StreamCompareResult,
+    StreamOverhead,
+    _compute_overhead,
+    export_stream_compare_json,
+    export_stream_compare_markdown,
+    format_stream_compare_markdown,
+    format_stream_compare_summary,
+    run_stream_compare,
+)
+
+
+def _make_result(
+    latencies: list[float],
+    ttfts: list[float] | None = None,
+    throughput: float = 10.0,
+) -> tuple[dict, BenchmarkResult]:
+    """Create a fake benchmark result."""
+    if ttfts is None:
+        ttfts = [lat * 0.3 for lat in latencies]
+    requests = []
+    for lat, ttft in zip(latencies, ttfts):
+        requests.append(RequestResult(
+            latency_ms=lat,
+            ttft_ms=ttft,
+            tpot_ms=lat * 0.05,
+            prompt_tokens=10,
+            completion_tokens=20,
+            success=True,
+        ))
+    mean_lat = sum(latencies) / len(latencies)
+    sorted_lat = sorted(latencies)
+    mean_ttft = sum(ttfts) / len(ttfts)
+    sorted_ttft = sorted(ttfts)
+    br = BenchmarkResult(
+        model="test-model",
+        base_url="http://localhost:8000",
+        completed=len(latencies),
+        failed=0,
+        total_duration_s=5.0,
+        request_throughput=throughput,
+        output_throughput=throughput * 20.0,
+        total_token_throughput=throughput * 30.0,
+        mean_ttft_ms=mean_ttft,
+        p50_ttft_ms=sorted_ttft[len(ttfts) // 2],
+        p90_ttft_ms=sorted_ttft[int(len(ttfts) * 0.9)],
+        p99_ttft_ms=sorted_ttft[-1],
+        mean_tpot_ms=mean_lat * 0.05,
+        mean_e2el_ms=mean_lat,
+        p50_e2el_ms=sorted_lat[len(latencies) // 2],
+        p90_e2el_ms=sorted_lat[int(len(latencies) * 0.9)],
+        p99_e2el_ms=sorted_lat[-1],
+        requests=requests,
+    )
+    rd = {
+        "model": "test-model",
+        "completed": br.completed,
+        "failed": br.failed,
+        "request_throughput": br.request_throughput,
+        "output_throughput": br.output_throughput,
+        "total_token_throughput": br.total_token_throughput,
+        "mean_ttft_ms": br.mean_ttft_ms,
+        "p50_ttft_ms": br.p50_ttft_ms,
+        "p90_ttft_ms": br.p90_ttft_ms,
+        "p99_ttft_ms": br.p99_ttft_ms,
+        "mean_tpot_ms": br.mean_tpot_ms,
+        "mean_e2el_ms": br.mean_e2el_ms,
+        "p50_e2el_ms": br.p50_e2el_ms,
+        "p90_e2el_ms": br.p90_e2el_ms,
+        "p99_e2el_ms": br.p99_e2el_ms,
+    }
+    return rd, br
+
+
+class TestComputeOverhead:
+    """Tests for overhead calculation."""
+
+    def test_streaming_slower(self):
+        _, ns = _make_result([100.0, 110.0, 105.0], throughput=10.0)
+        _, s = _make_result([150.0, 160.0, 155.0], throughput=8.0)
+        o = _compute_overhead(s, ns)
+        assert o.mean_latency_delta_ms > 0  # streaming slower
+        assert o.throughput_delta_pct < 0  # streaming lower throughput
+
+    def test_streaming_beneficial_ttft(self):
+        # Streaming has lower TTFT
+        _, ns = _make_result([100.0, 110.0], ttfts=[50.0, 55.0], throughput=10.0)
+        _, s = _make_result([120.0, 130.0], ttfts=[20.0, 25.0], throughput=9.0)
+        o = _compute_overhead(s, ns)
+        assert o.ttft_delta_ms is not None
+        assert o.ttft_delta_ms < 0  # streaming has lower TTFT
+        assert o.streaming_beneficial is True
+
+    def test_identical_results(self):
+        _, ns = _make_result([100.0, 100.0], throughput=10.0)
+        _, s = _make_result([100.0, 100.0], throughput=10.0)
+        o = _compute_overhead(s, ns)
+        assert o.mean_latency_delta_ms == 0.0
+        assert o.throughput_delta_pct == 0.0
+
+    def test_zero_throughput_baseline(self):
+        _, ns = _make_result([100.0], throughput=0.0)
+        _, s = _make_result([100.0], throughput=5.0)
+        o = _compute_overhead(s, ns)
+        assert o.throughput_delta_pct == 0.0  # avoid division by zero
+
+
+class TestRunStreamCompare:
+    """Tests for run_stream_compare."""
+
+    def test_basic_comparison(self):
+        ns_rd, ns_br = _make_result([100.0, 110.0, 105.0], throughput=10.0)
+        s_rd, s_br = _make_result([150.0, 160.0, 155.0], throughput=8.0)
+
+        call_count = 0
+
+        async def fake_run(args, base_url):
+            nonlocal call_count
+            if call_count == 0:
+                # First call is non-streaming
+                assert args.stream is False
+                call_count += 1
+                return ns_rd, ns_br
+            assert args.stream is True
+            call_count += 1
+            return s_rd, s_br
+
+        args = Namespace(
+            base_url="http://localhost:8000",
+            model="test-model",
+            stream=None,
+        )
+
+        with patch("xpyd_bench.stream_compare.run_benchmark", side_effect=fake_run):
+            result = asyncio.run(run_stream_compare(args, threshold_pct=5.0))
+
+        assert result.streaming_result is not None
+        assert result.non_streaming_result is not None
+        assert result.overhead.mean_latency_delta_ms > 0
+        assert result.comparison is not None
+
+    def test_args_not_mutated(self):
+        """Original args should not be modified."""
+        rd, br = _make_result([100.0], throughput=10.0)
+
+        async def fake_run(args, base_url):
+            return rd, br
+
+        args = Namespace(
+            base_url="http://localhost:8000",
+            model="test-model",
+            stream=None,
+        )
+
+        with patch("xpyd_bench.stream_compare.run_benchmark", side_effect=fake_run):
+            asyncio.run(run_stream_compare(args, threshold_pct=5.0))
+
+        assert args.stream is None  # not mutated
+
+
+class TestStreamCompareResult:
+    """Tests for StreamCompareResult dataclass."""
+
+    def test_to_dict_empty(self):
+        r = StreamCompareResult()
+        d = r.to_dict()
+        assert d["base_url"] == ""
+        assert d["overhead"]["ttft_delta_ms"] is None
+
+    def test_to_dict_with_data(self):
+        rd, br = _make_result([100.0], throughput=10.0)
+        r = StreamCompareResult(
+            base_url="http://localhost",
+            model="m",
+            streaming_result=br,
+            non_streaming_result=br,
+            streaming_dict=rd,
+            non_streaming_dict=rd,
+            overhead=StreamOverhead(
+                ttft_delta_ms=-5.0,
+                streaming_beneficial=True,
+            ),
+        )
+        d = r.to_dict()
+        assert d["model"] == "m"
+        assert d["overhead"]["streaming_beneficial"] is True
+
+
+class TestFormatting:
+    """Tests for summary formatting."""
+
+    def test_format_summary_no_results(self):
+        r = StreamCompareResult()
+        s = format_stream_compare_summary(r)
+        assert "No results" in s
+
+    def test_format_summary_with_results(self):
+        _, ns = _make_result([100.0, 110.0], throughput=10.0)
+        _, s = _make_result([150.0, 160.0], throughput=8.0)
+        r = StreamCompareResult(
+            base_url="http://localhost",
+            model="test",
+            streaming_result=s,
+            non_streaming_result=ns,
+            overhead=_compute_overhead(s, ns),
+        )
+        text = format_stream_compare_summary(r)
+        assert "Streaming vs Non-Streaming" in text
+        assert "TTFT Delta" in text
+
+    def test_format_markdown_no_results(self):
+        r = StreamCompareResult()
+        md = format_stream_compare_markdown(r)
+        assert "No results" in md
+
+    def test_format_markdown_with_results(self):
+        _, ns = _make_result([100.0, 110.0], throughput=10.0)
+        _, s = _make_result([120.0, 130.0], ttfts=[10.0, 12.0], throughput=9.0)
+        r = StreamCompareResult(
+            base_url="http://localhost",
+            model="test",
+            streaming_result=s,
+            non_streaming_result=ns,
+            overhead=_compute_overhead(s, ns),
+        )
+        md = format_stream_compare_markdown(r)
+        assert "Non-Streaming" in md
+        assert "Streaming" in md
+        assert "Overhead Summary" in md
+
+
+class TestExport:
+    """Tests for JSON and Markdown export."""
+
+    def test_export_json(self, tmp_path):
+        r = StreamCompareResult(
+            base_url="http://localhost",
+            model="test",
+            overhead=StreamOverhead(ttft_delta_ms=-5.0),
+        )
+        p = export_stream_compare_json(r, tmp_path / "out.json")
+        assert p.exists()
+        data = json.loads(p.read_text())
+        assert data["overhead"]["ttft_delta_ms"] == -5.0
+
+    def test_export_markdown(self, tmp_path):
+        _, ns = _make_result([100.0], throughput=10.0)
+        _, s = _make_result([120.0], throughput=9.0)
+        r = StreamCompareResult(
+            base_url="http://localhost",
+            model="test",
+            streaming_result=s,
+            non_streaming_result=ns,
+            overhead=_compute_overhead(s, ns),
+        )
+        p = export_stream_compare_markdown(r, tmp_path / "out.md")
+        assert p.exists()
+        assert "Streaming" in p.read_text()
+
+
+class TestCLIIntegration:
+    """Tests for CLI integration."""
+
+    def test_stream_compare_in_subcommands(self):
+        from xpyd_bench.main import _SUBCOMMANDS
+        assert "stream-compare" in _SUBCOMMANDS
+
+    def test_cli_entry_exists(self):
+        from xpyd_bench.cli import stream_compare_main
+        assert callable(stream_compare_main)


### PR DESCRIPTION
## Summary
Add `xpyd-bench stream-compare` CLI subcommand that benchmarks same prompts in both streaming and non-streaming modes, then reports overhead analysis.

## Changes
- New `src/xpyd_bench/stream_compare.py` module
- CLI entry point `stream_compare_main` in `cli.py`
- Registered `stream-compare` subcommand in `main.py`
- ROADMAP.md M76 marked ✅
- 16 tests in `tests/test_stream_compare.py`

## Features
- TTFT delta, mean/P99 latency delta, throughput impact
- Identifies when streaming is beneficial (lower TTFT)
- JSON and Markdown export
- Regression detection via existing compare logic

Closes #210