### PR TITLE
feat(M80): Configuration Inheritance (extends)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -664,3 +664,15 @@
 - `--dry-run` output shows git metadata section
 - Graceful fallback: returns None when git unavailable, not in repo, or command times out
 - Tests covering git info collection, fallback scenarios, serialization, and model field
+
+## M80: Configuration Inheritance (extends) ✅
+- `extends: <path>` key in YAML config to inherit from a parent config file
+- Relative paths resolved against the config file's directory
+- Multi-level inheritance supported (child → parent → grandparent)
+- Child values override parent values; parent provides defaults
+- Circular inheritance detected with clear error message
+- `extends` key removed from resolved config (not passed to benchmark)
+- `config validate` checks inheritance chain validity
+- `config dump` shows fully resolved config with inheritance applied
+- CLI flags take highest precedence (CLI > child YAML > parent YAML)
+- Tests covering single/multi-level inheritance, circular detection, CLI precedence, and error cases

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -1201,8 +1201,12 @@ def _load_yaml_config(
         previous behaviour of skipping keys whose current value is not
         ``None``.
     """
-    with open(path) as f:
-        cfg = yaml.safe_load(f) or {}
+    from xpyd_bench.config_cmd import ConfigInheritanceError, _resolve_yaml_chain
+
+    try:
+        cfg = _resolve_yaml_chain(path)
+    except (ConfigInheritanceError, yaml.YAMLError, OSError) as exc:
+        raise SystemExit(f"Error loading config {path}: {exc}") from exc
     for key, value in cfg.items():
         attr = key.replace("-", "_")
         if explicit_keys is not None:

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -126,10 +126,57 @@ _KNOWN_KEYS: set[str] = {
     "synthetic_image_size",
     "image_detail",
     "workload_stats",
+    "extends",
 }
 
 # Deprecated keys (currently none, placeholder for future use)
 _DEPRECATED_KEYS: dict[str, str] = {}
+
+
+class ConfigInheritanceError(Exception):
+    """Raised when config inheritance chain is invalid (circular, missing, etc.)."""
+
+
+def _resolve_yaml_chain(path: str, _seen: set[str] | None = None) -> dict[str, Any]:
+    """Resolve a YAML config file with ``extends`` inheritance.
+
+    Walks the ``extends`` chain, merging parent → child (child wins).
+    Detects circular references and raises ``ConfigInheritanceError``.
+
+    Returns the fully merged config dict (``extends`` key removed).
+    """
+    config_path = Path(path).resolve()
+    if _seen is None:
+        _seen = set()
+    key = str(config_path)
+    if key in _seen:
+        raise ConfigInheritanceError(
+            f"Circular config inheritance detected: {key}"
+        )
+    _seen.add(key)
+
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f) or {}
+
+    if not isinstance(cfg, dict):
+        raise ConfigInheritanceError(
+            f"Config must be a YAML mapping in {config_path}, got {type(cfg).__name__}"
+        )
+
+    extends = cfg.pop("extends", None)
+    if extends is not None:
+        # Resolve relative to the config file's directory
+        parent_path = (config_path.parent / extends).resolve()
+        if not parent_path.exists():
+            raise ConfigInheritanceError(
+                f"Extended config not found: {parent_path} (referenced from {config_path})"
+            )
+        parent_cfg = _resolve_yaml_chain(str(parent_path), _seen)
+        # Parent first, then child overlays
+        parent_cfg.update(cfg)
+        cfg = parent_cfg
+
+    return cfg
 
 
 def _load_and_check_yaml(path: str) -> tuple[dict[str, Any], list[str], list[str]]:
@@ -143,18 +190,16 @@ def _load_and_check_yaml(path: str) -> tuple[dict[str, Any], list[str], list[str
         return {}, warnings, errors
 
     try:
-        with open(config_path) as f:
-            cfg = yaml.safe_load(f)
+        cfg = _resolve_yaml_chain(str(config_path))
+    except ConfigInheritanceError as e:
+        errors.append(str(e))
+        return {}, warnings, errors
     except yaml.YAMLError as e:
         errors.append(f"Invalid YAML syntax: {e}")
         return {}, warnings, errors
 
-    if cfg is None:
+    if not cfg:
         warnings.append("Config file is empty")
-        return {}, warnings, errors
-
-    if not isinstance(cfg, dict):
-        errors.append(f"Config must be a YAML mapping, got {type(cfg).__name__}")
         return {}, warnings, errors
 
     for key in cfg:

--- a/tests/test_config_inheritance.py
+++ b/tests/test_config_inheritance.py
@@ -1,0 +1,128 @@
+"""Tests for configuration inheritance via ``extends`` (M80)."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+import yaml
+
+from xpyd_bench.config_cmd import (
+    ConfigInheritanceError,
+    _load_and_check_yaml,
+    _resolve_yaml_chain,
+)
+
+
+@pytest.fixture()
+def tmp_configs(tmp_path: Path):
+    """Helper to write YAML config files in tmp_path."""
+
+    def _write(name: str, data: dict) -> str:
+        p = tmp_path / name
+        p.write_text(yaml.dump(data))
+        return str(p)
+
+    return _write
+
+
+class TestResolveYamlChain:
+    """Tests for _resolve_yaml_chain()."""
+
+    def test_simple_no_extends(self, tmp_configs) -> None:
+        path = tmp_configs("base.yaml", {"model": "gpt-4", "num_prompts": 10})
+        cfg = _resolve_yaml_chain(path)
+        assert cfg == {"model": "gpt-4", "num_prompts": 10}
+
+    def test_single_level_inheritance(self, tmp_configs) -> None:
+        tmp_configs("base.yaml", {"model": "gpt-4", "num_prompts": 100, "temperature": 0.5})
+        child_path = tmp_configs("child.yaml", {"extends": "base.yaml", "num_prompts": 10})
+        cfg = _resolve_yaml_chain(child_path)
+        assert cfg["model"] == "gpt-4"
+        assert cfg["num_prompts"] == 10  # child overrides
+        assert cfg["temperature"] == 0.5  # inherited from parent
+
+    def test_multi_level_inheritance(self, tmp_configs) -> None:
+        tmp_configs("grandparent.yaml", {"model": "gpt-3.5", "temperature": 0.1, "stream": True})
+        tmp_configs("parent.yaml", {"extends": "grandparent.yaml", "model": "gpt-4"})
+        child_path = tmp_configs("child.yaml", {"extends": "parent.yaml", "temperature": 0.9})
+        cfg = _resolve_yaml_chain(child_path)
+        assert cfg["model"] == "gpt-4"  # from parent
+        assert cfg["temperature"] == 0.9  # from child
+        assert cfg["stream"] is True  # from grandparent
+
+    def test_circular_inheritance_detected(self, tmp_configs) -> None:
+        tmp_configs("a.yaml", {"extends": "b.yaml", "model": "x"})
+        tmp_configs("b.yaml", {"extends": "a.yaml", "model": "y"})
+        with pytest.raises(ConfigInheritanceError, match="Circular"):
+            _resolve_yaml_chain(str(Path(tmp_configs("a.yaml", {"extends": "b.yaml"}))))
+
+    def test_self_reference_detected(self, tmp_configs) -> None:
+        path = tmp_configs("self.yaml", {"extends": "self.yaml"})
+        with pytest.raises(ConfigInheritanceError, match="Circular"):
+            _resolve_yaml_chain(path)
+
+    def test_missing_parent(self, tmp_configs) -> None:
+        path = tmp_configs("child.yaml", {"extends": "nonexistent.yaml"})
+        with pytest.raises(ConfigInheritanceError, match="not found"):
+            _resolve_yaml_chain(path)
+
+    def test_extends_key_removed(self, tmp_configs) -> None:
+        tmp_configs("base.yaml", {"model": "gpt-4"})
+        child_path = tmp_configs("child.yaml", {"extends": "base.yaml", "num_prompts": 5})
+        cfg = _resolve_yaml_chain(child_path)
+        assert "extends" not in cfg
+
+    def test_empty_parent(self, tmp_configs) -> None:
+        tmp_configs("empty.yaml", {})
+        child_path = tmp_configs("child.yaml", {"extends": "empty.yaml", "model": "gpt-4"})
+        cfg = _resolve_yaml_chain(child_path)
+        assert cfg == {"model": "gpt-4"}
+
+
+class TestLoadAndCheckYamlWithExtends:
+    """Integration tests for _load_and_check_yaml with extends."""
+
+    def test_inheritance_resolved(self, tmp_configs) -> None:
+        tmp_configs("base.yaml", {"model": "gpt-4", "num_prompts": 100})
+        child_path = tmp_configs("child.yaml", {"extends": "base.yaml", "num_prompts": 5})
+        cfg, warnings, errors = _load_and_check_yaml(child_path)
+        assert not errors
+        assert cfg["model"] == "gpt-4"
+        assert cfg["num_prompts"] == 5
+
+    def test_circular_reports_error(self, tmp_configs) -> None:
+        tmp_configs("a.yaml", {"extends": "b.yaml"})
+        tmp_configs("b.yaml", {"extends": "a.yaml"})
+        _, _, errors = _load_and_check_yaml(
+            tmp_configs("a.yaml", {"extends": "b.yaml"})
+        )
+        assert any("Circular" in e for e in errors)
+
+    def test_missing_parent_reports_error(self, tmp_configs) -> None:
+        path = tmp_configs("child.yaml", {"extends": "ghost.yaml"})
+        _, _, errors = _load_and_check_yaml(path)
+        assert any("not found" in e for e in errors)
+
+    def test_unknown_keys_in_parent_warned(self, tmp_configs) -> None:
+        tmp_configs("base.yaml", {"model": "gpt-4", "bogus_key": 123})
+        child_path = tmp_configs("child.yaml", {"extends": "base.yaml"})
+        cfg, warnings, errors = _load_and_check_yaml(child_path)
+        assert not errors
+        assert any("bogus_key" in w for w in warnings)
+
+
+class TestCliLoadYamlConfig:
+    """Test CLI _load_yaml_config with extends support."""
+
+    def test_cli_precedence_over_inheritance(self, tmp_configs) -> None:
+        from xpyd_bench.cli import _load_yaml_config
+
+        tmp_configs("base.yaml", {"model": "gpt-3.5", "num_prompts": 100})
+        child_path = tmp_configs("child.yaml", {"extends": "base.yaml", "num_prompts": 50})
+
+        args = argparse.Namespace(model="cli-model", num_prompts=None, temperature=None)
+        result = _load_yaml_config(child_path, args, explicit_keys={"model"})
+        assert result.model == "cli-model"  # CLI wins
+        assert result.num_prompts == 50  # from child yaml


### PR DESCRIPTION
## Summary
Add `extends: <path>` key to YAML config files for configuration inheritance.

### Changes
- `_resolve_yaml_chain()` in config_cmd.py resolves inheritance chain recursively
- Child values override parent; parent provides defaults
- Circular inheritance detected with clear error
- Relative paths resolved against config file's directory
- CLI `_load_yaml_config()` updated to use inheritance resolution
- `extends` added to known config keys
- 13 tests covering single/multi-level, circular, missing parent, CLI precedence

Closes #218