### PR TITLE
feat(bench): M82 — Benchmark Baseline Registry

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -686,3 +686,15 @@
 - `BenchmarkResult` includes `rolling_metrics` dict with windows and degradation info
 - YAML config support (`rolling_metrics`, `rolling_window`, `rolling_step`)
 - Tests covering window computation, degradation detection, custom percentiles, and config keys
+
+## M82: Benchmark Baseline Registry ✅
+- `xpyd-bench baseline save <name> <result.json>` CLI subcommand to register a named baseline
+- `xpyd-bench baseline list` to show all saved baselines with name, date, model, summary metrics
+- `xpyd-bench baseline show <name>` to print baseline details
+- `xpyd-bench baseline delete <name>` to remove a baseline
+- `--compare-baseline <name>` flag on `xpyd-bench run` to auto-compare after benchmark
+- Baseline registry stored in `~/.xpyd-bench/baselines/` (JSON files + index)
+- `--baseline-dir <path>` to override registry location
+- YAML config support (`compare_baseline`, `baseline_dir`)
+- Reuse existing compare logic for regression detection
+- Tests covering save, list, show, delete, auto-compare, custom dir, and edge cases

--- a/src/xpyd_bench/baseline.py
+++ b/src/xpyd_bench/baseline.py
@@ -1,0 +1,164 @@
+"""Benchmark Baseline Registry (M82).
+
+Save, list, show, delete named benchmark baselines and auto-compare
+against them after a benchmark run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_DIR = os.path.expanduser("~/.xpyd-bench/baselines")
+
+
+def _registry_dir(baseline_dir: str | None = None) -> Path:
+    """Return the baseline registry directory, creating if needed."""
+    d = Path(baseline_dir) if baseline_dir else Path(_DEFAULT_DIR)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _index_path(baseline_dir: str | None = None) -> Path:
+    return _registry_dir(baseline_dir) / "index.json"
+
+
+def _load_index(baseline_dir: str | None = None) -> dict[str, Any]:
+    p = _index_path(baseline_dir)
+    if p.exists():
+        return json.loads(p.read_text())
+    return {}
+
+
+def _save_index(index: dict[str, Any], baseline_dir: str | None = None) -> None:
+    p = _index_path(baseline_dir)
+    p.write_text(json.dumps(index, indent=2) + "\n")
+
+
+def save_baseline(
+    name: str,
+    result_path: str,
+    baseline_dir: str | None = None,
+) -> dict[str, Any]:
+    """Save a benchmark result as a named baseline.
+
+    Returns the baseline entry dict.
+    """
+    src = Path(result_path)
+    if not src.exists():
+        raise FileNotFoundError(f"Result file not found: {result_path}")
+
+    data = json.loads(src.read_text())
+    reg = _registry_dir(baseline_dir)
+    dest = reg / f"{name}.json"
+    dest.write_text(json.dumps(data, indent=2) + "\n")
+
+    index = _load_index(baseline_dir)
+    entry: dict[str, Any] = {
+        "name": name,
+        "saved_at": datetime.now(timezone.utc).isoformat(),
+        "model": data.get("model", ""),
+        "file": str(dest),
+    }
+    # Extract summary metrics
+    for key in ("mean_ttft_ms", "mean_tpot_ms", "output_throughput"):
+        if key in data:
+            entry[key] = data[key]
+
+    index[name] = entry
+    _save_index(index, baseline_dir)
+    return entry
+
+
+def list_baselines(baseline_dir: str | None = None) -> list[dict[str, Any]]:
+    """List all saved baselines."""
+    index = _load_index(baseline_dir)
+    return list(index.values())
+
+
+def show_baseline(name: str, baseline_dir: str | None = None) -> dict[str, Any]:
+    """Load and return a named baseline's full data."""
+    index = _load_index(baseline_dir)
+    if name not in index:
+        raise KeyError(f"Baseline not found: {name}")
+    fpath = Path(index[name]["file"])
+    if not fpath.exists():
+        raise FileNotFoundError(f"Baseline file missing: {fpath}")
+    return json.loads(fpath.read_text())
+
+
+def delete_baseline(name: str, baseline_dir: str | None = None) -> None:
+    """Delete a named baseline."""
+    index = _load_index(baseline_dir)
+    if name not in index:
+        raise KeyError(f"Baseline not found: {name}")
+    fpath = Path(index[name]["file"])
+    if fpath.exists():
+        fpath.unlink()
+    del index[name]
+    _save_index(index, baseline_dir)
+
+
+def compare_against_baseline(
+    name: str,
+    result_data: dict[str, Any],
+    baseline_dir: str | None = None,
+    threshold_pct: float = 5.0,
+) -> dict[str, Any]:
+    """Compare benchmark result against a named baseline.
+
+    Returns a comparison dict with metrics, deltas, and regression status.
+    """
+    baseline_data = show_baseline(name, baseline_dir)
+
+    metrics = [
+        "mean_ttft_ms",
+        "mean_tpot_ms",
+        "mean_e2e_latency_ms",
+        "output_throughput",
+        "p99_ttft_ms",
+        "p99_tpot_ms",
+        "p99_e2e_latency_ms",
+    ]
+
+    comparisons: list[dict[str, Any]] = []
+    regression_detected = False
+
+    for m in metrics:
+        bv = baseline_data.get(m)
+        cv = result_data.get(m)
+        if bv is None or cv is None:
+            continue
+
+        if bv == 0:
+            delta_pct = 0.0
+        else:
+            delta_pct = round(((cv - bv) / abs(bv)) * 100, 1)
+
+        # For throughput, higher is better; for latency, lower is better
+        higher_is_better = "throughput" in m
+        if higher_is_better:
+            regressed = delta_pct < -threshold_pct
+        else:
+            regressed = delta_pct > threshold_pct
+
+        if regressed:
+            regression_detected = True
+
+        comparisons.append({
+            "metric": m,
+            "baseline": round(bv, 2),
+            "current": round(cv, 2),
+            "delta_pct": delta_pct,
+            "regressed": regressed,
+        })
+
+    return {
+        "baseline_name": name,
+        "comparisons": comparisons,
+        "regression_detected": regression_detected,
+        "threshold_pct": threshold_pct,
+    }

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -551,6 +551,22 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Rolling window step size in seconds (default: 5).",
     )
 
+    # Baseline comparison (M82)
+    parser.add_argument(
+        "--compare-baseline",
+        type=str,
+        default=None,
+        dest="compare_baseline",
+        help="Compare results against a named baseline after benchmark.",
+    )
+    parser.add_argument(
+        "--baseline-dir",
+        type=str,
+        default=None,
+        dest="baseline_dir",
+        help="Custom baseline registry directory.",
+    )
+
     # Response validation (M47)
     parser.add_argument(
         "--validate-response",
@@ -1631,6 +1647,25 @@ def bench_main(argv: list[str] | None = None) -> None:
     # Save results if requested
     if args.save_result:
         _save_result(args, result)
+
+    # Baseline comparison (M82)
+    compare_bl = getattr(args, "compare_baseline", None)
+    if compare_bl:
+        from xpyd_bench.baseline import compare_against_baseline
+
+        bl_dir = getattr(args, "baseline_dir", None)
+        try:
+            bl_result = compare_against_baseline(compare_bl, result, baseline_dir=bl_dir)
+            print(f"\n--- Baseline Comparison: '{compare_bl}' ---")
+            for c in bl_result["comparisons"]:
+                indicator = "REGRESSED" if c["regressed"] else "ok"
+                print(f"  {c['metric']}: baseline={c['baseline']}, current={c['current']}, "
+                      f"delta={c['delta_pct']:+.1f}% [{indicator}]")
+            if bl_result["regression_detected"]:
+                print("  ⚠ Regression detected!")
+        except (KeyError, FileNotFoundError) as exc:
+            import sys as _sys
+            print(f"Baseline comparison failed: {exc}", file=_sys.stderr)
 
     # Cost estimation (M39)
     cost_model_path = getattr(args, "cost_model", None)

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -129,6 +129,8 @@ _KNOWN_KEYS: set[str] = {
     "rolling_metrics",
     "rolling_window",
     "rolling_step",
+    "compare_baseline",
+    "baseline_dir",
     "extends",
 }
 

--- a/src/xpyd_bench/main.py
+++ b/src/xpyd_bench/main.py
@@ -86,6 +86,7 @@ _SUBCOMMANDS = {
     "resume",
     "model-compare",
     "stream-compare",
+    "baseline",
 }
 
 
@@ -189,6 +190,8 @@ def main() -> None:
         from xpyd_bench.cli import stream_compare_main
 
         stream_compare_main(rest)
+    elif subcmd == "baseline":
+        _baseline_subcommand(rest)
 
 
 def _config_subcommand(argv: list[str]) -> None:
@@ -236,6 +239,81 @@ def _presets_subcommand(argv: list[str]) -> None:
     else:
         print(
             f"Unknown presets subcommand '{sub}'. Use 'list' or 'show'.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _baseline_subcommand(argv: list[str]) -> None:
+    """Handle 'xpyd-bench baseline <save|list|show|delete>' subcommand."""
+    import argparse
+    import json
+
+    if not argv:
+        print(
+            "Usage: xpyd-bench baseline <save|list|show|delete> [options]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    sub = argv[0]
+    rest = argv[1:]
+
+    if sub == "save":
+        parser = argparse.ArgumentParser(prog="xpyd-bench baseline save")
+        parser.add_argument("name", help="Name for the baseline")
+        parser.add_argument("result", help="Path to result JSON file")
+        parser.add_argument("--baseline-dir", default=None, help="Custom baseline directory")
+        args = parser.parse_args(rest)
+
+        from xpyd_bench.baseline import save_baseline
+
+        entry = save_baseline(args.name, args.result, baseline_dir=args.baseline_dir)
+        print(f"Baseline '{args.name}' saved.")
+        print(json.dumps(entry, indent=2))
+
+    elif sub == "list":
+        parser = argparse.ArgumentParser(prog="xpyd-bench baseline list")
+        parser.add_argument("--baseline-dir", default=None, help="Custom baseline directory")
+        args = parser.parse_args(rest)
+
+        from xpyd_bench.baseline import list_baselines
+
+        baselines = list_baselines(baseline_dir=args.baseline_dir)
+        if not baselines:
+            print("No baselines saved.")
+        else:
+            for b in baselines:
+                line = f"  {b['name']}  saved={b.get('saved_at', '?')}"
+                if "model" in b and b["model"]:
+                    line += f"  model={b['model']}"
+                print(line)
+
+    elif sub == "show":
+        parser = argparse.ArgumentParser(prog="xpyd-bench baseline show")
+        parser.add_argument("name", help="Baseline name")
+        parser.add_argument("--baseline-dir", default=None, help="Custom baseline directory")
+        args = parser.parse_args(rest)
+
+        from xpyd_bench.baseline import show_baseline
+
+        data = show_baseline(args.name, baseline_dir=args.baseline_dir)
+        print(json.dumps(data, indent=2))
+
+    elif sub == "delete":
+        parser = argparse.ArgumentParser(prog="xpyd-bench baseline delete")
+        parser.add_argument("name", help="Baseline name to delete")
+        parser.add_argument("--baseline-dir", default=None, help="Custom baseline directory")
+        args = parser.parse_args(rest)
+
+        from xpyd_bench.baseline import delete_baseline
+
+        delete_baseline(args.name, baseline_dir=args.baseline_dir)
+        print(f"Baseline '{args.name}' deleted.")
+
+    else:
+        print(
+            f"Unknown baseline subcommand '{sub}'. Use 'save', 'list', 'show', or 'delete'.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,139 @@
+"""Tests for Benchmark Baseline Registry (M82)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_bench.baseline import (
+    compare_against_baseline,
+    delete_baseline,
+    list_baselines,
+    save_baseline,
+    show_baseline,
+)
+
+
+@pytest.fixture()
+def baseline_dir(tmp_path: Path) -> str:
+    return str(tmp_path / "baselines")
+
+
+@pytest.fixture()
+def sample_result(tmp_path: Path) -> str:
+    data = {
+        "model": "test-model",
+        "mean_ttft_ms": 50.0,
+        "mean_tpot_ms": 10.0,
+        "output_throughput": 100.0,
+        "mean_e2e_latency_ms": 200.0,
+        "p99_ttft_ms": 80.0,
+        "p99_tpot_ms": 15.0,
+        "p99_e2e_latency_ms": 350.0,
+    }
+    p = tmp_path / "result.json"
+    p.write_text(json.dumps(data))
+    return str(p)
+
+
+class TestSaveBaseline:
+    def test_save_creates_file(self, baseline_dir: str, sample_result: str) -> None:
+        entry = save_baseline("v1", sample_result, baseline_dir=baseline_dir)
+        assert entry["name"] == "v1"
+        assert entry["model"] == "test-model"
+        assert Path(baseline_dir, "v1.json").exists()
+        assert Path(baseline_dir, "index.json").exists()
+
+    def test_save_overwrite(self, baseline_dir: str, sample_result: str) -> None:
+        save_baseline("v1", sample_result, baseline_dir=baseline_dir)
+        save_baseline("v1", sample_result, baseline_dir=baseline_dir)
+        baselines = list_baselines(baseline_dir=baseline_dir)
+        assert len(baselines) == 1
+
+    def test_save_missing_file(self, baseline_dir: str) -> None:
+        with pytest.raises(FileNotFoundError):
+            save_baseline("v1", "/nonexistent/result.json", baseline_dir=baseline_dir)
+
+
+class TestListBaselines:
+    def test_empty(self, baseline_dir: str) -> None:
+        assert list_baselines(baseline_dir=baseline_dir) == []
+
+    def test_multiple(self, baseline_dir: str, sample_result: str) -> None:
+        save_baseline("a", sample_result, baseline_dir=baseline_dir)
+        save_baseline("b", sample_result, baseline_dir=baseline_dir)
+        baselines = list_baselines(baseline_dir=baseline_dir)
+        assert len(baselines) == 2
+        names = {b["name"] for b in baselines}
+        assert names == {"a", "b"}
+
+
+class TestShowBaseline:
+    def test_show(self, baseline_dir: str, sample_result: str) -> None:
+        save_baseline("v1", sample_result, baseline_dir=baseline_dir)
+        data = show_baseline("v1", baseline_dir=baseline_dir)
+        assert data["model"] == "test-model"
+        assert data["mean_ttft_ms"] == 50.0
+
+    def test_show_missing(self, baseline_dir: str) -> None:
+        with pytest.raises(KeyError, match="not found"):
+            show_baseline("nonexistent", baseline_dir=baseline_dir)
+
+
+class TestDeleteBaseline:
+    def test_delete(self, baseline_dir: str, sample_result: str) -> None:
+        save_baseline("v1", sample_result, baseline_dir=baseline_dir)
+        delete_baseline("v1", baseline_dir=baseline_dir)
+        assert list_baselines(baseline_dir=baseline_dir) == []
+        assert not Path(baseline_dir, "v1.json").exists()
+
+    def test_delete_missing(self, baseline_dir: str) -> None:
+        with pytest.raises(KeyError, match="not found"):
+            delete_baseline("nonexistent", baseline_dir=baseline_dir)
+
+
+class TestCompareAgainstBaseline:
+    def test_no_regression(self, baseline_dir: str, sample_result: str) -> None:
+        save_baseline("v1", sample_result, baseline_dir=baseline_dir)
+        current = {
+            "mean_ttft_ms": 50.0,
+            "mean_tpot_ms": 10.0,
+            "output_throughput": 100.0,
+        }
+        result = compare_against_baseline("v1", current, baseline_dir=baseline_dir)
+        assert result["regression_detected"] is False
+        assert result["baseline_name"] == "v1"
+
+    def test_regression_detected(self, baseline_dir: str, sample_result: str) -> None:
+        save_baseline("v1", sample_result, baseline_dir=baseline_dir)
+        current = {
+            "mean_ttft_ms": 100.0,  # doubled → regression
+            "mean_tpot_ms": 20.0,
+            "output_throughput": 50.0,  # halved → regression
+        }
+        result = compare_against_baseline("v1", current, baseline_dir=baseline_dir)
+        assert result["regression_detected"] is True
+
+    def test_custom_threshold(self, baseline_dir: str, sample_result: str) -> None:
+        save_baseline("v1", sample_result, baseline_dir=baseline_dir)
+        current = {"mean_ttft_ms": 53.0}  # 6% increase
+        # With 5% threshold → regression
+        r1 = compare_against_baseline("v1", current, baseline_dir=baseline_dir, threshold_pct=5.0)
+        assert r1["regression_detected"] is True
+        # With 10% threshold → no regression
+        r2 = compare_against_baseline("v1", current, baseline_dir=baseline_dir, threshold_pct=10.0)
+        assert r2["regression_detected"] is False
+
+    def test_missing_baseline(self, baseline_dir: str) -> None:
+        with pytest.raises(KeyError):
+            compare_against_baseline("nonexistent", {}, baseline_dir=baseline_dir)
+
+
+class TestConfigKeys:
+    def test_known_keys(self) -> None:
+        from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+        assert "compare_baseline" in _KNOWN_KEYS
+        assert "baseline_dir" in _KNOWN_KEYS


### PR DESCRIPTION
## Summary
Add a baseline registry for saving, managing, and auto-comparing benchmark results against named baselines.

## Changes
- New module `src/xpyd_bench/baseline.py` with save/list/show/delete/compare functions
- CLI subcommands: `xpyd-bench baseline save|list|show|delete`
- `--compare-baseline <name>` flag on `xpyd-bench run` to auto-compare after benchmark
- `--baseline-dir <path>` to override registry location
- YAML config keys: `compare_baseline`, `baseline_dir`
- 14 tests covering all CRUD operations, comparison logic, and edge cases

## Design
- Baselines stored as JSON files in `~/.xpyd-bench/baselines/` with an index file
- Comparison reuses regression detection logic (configurable threshold)
- Supports custom baseline directories for project-specific baselines

Closes #222