### PR TITLE
feat(M86): Adaptive Timeout (Auto-Tuning)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -727,7 +727,7 @@
 - YAML config support (`deduplicate: true`)
 - Tests covering dedup detection, hash computation, and summary reporting
 
-## M86: Adaptive Timeout (Auto-Tuning) ✗
+## M86: Adaptive Timeout (Auto-Tuning) ✅
 - `--adaptive-timeout` CLI flag to auto-tune per-request timeout based on observed latencies
 - Initial timeout from `--timeout` value, then adjust based on rolling P99 + multiplier
 - `--adaptive-timeout-multiplier <float>` (default 3.0) controls safety margin

--- a/src/xpyd_bench/bench/adaptive_timeout.py
+++ b/src/xpyd_bench/bench/adaptive_timeout.py
@@ -1,0 +1,77 @@
+"""Adaptive timeout auto-tuning based on observed latencies (M86)."""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+
+import numpy as np
+
+DEFAULT_MULTIPLIER: float = 3.0
+ROLLING_WINDOW_SIZE: int = 100
+MIN_SAMPLES_FOR_ADAPTATION: int = 5
+
+
+class AdaptiveTimeout:
+    """Track request latencies and compute adaptive per-request timeouts.
+
+    The effective timeout is ``rolling_p99 * multiplier``, clamped to
+    ``[min_timeout, initial_timeout]``.  Until enough samples are collected
+    the initial (static) timeout is returned.
+
+    Parameters
+    ----------
+    initial_timeout:
+        The starting timeout in seconds (from ``--timeout``).
+    multiplier:
+        Safety margin multiplier applied to rolling P99.
+    window_size:
+        Maximum number of recent latencies to consider.
+    """
+
+    def __init__(
+        self,
+        initial_timeout: float = 300.0,
+        multiplier: float = DEFAULT_MULTIPLIER,
+        window_size: int = ROLLING_WINDOW_SIZE,
+    ) -> None:
+        if initial_timeout <= 0:
+            raise ValueError(f"initial_timeout must be positive, got {initial_timeout}")
+        if multiplier <= 0:
+            raise ValueError(f"multiplier must be positive, got {multiplier}")
+        self._initial = initial_timeout
+        self._multiplier = multiplier
+        self._window_size = window_size
+        self._latencies: deque[float] = deque(maxlen=window_size)
+        self._lock = threading.Lock()
+        # Minimum timeout to avoid overly aggressive shrinking
+        self._min_timeout = 1.0
+
+    @property
+    def initial_timeout(self) -> float:
+        return self._initial
+
+    @property
+    def multiplier(self) -> float:
+        return self._multiplier
+
+    def record(self, latency_s: float) -> None:
+        """Record a completed request latency (seconds)."""
+        with self._lock:
+            self._latencies.append(latency_s)
+
+    def get_timeout(self) -> float:
+        """Return the current adaptive timeout in seconds."""
+        with self._lock:
+            if len(self._latencies) < MIN_SAMPLES_FOR_ADAPTATION:
+                return self._initial
+            arr = np.array(self._latencies, dtype=np.float64)
+        p99 = float(np.percentile(arr, 99))
+        adaptive = p99 * self._multiplier
+        # Clamp between min and initial
+        return max(self._min_timeout, min(adaptive, self._initial))
+
+    def sample_count(self) -> int:
+        """Number of latency samples recorded so far."""
+        with self._lock:
+            return len(self._latencies)

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -33,6 +33,7 @@ class RequestResult:
     response_bytes: int | None = None  # Response payload size in bytes (M67)
     generation_tps: float | None = None  # Output tokens/s for this request (M68)
     timeout_detected: bool = False  # Whether request timed out (M70)
+    effective_timeout: float | None = None  # Actual timeout used (M86)
     queue_time_ms: float | None = None  # Client-side queuing time in ms (M71)
     response_hash: str | None = None  # SHA-256 hash of response text (M85)
 

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -790,23 +790,46 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     measure_generation_speed = bool(getattr(args, "measure_generation_speed", False))
     workload_stats_enabled = bool(getattr(args, "workload_stats", False))
 
+    # Adaptive timeout (M86)
+    adaptive_timeout_enabled = bool(getattr(args, "adaptive_timeout", False))
+    adaptive_timeout_obj = None
+    if adaptive_timeout_enabled:
+        from xpyd_bench.bench.adaptive_timeout import AdaptiveTimeout
+
+        at_multiplier = float(
+            getattr(args, "adaptive_timeout_multiplier", 3.0) or 3.0
+        )
+        adaptive_timeout_obj = AdaptiveTimeout(
+            initial_timeout=request_timeout,
+            multiplier=at_multiplier,
+        )
+
     async def _do_send(
         client: httpx.AsyncClient, payload: dict[str, Any]
     ) -> RequestResult:
         rid = _make_request_id()
+        # Determine effective timeout
+        eff_timeout = request_timeout
+        if adaptive_timeout_obj is not None:
+            eff_timeout = adaptive_timeout_obj.get_timeout()
+
         if use_plugin:
             r = await plugin.send_request(
                 client, url, payload,
                 is_streaming=is_streaming,
-                request_timeout=request_timeout,
+                request_timeout=eff_timeout,
                 retries=req_retries,
                 retry_delay=req_retry_delay,
             )
             r.request_id = rid
+            r.effective_timeout = eff_timeout
+            # Record latency for adaptation
+            if adaptive_timeout_obj is not None and r.success:
+                adaptive_timeout_obj.record(r.latency_ms / 1000.0)
             return r
-        return await _send_request(
+        r = await _send_request(
             client, url, payload, is_streaming,
-            request_timeout=request_timeout,
+            request_timeout=eff_timeout,
             retries=req_retries,
             retry_delay=req_retry_delay,
             compress=req_compress,
@@ -815,6 +838,11 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
             track_ratelimits=track_ratelimits_enabled,
             track_payload_size=track_payload_size_enabled,
         )
+        r.effective_timeout = eff_timeout
+        # Record latency for adaptation
+        if adaptive_timeout_obj is not None and r.success:
+            adaptive_timeout_obj.record(r.latency_ms / 1000.0)
+        return r
 
     # Noise injection (M60)
     from xpyd_bench.noise import NoiseInjector, build_noise_config_from_args

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -623,6 +623,22 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Detect and report duplicate responses from the server.",
     )
 
+    # Adaptive timeout (M86)
+    parser.add_argument(
+        "--adaptive-timeout",
+        action="store_true",
+        default=False,
+        dest="adaptive_timeout",
+        help="Auto-tune per-request timeout based on observed latencies.",
+    )
+    parser.add_argument(
+        "--adaptive-timeout-multiplier",
+        type=float,
+        default=3.0,
+        dest="adaptive_timeout_multiplier",
+        help="Safety margin multiplier for adaptive timeout (default: 3.0).",
+    )
+
     # Custom headers
     parser.add_argument(
         "--header",

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -137,6 +137,8 @@ _KNOWN_KEYS: set[str] = {
     "confidence_intervals",
     "confidence_level",
     "deduplicate",
+    "adaptive_timeout",
+    "adaptive_timeout_multiplier",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/tests/test_adaptive_timeout.py
+++ b/tests/test_adaptive_timeout.py
@@ -1,0 +1,146 @@
+"""Tests for M86: Adaptive Timeout (Auto-Tuning)."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_bench.bench.adaptive_timeout import (
+    MIN_SAMPLES_FOR_ADAPTATION,
+    AdaptiveTimeout,
+)
+from xpyd_bench.bench.models import RequestResult
+
+
+class TestAdaptiveTimeout:
+    """Unit tests for AdaptiveTimeout class."""
+
+    def test_initial_timeout_returned_before_enough_samples(self):
+        at = AdaptiveTimeout(initial_timeout=60.0, multiplier=3.0)
+        assert at.get_timeout() == 60.0
+        # Record fewer than MIN_SAMPLES_FOR_ADAPTATION
+        for i in range(MIN_SAMPLES_FOR_ADAPTATION - 1):
+            at.record(1.0)
+        assert at.get_timeout() == 60.0
+
+    def test_adaptive_after_enough_samples(self):
+        at = AdaptiveTimeout(initial_timeout=300.0, multiplier=3.0)
+        # Record consistent 1s latencies
+        for _ in range(20):
+            at.record(1.0)
+        timeout = at.get_timeout()
+        # P99 of all-1.0 values = 1.0, so adaptive = 3.0
+        assert timeout == pytest.approx(3.0, abs=0.1)
+
+    def test_multiplier_effect(self):
+        at_low = AdaptiveTimeout(initial_timeout=300.0, multiplier=2.0)
+        at_high = AdaptiveTimeout(initial_timeout=300.0, multiplier=5.0)
+        for _ in range(20):
+            at_low.record(1.0)
+            at_high.record(1.0)
+        assert at_low.get_timeout() < at_high.get_timeout()
+
+    def test_clamped_to_initial(self):
+        """Adaptive timeout should never exceed initial_timeout."""
+        at = AdaptiveTimeout(initial_timeout=10.0, multiplier=3.0)
+        # Record very high latencies
+        for _ in range(20):
+            at.record(100.0)
+        assert at.get_timeout() == 10.0
+
+    def test_minimum_timeout(self):
+        """Adaptive timeout should not go below 1.0s."""
+        at = AdaptiveTimeout(initial_timeout=300.0, multiplier=3.0)
+        # Record very small latencies
+        for _ in range(20):
+            at.record(0.001)
+        timeout = at.get_timeout()
+        assert timeout >= 1.0
+
+    def test_sample_count(self):
+        at = AdaptiveTimeout(initial_timeout=60.0)
+        assert at.sample_count() == 0
+        at.record(1.0)
+        at.record(2.0)
+        assert at.sample_count() == 2
+
+    def test_rolling_window(self):
+        """Older samples should be dropped when window is full."""
+        at = AdaptiveTimeout(initial_timeout=300.0, multiplier=3.0, window_size=10)
+        # Fill with high latencies
+        for _ in range(10):
+            at.record(50.0)
+        high_timeout = at.get_timeout()
+        # Replace all with low latencies
+        for _ in range(10):
+            at.record(0.5)
+        low_timeout = at.get_timeout()
+        assert low_timeout < high_timeout
+
+    def test_invalid_initial_timeout(self):
+        with pytest.raises(ValueError, match="initial_timeout must be positive"):
+            AdaptiveTimeout(initial_timeout=0)
+
+    def test_invalid_multiplier(self):
+        with pytest.raises(ValueError, match="multiplier must be positive"):
+            AdaptiveTimeout(initial_timeout=60.0, multiplier=0)
+
+    def test_properties(self):
+        at = AdaptiveTimeout(initial_timeout=42.0, multiplier=2.5)
+        assert at.initial_timeout == 42.0
+        assert at.multiplier == 2.5
+
+
+class TestRequestResultEffectiveTimeout:
+    """Test effective_timeout field on RequestResult."""
+
+    def test_default_none(self):
+        r = RequestResult()
+        assert r.effective_timeout is None
+
+    def test_set_value(self):
+        r = RequestResult()
+        r.effective_timeout = 15.5
+        assert r.effective_timeout == 15.5
+
+
+class TestConfigKeys:
+    """Test that adaptive timeout config keys are registered."""
+
+    def test_known_keys(self):
+        from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+        assert "adaptive_timeout" in _KNOWN_KEYS
+        assert "adaptive_timeout_multiplier" in _KNOWN_KEYS
+
+
+class TestCLIArgs:
+    """Test CLI argument parsing for adaptive timeout."""
+
+    def _make_parser(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("base_url", nargs="?", default="http://localhost:8000")
+        _add_vllm_compat_args(parser)
+        return parser
+
+    def test_adaptive_timeout_flag(self):
+        parser = self._make_parser()
+        args = parser.parse_args(["--adaptive-timeout"])
+        assert args.adaptive_timeout is True
+
+    def test_adaptive_timeout_multiplier(self):
+        parser = self._make_parser()
+        args = parser.parse_args([
+            "--adaptive-timeout",
+            "--adaptive-timeout-multiplier", "5.0",
+        ])
+        assert args.adaptive_timeout_multiplier == 5.0
+
+    def test_default_multiplier(self):
+        parser = self._make_parser()
+        args = parser.parse_args([])
+        assert args.adaptive_timeout is False
+        assert args.adaptive_timeout_multiplier == 3.0


### PR DESCRIPTION
## Summary
Adaptive per-request timeout that auto-tunes based on observed latencies using rolling P99 × configurable multiplier.

## Changes
- **New module**: `src/xpyd_bench/bench/adaptive_timeout.py`
  - `AdaptiveTimeout` class with rolling P99 × multiplier logic
  - Clamped between 1.0s minimum and initial_timeout maximum
  - Thread-safe with configurable rolling window (default 100 samples)
  - Returns initial timeout until MIN_SAMPLES_FOR_ADAPTATION (5) collected
- **Models**: `RequestResult.effective_timeout` field tracks actual timeout per request
- **CLI**: `--adaptive-timeout` flag + `--adaptive-timeout-multiplier <float>` (default 3.0)
- **YAML config**: `adaptive_timeout`, `adaptive_timeout_multiplier`
- **Runner**: Integration at `_do_send` — records latency on success, feeds adaptive timeout
- **Tests**: 16 tests covering adaptation, multiplier, clamping, rolling window, CLI, config keys
- **ROADMAP**: M86 marked ✅

## Tests
All 1545 tests pass. Lint clean (ruff + isort).

Closes #232