### PR TITLE
feat(M79): Git Metadata Capture in Benchmark Results

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -655,3 +655,12 @@
 - Useful for understanding actual workload characteristics vs configured parameters
 - YAML config support (`workload_stats: true`)
 - Tests covering stats computation, CLI flag, YAML config, and edge cases
+
+## M79: Git Metadata Capture in Benchmark Results ✅
+- `collect_git_info()` utility in `src/xpyd_bench/bench/env.py`
+- Auto-detect git repository and capture: commit hash, short commit, branch, dirty status, remote URL
+- `BenchmarkResult` includes `git_info` dict field (auto-populated, None if not in git repo)
+- All saved JSON results include `git_info` section when available
+- `--dry-run` output shows git metadata section
+- Graceful fallback: returns None when git unavailable, not in repo, or command times out
+- Tests covering git info collection, fallback scenarios, serialization, and model field

--- a/src/xpyd_bench/bench/env.py
+++ b/src/xpyd_bench/bench/env.py
@@ -4,8 +4,51 @@ from __future__ import annotations
 
 import platform
 import socket
+import subprocess
 import sys
 from datetime import datetime, timezone
+
+
+def collect_git_info() -> dict[str, str] | None:
+    """Collect git repository metadata if running inside a git repo.
+
+    Returns a dict with keys: commit, branch, dirty, remote_url.
+    Returns None if not in a git repository or git is not available.
+    """
+    try:
+        # Check if we're in a git repo
+        subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            capture_output=True,
+            check=True,
+            timeout=5,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+    info: dict[str, str] = {}
+
+    def _git(*args: str) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip()
+
+    try:
+        info["commit"] = _git("rev-parse", "HEAD")
+        info["commit_short"] = _git("rev-parse", "--short", "HEAD")
+        info["branch"] = _git("rev-parse", "--abbrev-ref", "HEAD")
+        # dirty = any uncommitted changes
+        dirty_output = _git("status", "--porcelain")
+        info["dirty"] = str(bool(dirty_output))
+        info["remote_url"] = _git("config", "--get", "remote.origin.url")
+    except (subprocess.TimeoutExpired, Exception):
+        pass
+
+    return info if info else None
 
 
 def collect_env_info() -> dict[str, str]:

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -153,3 +153,6 @@ class BenchmarkResult:
 
     # Workload distribution statistics (M78)
     workload_stats: dict | None = None
+
+    # Git repository metadata (M79)
+    git_info: dict[str, str] | None = None

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -16,7 +16,7 @@ import httpx
 import numpy as np
 
 from xpyd_bench.bench.debug_log import DebugLogger
-from xpyd_bench.bench.env import collect_env_info
+from xpyd_bench.bench.env import collect_env_info, collect_git_info
 from xpyd_bench.bench.models import BenchmarkResult, RequestResult
 
 # ---------------------------------------------------------------------------
@@ -759,6 +759,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         output_len=args.output_len,
         duration_limit=duration_limit,
         environment=collect_env_info(),
+        git_info=collect_git_info(),
     )
 
     # Timeout & retry settings
@@ -1531,6 +1532,7 @@ async def replay_trace(
         model=model,
         num_prompts=len(trace.entries),
         environment=collect_env_info(),
+        git_info=collect_git_info(),
     )
 
     replay_kwargs: dict[str, Any] = {
@@ -1613,6 +1615,8 @@ def _to_dict(r: BenchmarkResult) -> dict:
             d[key] = val  # None serializes as JSON null
     if r.environment:
         d["environment"] = r.environment
+    if r.git_info:
+        d["git_info"] = r.git_info
     if r.partial:
         d["partial"] = True
     if r.tags:

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -1121,13 +1121,21 @@ def _dry_run(args: argparse.Namespace, base_url: str) -> None:
         print("  (estimated from num_prompts × input_len / output_len)")
 
     # Environment info
-    from xpyd_bench.bench.env import collect_env_info
+    from xpyd_bench.bench.env import collect_env_info, collect_git_info
 
     env = collect_env_info()
     print()
     print("Environment:")
     for k, v in env.items():
         print(f"  {k}: {v}")
+
+    # Git metadata
+    git_info = collect_git_info()
+    if git_info:
+        print()
+        print("Git:")
+        for k, v in git_info.items():
+            print(f"  {k}: {v}")
 
     print(f"{'='*60}")
 

--- a/tests/test_git_info.py
+++ b/tests/test_git_info.py
@@ -1,0 +1,81 @@
+"""Tests for git metadata capture (M79)."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from xpyd_bench.bench.env import collect_git_info
+from xpyd_bench.bench.models import BenchmarkResult
+
+
+class TestCollectGitInfo:
+    """Tests for collect_git_info()."""
+
+    def test_returns_dict_in_git_repo(self) -> None:
+        """When running inside a git repo, returns metadata dict."""
+        info = collect_git_info()
+        # This test suite runs inside xPyD-bench which is a git repo
+        assert info is not None
+        assert "commit" in info
+        assert "commit_short" in info
+        assert "branch" in info
+        assert "dirty" in info
+        assert "remote_url" in info
+        # commit should be a 40-char hex string
+        assert len(info["commit"]) == 40
+        assert len(info["commit_short"]) >= 7
+        # dirty is "True" or "False"
+        assert info["dirty"] in ("True", "False")
+
+    def test_returns_none_when_not_in_repo(self) -> None:
+        """When git rev-parse fails, returns None."""
+        with patch("subprocess.run", side_effect=subprocess.CalledProcessError(128, "git")):
+            assert collect_git_info() is None
+
+    def test_returns_none_when_git_not_installed(self) -> None:
+        """When git binary is not found, returns None."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert collect_git_info() is None
+
+    def test_returns_none_on_timeout(self) -> None:
+        """When git command times out, returns None."""
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("git", 5)):
+            assert collect_git_info() is None
+
+
+class TestBenchmarkResultGitInfo:
+    """Tests for git_info field on BenchmarkResult."""
+
+    def test_default_none(self) -> None:
+        """git_info defaults to None."""
+        r = BenchmarkResult()
+        assert r.git_info is None
+
+    def test_set_git_info(self) -> None:
+        """Can set git_info on BenchmarkResult."""
+        info = {"commit": "abc123", "branch": "main", "dirty": "False"}
+        r = BenchmarkResult(git_info=info)
+        assert r.git_info == info
+        assert r.git_info["branch"] == "main"
+
+
+class TestGitInfoSerialization:
+    """Tests for git_info in JSON output."""
+
+    def test_git_info_in_result_dict(self) -> None:
+        """git_info is included in serialized result dict."""
+        from xpyd_bench.bench.runner import _to_dict as result_to_dict
+
+        info = {"commit": "abc123", "branch": "main", "dirty": "False", "remote_url": "https://example.com"}
+        r = BenchmarkResult(git_info=info)
+        d = result_to_dict(r)
+        assert d["git_info"] == info
+
+    def test_git_info_omitted_when_none(self) -> None:
+        """git_info is not in serialized dict when None."""
+        from xpyd_bench.bench.runner import _to_dict as result_to_dict
+
+        r = BenchmarkResult()
+        d = result_to_dict(r)
+        assert "git_info" not in d


### PR DESCRIPTION
Closes #216

## Changes
- Add `collect_git_info()` to `src/xpyd_bench/bench/env.py`
- Add `git_info` field to `BenchmarkResult` in models.py
- Auto-populate git_info in runner.py (both run and replay paths)
- Include git_info in JSON serialization (`_to_dict`)
- Show git metadata in dry-run output (cli.py)
- Update ROADMAP.md with M79 milestone (marked ✅)

## Tests
8 new tests in `tests/test_git_info.py`:
- Git info collection in real repo
- Fallback when not in repo / git missing / timeout
- BenchmarkResult field defaults and assignment
- Serialization inclusion/exclusion