### PR TITLE
feat(M83): benchmark abort on error threshold

### DIFF
--- a/tests/test_error_threshold.py
+++ b/tests/test_error_threshold.py
@@ -52,11 +52,13 @@ def test_error_abort_sets_partial_and_reason():
 
 def test_aborted_reason_in_serialization():
     """aborted_reason should appear in dict serialization."""
+    from dataclasses import asdict
+
     from xpyd_bench.bench.models import BenchmarkResult
 
     result = BenchmarkResult()
     result.aborted_reason = "Error rate too high"
-    d = result.to_dict()
+    d = asdict(result)
     assert d["aborted_reason"] == "Error rate too high"
 
 
@@ -70,7 +72,7 @@ def test_aborted_reason_none_by_default():
 
 def test_known_config_keys_include_error_rate():
     """max_error_rate and max_error_rate_window are in known config keys."""
-    from xpyd_bench.config_cmd import KNOWN_CONFIG_KEYS
+    from xpyd_bench.config_cmd import _KNOWN_KEYS
 
-    assert "max_error_rate" in KNOWN_CONFIG_KEYS
-    assert "max_error_rate_window" in KNOWN_CONFIG_KEYS
+    assert "max_error_rate" in _KNOWN_KEYS
+    assert "max_error_rate_window" in _KNOWN_KEYS


### PR DESCRIPTION
## Summary
Add `--max-error-rate` CLI flag to abort benchmarks early when error rate exceeds a configurable threshold. Prevents wasting time on failing benchmarks.

## Changes
- `--max-error-rate <float>` (0.0-1.0): abort threshold
- `--max-error-rate-window <N>` (default 10): minimum requests before checking
- `BenchmarkResult.aborted_reason` field with descriptive message
- YAML config support (`max_error_rate`, `max_error_rate_window`)
- In-flight requests get grace period on abort
- 8 tests covering all scenarios

Closes #224