### PR TITLE
feat(bench): M81 — Rolling Window Metrics (Percentile-over-Time)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -676,3 +676,13 @@
 - `config dump` shows fully resolved config with inheritance applied
 - CLI flags take highest precedence (CLI > child YAML > parent YAML)
 - Tests covering single/multi-level inheritance, circular detection, CLI precedence, and error cases
+
+## M81: Rolling Window Metrics (Percentile-over-Time) ✅
+- `--rolling-metrics` CLI flag to enable rolling window latency percentile tracking
+- `--rolling-window SECONDS` configurable window size (default 10)
+- `--rolling-step SECONDS` configurable step size (default 5)
+- Compute P50/P90/P99 latency per time window across benchmark duration
+- Detect mid-run performance degradation (compare first vs last window P99)
+- `BenchmarkResult` includes `rolling_metrics` dict with windows and degradation info
+- YAML config support (`rolling_metrics`, `rolling_window`, `rolling_step`)
+- Tests covering window computation, degradation detection, custom percentiles, and config keys

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -156,3 +156,6 @@ class BenchmarkResult:
 
     # Git repository metadata (M79)
     git_info: dict[str, str] | None = None
+
+    # Rolling window metrics (M81)
+    rolling_metrics: dict | None = None

--- a/src/xpyd_bench/bench/rolling_metrics.py
+++ b/src/xpyd_bench/bench/rolling_metrics.py
@@ -1,0 +1,117 @@
+"""Rolling window metrics — percentile-over-time tracking (M81).
+
+Computes latency percentiles (P50/P90/P99) in sliding time windows to detect
+mid-run performance degradation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def compute_rolling_metrics(
+    latencies_ms: list[float],
+    start_times: list[float],
+    bench_start_time: float,
+    window_seconds: float = 10.0,
+    step_seconds: float = 5.0,
+    percentiles: tuple[float, ...] = (50.0, 90.0, 99.0),
+) -> dict[str, Any]:
+    """Compute rolling window percentile metrics over benchmark duration.
+
+    Parameters
+    ----------
+    latencies_ms:
+        Per-request end-to-end latencies in milliseconds.
+    start_times:
+        Per-request start timestamps (``perf_counter``).
+    bench_start_time:
+        Benchmark start timestamp (``perf_counter``).
+    window_seconds:
+        Sliding window size in seconds.
+    step_seconds:
+        Step size between windows in seconds.
+    percentiles:
+        Which percentiles to compute (0-100 scale).
+
+    Returns
+    -------
+    dict with ``windows`` (list of window dicts) and ``config`` (window params).
+    Each window dict has ``time_offset_s``, ``count``, and ``pN_latency_ms`` keys.
+    Empty dict when fewer than 2 data points.
+    """
+    if len(latencies_ms) < 2 or len(start_times) < 2:
+        return {}
+
+    # Pair data and compute relative times
+    pairs = [
+        (st - bench_start_time, lat)
+        for st, lat in zip(start_times, latencies_ms)
+        if st is not None
+    ]
+    if len(pairs) < 2:
+        return {}
+
+    pairs.sort(key=lambda p: p[0])
+    total_duration = pairs[-1][0]
+
+    windows: list[dict[str, Any]] = []
+    t = 0.0
+    while t <= total_duration:
+        window_end = t + window_seconds
+        window_lats = [lat for rel_t, lat in pairs if t <= rel_t < window_end]
+
+        if window_lats:
+            entry: dict[str, Any] = {
+                "time_offset_s": round(t, 2),
+                "count": len(window_lats),
+            }
+            for p in percentiles:
+                key = f"p{int(p)}_latency_ms" if p == int(p) else f"p{p}_latency_ms"
+                entry[key] = round(_percentile(window_lats, p), 2)
+            windows.append(entry)
+
+        t += step_seconds
+
+    if not windows:
+        return {}
+
+    # Detect degradation: compare first and last window P99
+    p99_key = "p99_latency_ms"
+    degradation: dict[str, Any] | None = None
+    if len(windows) >= 2 and p99_key in windows[0] and p99_key in windows[-1]:
+        first_p99 = windows[0][p99_key]
+        last_p99 = windows[-1][p99_key]
+        if first_p99 > 0:
+            change_pct = round(((last_p99 - first_p99) / first_p99) * 100, 1)
+            degradation = {
+                "first_window_p99_ms": first_p99,
+                "last_window_p99_ms": last_p99,
+                "change_pct": change_pct,
+                "degraded": change_pct > 10.0,
+            }
+
+    return {
+        "config": {
+            "window_seconds": window_seconds,
+            "step_seconds": step_seconds,
+            "percentiles": list(percentiles),
+        },
+        "windows": windows,
+        "degradation": degradation,
+    }
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Compute a percentile value from a sorted-capable list."""
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    sorted_v = sorted(values)
+    k = (pct / 100.0) * (len(sorted_v) - 1)
+    f = int(k)
+    c = f + 1
+    if c >= len(sorted_v):
+        return sorted_v[-1]
+    return sorted_v[f] + (k - f) * (sorted_v[c] - sorted_v[f])

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -1267,6 +1267,24 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         if ws:
             result.workload_stats = ws
 
+    # Rolling window metrics (M81)
+    rolling_enabled = bool(getattr(args, "rolling_metrics", False))
+    if rolling_enabled and result.requests:
+        from xpyd_bench.bench.rolling_metrics import compute_rolling_metrics
+
+        lats = [r.latency_ms for r in result.requests if r.success]
+        sts = [r.start_time for r in result.requests if r.success and r.start_time is not None]
+        if len(lats) == len(sts) and len(lats) >= 2:
+            rm = compute_rolling_metrics(
+                lats,
+                sts,
+                result.bench_start_time,
+                window_seconds=getattr(args, "rolling_window", 10.0),
+                step_seconds=getattr(args, "rolling_step", 5.0),
+            )
+            if rm:
+                result.rolling_metrics = rm
+
     # Response validation (M47)
     validators_specs = getattr(args, "validate_response", None) or []
     if validators_specs:

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -528,6 +528,29 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Compute and report prompt/output token length distributions.",
     )
 
+    # Rolling window metrics (M81)
+    parser.add_argument(
+        "--rolling-metrics",
+        action="store_true",
+        default=False,
+        dest="rolling_metrics",
+        help="Compute rolling-window latency percentiles over benchmark duration.",
+    )
+    parser.add_argument(
+        "--rolling-window",
+        type=float,
+        default=10.0,
+        dest="rolling_window",
+        help="Rolling window size in seconds (default: 10).",
+    )
+    parser.add_argument(
+        "--rolling-step",
+        type=float,
+        default=5.0,
+        dest="rolling_step",
+        help="Rolling window step size in seconds (default: 5).",
+    )
+
     # Response validation (M47)
     parser.add_argument(
         "--validate-response",

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -126,6 +126,9 @@ _KNOWN_KEYS: set[str] = {
     "synthetic_image_size",
     "image_detail",
     "workload_stats",
+    "rolling_metrics",
+    "rolling_window",
+    "rolling_step",
     "extends",
 }
 

--- a/tests/test_rolling_metrics.py
+++ b/tests/test_rolling_metrics.py
@@ -1,0 +1,135 @@
+"""Tests for rolling window metrics (M81)."""
+
+from __future__ import annotations
+
+from xpyd_bench.bench.rolling_metrics import compute_rolling_metrics
+
+
+class TestComputeRollingMetrics:
+    """Tests for compute_rolling_metrics."""
+
+    def test_empty_data(self) -> None:
+        assert compute_rolling_metrics([], [], 0.0) == {}
+
+    def test_single_data_point(self) -> None:
+        assert compute_rolling_metrics([100.0], [1.0], 0.0) == {}
+
+    def test_basic_windows(self) -> None:
+        # 10 requests spread over 20 seconds
+        bench_start = 0.0
+        start_times = [float(i * 2) for i in range(10)]  # 0, 2, 4, ..., 18
+        latencies = [100.0 + i * 10 for i in range(10)]  # 100, 110, ..., 190
+
+        result = compute_rolling_metrics(
+            latencies, start_times, bench_start,
+            window_seconds=10.0, step_seconds=5.0,
+        )
+
+        assert "windows" in result
+        assert "config" in result
+        assert len(result["windows"]) > 0
+
+        # Check first window
+        first = result["windows"][0]
+        assert first["time_offset_s"] == 0.0
+        assert first["count"] > 0
+        assert "p50_latency_ms" in first
+        assert "p90_latency_ms" in first
+        assert "p99_latency_ms" in first
+
+    def test_degradation_detection(self) -> None:
+        # Simulate degradation: low latency first, high latency later
+        bench_start = 0.0
+        start_times = list(range(20))
+        latencies = [50.0] * 10 + [200.0] * 10
+
+        result = compute_rolling_metrics(
+            latencies, start_times, bench_start,
+            window_seconds=10.0, step_seconds=10.0,
+        )
+
+        assert result.get("degradation") is not None
+        assert result["degradation"]["degraded"] is True
+        assert result["degradation"]["change_pct"] > 10.0
+
+    def test_no_degradation(self) -> None:
+        # Stable latency
+        bench_start = 0.0
+        start_times = list(range(20))
+        latencies = [100.0] * 20
+
+        result = compute_rolling_metrics(
+            latencies, start_times, bench_start,
+            window_seconds=10.0, step_seconds=10.0,
+        )
+
+        assert result.get("degradation") is not None
+        assert result["degradation"]["degraded"] is False
+        assert result["degradation"]["change_pct"] == 0.0
+
+    def test_custom_percentiles(self) -> None:
+        bench_start = 0.0
+        start_times = [float(i) for i in range(10)]
+        latencies = [float(i * 10) for i in range(10)]
+
+        result = compute_rolling_metrics(
+            latencies, start_times, bench_start,
+            window_seconds=20.0, step_seconds=20.0,
+            percentiles=(50.0, 75.0, 95.0),
+        )
+
+        assert len(result["windows"]) >= 1
+        w = result["windows"][0]
+        assert "p50_latency_ms" in w
+        assert "p75_latency_ms" in w
+        assert "p95_latency_ms" in w
+
+    def test_config_in_result(self) -> None:
+        result = compute_rolling_metrics(
+            [100.0, 200.0], [0.0, 1.0], 0.0,
+            window_seconds=5.0, step_seconds=2.0,
+        )
+        cfg = result["config"]
+        assert cfg["window_seconds"] == 5.0
+        assert cfg["step_seconds"] == 2.0
+        assert cfg["percentiles"] == [50.0, 90.0, 99.0]
+
+    def test_none_start_times_filtered(self) -> None:
+        # None start times should be filtered out
+        result = compute_rolling_metrics(
+            [100.0, 200.0, 300.0],
+            [0.0, None, 2.0],  # type: ignore[list-item]
+            0.0,
+            window_seconds=10.0,
+            step_seconds=10.0,
+        )
+        # Should still produce results from the 2 valid points
+        assert result != {}
+        assert result["windows"][0]["count"] == 2
+
+
+class TestBenchmarkResultField:
+    """Test that rolling_metrics field exists on BenchmarkResult."""
+
+    def test_field_default(self) -> None:
+        from xpyd_bench.bench.models import BenchmarkResult
+
+        r = BenchmarkResult()
+        assert r.rolling_metrics is None
+
+    def test_field_set(self) -> None:
+        from xpyd_bench.bench.models import BenchmarkResult
+
+        r = BenchmarkResult(rolling_metrics={"windows": []})
+        assert r.rolling_metrics == {"windows": []}
+
+
+class TestConfigKey:
+    """Test that rolling_metrics config keys are recognized."""
+
+    def test_known_keys(self) -> None:
+        from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+        assert "rolling_metrics" in _KNOWN_KEYS
+        assert "rolling_window" in _KNOWN_KEYS
+        assert "rolling_step" in _KNOWN_KEYS


### PR DESCRIPTION
## Summary
Add rolling window latency percentile tracking to detect mid-run performance degradation.

## Changes
- New module `src/xpyd_bench/bench/rolling_metrics.py` with `compute_rolling_metrics()`
- CLI flags: `--rolling-metrics`, `--rolling-window`, `--rolling-step`
- `BenchmarkResult.rolling_metrics` field for JSON output
- Degradation detection: compares first vs last window P99 (>10% = degraded)
- YAML config keys: `rolling_metrics`, `rolling_window`, `rolling_step`
- 11 tests covering all functionality

## Design
Sliding window approach: for each time step, collect all request latencies within the window and compute percentiles. Outputs a time series of percentile values plus a degradation summary.

Closes #220