### PR TITLE
feat(m77): multimodal vision benchmarking

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -633,3 +633,14 @@
 - Identify when streaming is beneficial vs detrimental
 - JSON and terminal summary output
 - Tests covering dual-mode execution, overhead calculation, and CLI integration
+
+## M77: Multimodal (Vision) Benchmarking ✅
+- `--image-url <url>` CLI flag to include an HTTP image in every chat prompt
+- `--image-dir <path>` to randomly sample images from a directory per request
+- `--synthetic-images N` to generate N synthetic PNG images for benchmarking
+- `--synthetic-image-size WxH` for synthetic image dimensions (default 64x64)
+- `--image-detail auto|low|high` to control vision detail level
+- Multimodal content array in chat messages (OpenAI vision API format)
+- Dummy server handles multimodal content in token estimation
+- YAML config support (`image_url`, `image_dir`, `synthetic_images`, `synthetic_image_size`, `image_detail`)
+- Tests covering image generation, content building, CLI parsing, payload construction, and config keys

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -440,7 +440,19 @@ def _build_payload(
         payload["model"] = args.model
 
     if is_chat:
-        payload["messages"] = [{"role": "user", "content": prompt}]
+        # Vision / multimodal support (M77)
+        vision_sources = getattr(args, "_vision_sources", None)
+        if vision_sources:
+            import random as _random
+
+            from xpyd_bench.bench.vision import build_vision_payload_content
+
+            image_detail = getattr(args, "image_detail", "auto") or "auto"
+            src = _random.choice(vision_sources)
+            content = build_vision_payload_content(prompt, src, image_detail)
+            payload["messages"] = [{"role": "user", "content": content}]
+        else:
+            payload["messages"] = [{"role": "user", "content": prompt}]
     else:
         payload["prompt"] = prompt
 
@@ -590,6 +602,28 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
 
         plugin = registry.get(backend_name)
         use_plugin = True
+
+    # Load vision image sources (M77)
+    _vision_image_url = getattr(args, "image_url", None)
+    _vision_image_dir = getattr(args, "image_dir", None)
+    _vision_synthetic = getattr(args, "synthetic_images", 0) or 0
+    if _vision_image_url or _vision_image_dir or _vision_synthetic > 0:
+        from xpyd_bench.bench.vision import load_image_sources
+
+        _synth_size = getattr(args, "synthetic_image_size", "64x64") or "64x64"
+        _sw, _sh = (int(x) for x in _synth_size.split("x"))
+        args._vision_sources = load_image_sources(
+            image_dir=_vision_image_dir,
+            image_url=_vision_image_url,
+            synthetic_images=_vision_synthetic,
+            synthetic_width=_sw,
+            synthetic_height=_sh,
+            seed=args.seed,
+        )
+        if not args._vision_sources:
+            raise SystemExit("ERROR: Vision mode enabled but no images found/generated.")
+    else:
+        args._vision_sources = None
 
     is_chat = "chat" in args.endpoint
     is_embeddings = "embeddings" in args.endpoint

--- a/src/xpyd_bench/bench/vision.py
+++ b/src/xpyd_bench/bench/vision.py
@@ -1,0 +1,182 @@
+"""Multimodal (vision) input utilities for benchmarking VLMs (M77)."""
+
+from __future__ import annotations
+
+import base64
+import random
+from pathlib import Path
+from typing import Any
+
+# Common MIME types by extension
+_EXT_TO_MIME: dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+    ".svg": "image/svg+xml",
+}
+
+
+def _guess_mime(path: str) -> str:
+    """Guess MIME type from file extension."""
+    ext = Path(path).suffix.lower()
+    return _EXT_TO_MIME.get(ext, "image/png")
+
+
+def encode_image_base64(path: str) -> str:
+    """Read an image file and return its base64-encoded string."""
+    with open(path, "rb") as f:
+        return base64.b64encode(f.read()).decode("ascii")
+
+
+def build_vision_content(
+    text: str,
+    *,
+    image_urls: list[str] | None = None,
+    image_files: list[str] | None = None,
+    image_detail: str = "auto",
+) -> list[dict[str, Any]]:
+    """Build a multimodal ``content`` array for an OpenAI chat message.
+
+    Parameters
+    ----------
+    text:
+        The text portion of the user message.
+    image_urls:
+        HTTP(S) URLs to include as ``image_url`` content parts.
+    image_files:
+        Local file paths to include as base64-encoded ``image_url`` parts.
+    image_detail:
+        Image detail level: ``"auto"``, ``"low"``, or ``"high"``.
+
+    Returns
+    -------
+    list[dict]:
+        A ``content`` array suitable for OpenAI chat completions.
+    """
+    parts: list[dict[str, Any]] = []
+
+    # Add image parts first (URLs)
+    for url in image_urls or []:
+        parts.append({
+            "type": "image_url",
+            "image_url": {"url": url, "detail": image_detail},
+        })
+
+    # Add image parts (local files as base64 data URIs)
+    for fpath in image_files or []:
+        mime = _guess_mime(fpath)
+        b64 = encode_image_base64(fpath)
+        data_uri = f"data:{mime};base64,{b64}"
+        parts.append({
+            "type": "image_url",
+            "image_url": {"url": data_uri, "detail": image_detail},
+        })
+
+    # Add text part
+    parts.append({"type": "text", "text": text})
+
+    return parts
+
+
+def generate_synthetic_image(
+    width: int = 64,
+    height: int = 64,
+    seed: int | None = None,
+) -> bytes:
+    """Generate a minimal synthetic PNG image (random pixels).
+
+    Returns raw PNG bytes. Uses a simple uncompressed PNG to avoid
+    numpy/PIL dependencies.
+    """
+    import struct
+    import zlib
+
+    rng = random.Random(seed)
+
+    # Build raw pixel data (RGB)
+    raw_rows = []
+    for _ in range(height):
+        row = b"\x00"  # filter byte: None
+        row += bytes(rng.randint(0, 255) for _ in range(width * 3))
+        raw_rows.append(row)
+    raw_data = b"".join(raw_rows)
+
+    def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+        c = chunk_type + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+
+    # PNG signature
+    sig = b"\x89PNG\r\n\x1a\n"
+    # IHDR
+    ihdr_data = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    ihdr = _chunk(b"IHDR", ihdr_data)
+    # IDAT
+    compressed = zlib.compress(raw_data)
+    idat = _chunk(b"IDAT", compressed)
+    # IEND
+    iend = _chunk(b"IEND", b"")
+
+    return sig + ihdr + idat + iend
+
+
+def load_image_sources(
+    image_dir: str | None = None,
+    image_url: str | None = None,
+    synthetic_images: int = 0,
+    synthetic_width: int = 64,
+    synthetic_height: int = 64,
+    seed: int = 0,
+) -> list[dict[str, Any]]:
+    """Load or generate image sources for vision benchmarking.
+
+    Returns a list of dicts, each with either ``"url"`` or ``"data_uri"`` key.
+    """
+    sources: list[dict[str, Any]] = []
+
+    # Load from directory
+    if image_dir:
+        p = Path(image_dir)
+        if not p.is_dir():
+            raise FileNotFoundError(f"Image directory not found: {image_dir}")
+        exts = set(_EXT_TO_MIME.keys())
+        for f in sorted(p.iterdir()):
+            if f.suffix.lower() in exts:
+                mime = _guess_mime(str(f))
+                b64 = encode_image_base64(str(f))
+                sources.append({"data_uri": f"data:{mime};base64,{b64}"})
+
+    # Single URL
+    if image_url:
+        sources.append({"url": image_url})
+
+    # Synthetic images
+    if synthetic_images > 0:
+        for i in range(synthetic_images):
+            img_bytes = generate_synthetic_image(
+                width=synthetic_width,
+                height=synthetic_height,
+                seed=seed + i,
+            )
+            b64 = base64.b64encode(img_bytes).decode("ascii")
+            sources.append({"data_uri": f"data:image/png;base64,{b64}"})
+
+    return sources
+
+
+def build_vision_payload_content(
+    text: str,
+    image_source: dict[str, Any],
+    image_detail: str = "auto",
+) -> list[dict[str, Any]]:
+    """Build multimodal content array from a text prompt and one image source."""
+    url = image_source.get("url") or image_source.get("data_uri", "")
+    return [
+        {
+            "type": "image_url",
+            "image_url": {"url": url, "detail": image_detail},
+        },
+        {"type": "text", "text": text},
+    ]

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -406,6 +406,45 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Enable gzip compression of request bodies (Content-Encoding: gzip).",
     )
 
+    # Multimodal / Vision (M77)
+    vision_group = parser.add_argument_group("multimodal / vision (M77)")
+    vision_group.add_argument(
+        "--image-url",
+        type=str,
+        default=None,
+        dest="image_url",
+        help="HTTP(S) URL of an image to include in every chat prompt.",
+    )
+    vision_group.add_argument(
+        "--image-dir",
+        type=str,
+        default=None,
+        dest="image_dir",
+        help="Directory of image files to randomly sample from for each prompt.",
+    )
+    vision_group.add_argument(
+        "--synthetic-images",
+        type=int,
+        default=0,
+        dest="synthetic_images",
+        help="Number of synthetic images to generate for vision benchmarking.",
+    )
+    vision_group.add_argument(
+        "--synthetic-image-size",
+        type=str,
+        default="64x64",
+        dest="synthetic_image_size",
+        help="Synthetic image dimensions as WxH (default: 64x64).",
+    )
+    vision_group.add_argument(
+        "--image-detail",
+        type=str,
+        default="auto",
+        dest="image_detail",
+        choices=["auto", "low", "high"],
+        help="Image detail level for vision requests (default: auto).",
+    )
+
     # Anomaly detection (M43)
     parser.add_argument(
         "--anomaly-threshold",

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -120,6 +120,11 @@ _KNOWN_KEYS: set[str] = {
     "percentiles",
     "checkpoint_dir",
     "checkpoint_interval",
+    "image_url",
+    "image_dir",
+    "synthetic_images",
+    "synthetic_image_size",
+    "image_detail",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -146,7 +146,21 @@ def _estimate_prompt_tokens(prompt: str | list | None, messages: list | None) ->
         text = _normalize_prompt(prompt)
         return max(1, len(text) // 4)
     if messages is not None:
-        total = sum(len(m.get("content", "")) for m in messages)
+        total = 0
+        for m in messages:
+            c = m.get("content", "")
+            if isinstance(c, str):
+                total += len(c)
+            elif isinstance(c, list):
+                # Multimodal content: sum text parts, count image parts as 85 tokens
+                for part in c:
+                    if isinstance(part, dict):
+                        if part.get("type") == "text":
+                            total += len(part.get("text", ""))
+                        elif part.get("type") == "image_url":
+                            total += 85 * 4  # ~85 tokens for low-detail image
+            else:
+                total += len(str(c))
         return max(1, total // 4)
     return 1
 

--- a/tests/test_m77_vision.py
+++ b/tests/test_m77_vision.py
@@ -1,0 +1,344 @@
+"""Tests for M77: Multimodal (Vision) Benchmarking."""
+
+from __future__ import annotations
+
+import base64
+from argparse import Namespace
+
+import pytest
+
+from xpyd_bench.bench.vision import (
+    build_vision_content,
+    build_vision_payload_content,
+    encode_image_base64,
+    generate_synthetic_image,
+    load_image_sources,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for vision.py
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSyntheticImage:
+    """Tests for synthetic image generation."""
+
+    def test_returns_valid_png(self):
+        data = generate_synthetic_image(width=8, height=8, seed=42)
+        assert isinstance(data, bytes)
+        assert data[:8] == b"\x89PNG\r\n\x1a\n"  # PNG signature
+
+    def test_deterministic_with_seed(self):
+        a = generate_synthetic_image(width=8, height=8, seed=42)
+        b = generate_synthetic_image(width=8, height=8, seed=42)
+        assert a == b
+
+    def test_different_seeds_differ(self):
+        a = generate_synthetic_image(width=8, height=8, seed=1)
+        b = generate_synthetic_image(width=8, height=8, seed=2)
+        assert a != b
+
+
+class TestEncodeImageBase64:
+    """Tests for base64 encoding."""
+
+    def test_encodes_file(self, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\nfakedata")
+        result = encode_image_base64(str(img))
+        decoded = base64.b64decode(result)
+        assert decoded == b"\x89PNG\r\n\x1a\nfakedata"
+
+
+class TestBuildVisionContent:
+    """Tests for building multimodal content arrays."""
+
+    def test_text_only(self):
+        parts = build_vision_content("describe this")
+        assert len(parts) == 1
+        assert parts[0] == {"type": "text", "text": "describe this"}
+
+    def test_with_url(self):
+        parts = build_vision_content(
+            "describe this",
+            image_urls=["https://example.com/img.png"],
+        )
+        assert len(parts) == 2
+        assert parts[0]["type"] == "image_url"
+        assert parts[0]["image_url"]["url"] == "https://example.com/img.png"
+        assert parts[0]["image_url"]["detail"] == "auto"
+        assert parts[1]["type"] == "text"
+
+    def test_with_file(self, tmp_path):
+        img = tmp_path / "test.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0fakeimg")
+        parts = build_vision_content(
+            "describe",
+            image_files=[str(img)],
+            image_detail="high",
+        )
+        assert len(parts) == 2
+        assert parts[0]["type"] == "image_url"
+        assert parts[0]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+        assert parts[0]["image_url"]["detail"] == "high"
+
+    def test_multiple_images(self):
+        parts = build_vision_content(
+            "compare",
+            image_urls=["https://a.com/1.png", "https://a.com/2.png"],
+        )
+        assert len(parts) == 3  # 2 images + 1 text
+
+
+class TestLoadImageSources:
+    """Tests for loading image sources."""
+
+    def test_from_url(self):
+        sources = load_image_sources(image_url="https://example.com/img.png")
+        assert len(sources) == 1
+        assert sources[0]["url"] == "https://example.com/img.png"
+
+    def test_from_directory(self, tmp_path):
+        (tmp_path / "a.png").write_bytes(b"fake-png")
+        (tmp_path / "b.jpg").write_bytes(b"fake-jpg")
+        (tmp_path / "not_image.txt").write_text("nope")
+        sources = load_image_sources(image_dir=str(tmp_path))
+        assert len(sources) == 2
+        assert all("data_uri" in s for s in sources)
+
+    def test_synthetic(self):
+        sources = load_image_sources(synthetic_images=3, seed=42)
+        assert len(sources) == 3
+        assert all("data_uri" in s for s in sources)
+        # Should be valid base64 data URIs
+        for s in sources:
+            assert s["data_uri"].startswith("data:image/png;base64,")
+
+    def test_missing_directory_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_image_sources(image_dir="/nonexistent/dir")
+
+    def test_empty_returns_empty(self):
+        sources = load_image_sources()
+        assert sources == []
+
+
+class TestBuildVisionPayloadContent:
+    """Tests for build_vision_payload_content."""
+
+    def test_with_url_source(self):
+        src = {"url": "https://example.com/img.png"}
+        parts = build_vision_payload_content("describe", src)
+        assert len(parts) == 2
+        assert parts[0]["type"] == "image_url"
+        assert parts[0]["image_url"]["url"] == "https://example.com/img.png"
+        assert parts[1] == {"type": "text", "text": "describe"}
+
+    def test_with_data_uri_source(self):
+        src = {"data_uri": "data:image/png;base64,abc123"}
+        parts = build_vision_payload_content("describe", src, image_detail="low")
+        assert parts[0]["image_url"]["url"] == "data:image/png;base64,abc123"
+        assert parts[0]["image_url"]["detail"] == "low"
+
+
+# ---------------------------------------------------------------------------
+# Integration: _build_payload with vision sources
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPayloadVision:
+    """Test that _build_payload produces multimodal content when vision is enabled."""
+
+    def test_vision_payload_has_multimodal_content(self):
+        from xpyd_bench.bench.runner import _build_payload
+
+        args = Namespace(
+            model="gpt-4-vision-preview",
+            output_len=128,
+            temperature=None,
+            top_p=None,
+            top_k=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            best_of=None,
+            use_beam_search=False,
+            logprobs=None,
+            ignore_eos=False,
+            stop=None,
+            n=None,
+            api_seed=None,
+            echo=False,
+            suffix=None,
+            logit_bias=None,
+            user=None,
+            stream_options_include_usage=False,
+            response_format=None,
+            tools=None,
+            tool_choice=None,
+            parallel_tool_calls=None,
+            top_logprobs=None,
+            max_completion_tokens=None,
+            service_tier=None,
+            image_detail="auto",
+            _vision_sources=[{"url": "https://example.com/img.png"}],
+        )
+        payload = _build_payload(args, "What is in this image?", is_chat=True)
+        messages = payload["messages"]
+        assert len(messages) == 1
+        content = messages[0]["content"]
+        assert isinstance(content, list)
+        assert any(p["type"] == "image_url" for p in content)
+        assert any(p["type"] == "text" for p in content)
+
+    def test_no_vision_payload_is_string_content(self):
+        from xpyd_bench.bench.runner import _build_payload
+
+        args = Namespace(
+            model="gpt-4",
+            output_len=128,
+            temperature=None,
+            top_p=None,
+            top_k=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            best_of=None,
+            use_beam_search=False,
+            logprobs=None,
+            ignore_eos=False,
+            stop=None,
+            n=None,
+            api_seed=None,
+            echo=False,
+            suffix=None,
+            logit_bias=None,
+            user=None,
+            stream_options_include_usage=False,
+            response_format=None,
+            tools=None,
+            tool_choice=None,
+            parallel_tool_calls=None,
+            top_logprobs=None,
+            max_completion_tokens=None,
+            service_tier=None,
+            _vision_sources=None,
+        )
+        payload = _build_payload(args, "Hello world", is_chat=True)
+        messages = payload["messages"]
+        assert messages[0]["content"] == "Hello world"
+
+
+# ---------------------------------------------------------------------------
+# Dummy server multimodal token estimation
+# ---------------------------------------------------------------------------
+
+
+class TestDummyServerMultimodalTokens:
+    """Test that the dummy server handles multimodal content in token estimation."""
+
+    def test_string_content(self):
+        from xpyd_bench.dummy.server import _estimate_prompt_tokens
+
+        result = _estimate_prompt_tokens(None, [{"content": "hello world test"}])
+        assert result == max(1, len("hello world test") // 4)
+
+    def test_multimodal_content(self):
+        from xpyd_bench.dummy.server import _estimate_prompt_tokens
+
+        messages = [
+            {
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                    {"type": "text", "text": "describe this image"},
+                ]
+            }
+        ]
+        result = _estimate_prompt_tokens(None, messages)
+        # 85*4 chars for image + len("describe this image") chars, // 4
+        expected_chars = 85 * 4 + len("describe this image")
+        assert result == max(1, expected_chars // 4)
+
+    def test_empty_content(self):
+        from xpyd_bench.dummy.server import _estimate_prompt_tokens
+
+        result = _estimate_prompt_tokens(None, [{"content": []}])
+        assert result == 1  # max(1, 0//4)
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+def _make_parser():
+    """Helper to build a parser with vLLM-compat args."""
+    import argparse
+
+    from xpyd_bench.cli import _add_vllm_compat_args
+    parser = argparse.ArgumentParser()
+    _add_vllm_compat_args(parser)
+    return parser
+
+
+class TestVisionCLIArgs:
+    """Test CLI argument parsing for vision flags."""
+
+    def test_image_url_flag(self):
+        args = _make_parser().parse_args([
+            "--base-url", "http://localhost:8000",
+            "--image-url", "https://example.com/img.png",
+        ])
+        assert args.image_url == "https://example.com/img.png"
+
+    def test_image_dir_flag(self):
+        args = _make_parser().parse_args([
+            "--base-url", "http://localhost:8000",
+            "--image-dir", "/tmp/images",
+        ])
+        assert args.image_dir == "/tmp/images"
+
+    def test_synthetic_images_flag(self):
+        args = _make_parser().parse_args([
+            "--base-url", "http://localhost:8000",
+            "--synthetic-images", "5",
+        ])
+        assert args.synthetic_images == 5
+
+    def test_image_detail_flag(self):
+        args = _make_parser().parse_args([
+            "--base-url", "http://localhost:8000",
+            "--image-detail", "high",
+        ])
+        assert args.image_detail == "high"
+
+    def test_synthetic_image_size_flag(self):
+        args = _make_parser().parse_args([
+            "--base-url", "http://localhost:8000",
+            "--synthetic-image-size", "128x128",
+        ])
+        assert args.synthetic_image_size == "128x128"
+
+    def test_defaults(self):
+        args = _make_parser().parse_args(["--base-url", "http://localhost:8000"])
+        assert args.image_url is None
+        assert args.image_dir is None
+        assert args.synthetic_images == 0
+        assert args.image_detail == "auto"
+        assert args.synthetic_image_size == "64x64"
+
+
+# ---------------------------------------------------------------------------
+# Config known keys
+# ---------------------------------------------------------------------------
+
+
+class TestVisionConfigKeys:
+    """Test that vision config keys are recognized."""
+
+    def test_vision_keys_known(self):
+        from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+        vision_keys = {
+            "image_url", "image_dir", "synthetic_images",
+            "synthetic_image_size", "image_detail",
+        }
+        assert vision_keys.issubset(_KNOWN_KEYS)


### PR DESCRIPTION
## Summary
Add multimodal (vision) benchmarking support for VLMs.

Closes #212

## Changes
- **New module** `src/xpyd_bench/bench/vision.py`: image loading, synthetic PNG generation, multimodal content building
- **Runner**: `_build_payload` produces multimodal content array when vision sources are configured
- **CLI**: 5 new flags (`--image-url`, `--image-dir`, `--synthetic-images`, `--synthetic-image-size`, `--image-detail`)
- **Dummy server**: multimodal-aware token estimation (handles content arrays with image_url parts)
- **Config**: all vision keys added to `_KNOWN_KEYS`
- **ROADMAP**: M77 added as complete
- **Tests**: 27 new tests in `tests/test_m77_vision.py`

## Test Results
```
1441 passed in 33.98s
ruff check: All checks passed!
isort --check: All checks passed!
```