### PR TITLE
feat: M88 — Speculative Decoding Metrics

### DIFF
--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -36,6 +36,7 @@ class RequestResult:
     effective_timeout: float | None = None  # Actual timeout used (M86)
     queue_time_ms: float | None = None  # Client-side queuing time in ms (M71)
     response_hash: str | None = None  # SHA-256 hash of response text (M85)
+    spec_events: list | None = None  # Speculative decoding events (M88)
 
 
 @dataclass
@@ -170,3 +171,6 @@ class BenchmarkResult:
 
     # Deduplication summary (M85)
     dedup_summary: dict | None = None
+
+    # Speculative decoding summary (M88)
+    speculative_summary: dict | None = None

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -190,6 +190,7 @@ async def _send_request(
     sse_metrics: bool = False,
     track_ratelimits: bool = False,
     track_payload_size: bool = False,
+    speculative_metrics: bool = False,
 ) -> RequestResult:
     """Send one request and collect metrics, with optional retry."""
     last_result = RequestResult()
@@ -217,6 +218,7 @@ async def _send_request(
                     sse_metrics=sse_metrics,
                     track_ratelimits=track_ratelimits,
                     track_payload_size=track_payload_size,
+                    speculative_metrics=speculative_metrics,
                 )
                 result.request_id = request_id
                 # Payload size tracking for streaming (M67)
@@ -300,6 +302,7 @@ async def _send_streaming(
     sse_metrics: bool = False,
     track_ratelimits: bool = False,
     track_payload_size: bool = False,
+    speculative_metrics: bool = False,
 ) -> RequestResult:
     """Send a streaming request, measure TTFT / ITL."""
     result = RequestResult()
@@ -311,6 +314,7 @@ async def _send_streaming(
     collected_text_parts: list[str] = []  # M47: collect response text for validation
     stream_usage: dict[str, Any] | None = None
     chunk_timing_list: list[Any] = []  # M53: per-chunk timing data
+    spec_event_list: list[Any] = []  # M88: speculative decoding events
     _stream_response_bytes = 0  # M67: track streamed response size
 
     try:
@@ -341,6 +345,15 @@ async def _send_streaming(
                 # Capture usage from final streaming chunk (stream_options.include_usage)
                 if "usage" in chunk and chunk["usage"] is not None:
                     stream_usage = chunk["usage"]
+
+                # M88: Parse speculative decoding data from chunk
+                if speculative_metrics:
+                    from xpyd_bench.bench.speculative import parse_spec_data_from_chunk
+
+                    spec_ev = parse_spec_data_from_chunk(chunk)
+                    if spec_ev is not None:
+                        spec_ev.timestamp = now - start
+                        spec_event_list.append(spec_ev)
 
                 # Check if this chunk has content
                 choices = chunk.get("choices", [])
@@ -405,6 +418,10 @@ async def _send_streaming(
     # M53: Store chunk timings if SSE metrics enabled
     if sse_metrics and chunk_timing_list:
         result.chunk_timings = chunk_timing_list
+
+    # M88: Store speculative decoding events
+    if speculative_metrics and spec_event_list:
+        result.spec_events = spec_event_list
 
     # M67: Store streamed response bytes
     if track_payload_size:
@@ -789,6 +806,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
     track_payload_size_enabled = bool(getattr(args, "track_payload_size", False))
     measure_generation_speed = bool(getattr(args, "measure_generation_speed", False))
     workload_stats_enabled = bool(getattr(args, "workload_stats", False))
+    speculative_metrics_enabled = bool(getattr(args, "speculative_metrics", False))
 
     # Adaptive timeout (M86)
     adaptive_timeout_enabled = bool(getattr(args, "adaptive_timeout", False))
@@ -837,6 +855,7 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
             sse_metrics=sse_metrics_enabled,
             track_ratelimits=track_ratelimits_enabled,
             track_payload_size=track_payload_size_enabled,
+            speculative_metrics=speculative_metrics_enabled,
         )
         r.effective_timeout = eff_timeout
         # Record latency for adaptation
@@ -1299,6 +1318,17 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
         if per_request_sse:
             result.sse_metrics = compute_sse_aggregate(per_request_sse)
 
+    # Speculative decoding metrics aggregate (M88)
+    if speculative_metrics_enabled and result.requests:
+        from xpyd_bench.bench.speculative import analyze_spec_events, compute_speculative_aggregate
+
+        per_request_spec = []
+        for req in result.requests:
+            if req.spec_events:
+                per_request_spec.append(analyze_spec_events(req.spec_events))
+        if per_request_spec:
+            result.speculative_summary = compute_speculative_aggregate(per_request_spec)
+
     # Rate-limit header aggregation (M66)
     if track_ratelimits_enabled and result.requests:
         from xpyd_bench.bench.ratelimit import aggregate_ratelimit
@@ -1612,6 +1642,17 @@ def _print_summary(r: BenchmarkResult) -> None:
             label = label_map.get(prefix, prefix)
             parts_cp = [f"{k}={v:.2f}" for k, v in pcts.items()]
             print(f"      {label:5s}  {', '.join(parts_cp)} ms")
+    if r.speculative_summary:
+        sp = r.speculative_summary
+        n_with = sp.get("requests_with_spec_data", 0)
+        n_total = sp.get("total_requests", 0)
+        print(f"\n  🔮 Speculative Decoding: {n_with}/{n_total} requests with data")
+        if sp.get("overall_acceptance_rate") is not None:
+            print(f"      Acceptance rate: {sp['overall_acceptance_rate']:.2%}")
+        if sp.get("total_tokens_saved") is not None:
+            print(f"      Tokens saved: {sp['total_tokens_saved']}")
+        if sp.get("mean_draft_batch_size") is not None:
+            print(f"      Mean draft batch size: {sp['mean_draft_batch_size']:.1f}")
     print("=" * 60)
 
 
@@ -1768,4 +1809,6 @@ def _to_dict(r: BenchmarkResult) -> dict:
         d["confidence_intervals"] = r.confidence_intervals
     if r.dedup_summary:
         d["dedup_summary"] = r.dedup_summary
+    if r.speculative_summary:
+        d["speculative_summary"] = r.speculative_summary
     return d

--- a/src/xpyd_bench/bench/speculative.py
+++ b/src/xpyd_bench/bench/speculative.py
@@ -1,0 +1,193 @@
+"""Speculative decoding metrics analysis (M88).
+
+Parses speculative decoding indicators from SSE streaming responses
+and computes acceptance rate, draft batch sizes, and speculation overhead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+
+@dataclass
+class SpecTokenEvent:
+    """A single speculative decoding event from an SSE chunk."""
+
+    draft_tokens: int  # Number of draft tokens proposed
+    accepted_tokens: int  # Number of draft tokens accepted by verifier
+    timestamp: float  # perf_counter relative to request start (seconds)
+
+
+@dataclass
+class RequestSpecMetrics:
+    """Per-request speculative decoding analysis results."""
+
+    events: list[SpecTokenEvent] = field(default_factory=list)
+    total_draft_tokens: int = 0
+    total_accepted_tokens: int = 0
+    total_rejected_tokens: int = 0
+    mean_acceptance_rate: float | None = None
+    mean_draft_batch_size: float | None = None
+    tokens_saved: int = 0  # accepted tokens that skipped full verification
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_count": len(self.events),
+            "total_draft_tokens": self.total_draft_tokens,
+            "total_accepted_tokens": self.total_accepted_tokens,
+            "total_rejected_tokens": self.total_rejected_tokens,
+            "mean_acceptance_rate": (
+                round(self.mean_acceptance_rate, 4)
+                if self.mean_acceptance_rate is not None
+                else None
+            ),
+            "mean_draft_batch_size": (
+                round(self.mean_draft_batch_size, 2)
+                if self.mean_draft_batch_size is not None
+                else None
+            ),
+            "tokens_saved": self.tokens_saved,
+        }
+
+
+def analyze_spec_events(events: list[SpecTokenEvent]) -> RequestSpecMetrics:
+    """Analyze speculative decoding events for a single request.
+
+    Args:
+        events: List of SpecTokenEvent parsed from SSE chunks.
+
+    Returns:
+        RequestSpecMetrics with computed statistics.
+    """
+    result = RequestSpecMetrics(events=events)
+    if not events:
+        return result
+
+    draft_totals: list[int] = []
+    accepted_totals: list[int] = []
+    acceptance_rates: list[float] = []
+
+    for ev in events:
+        draft_totals.append(ev.draft_tokens)
+        accepted_totals.append(ev.accepted_tokens)
+        rejected = ev.draft_tokens - ev.accepted_tokens
+        result.total_draft_tokens += ev.draft_tokens
+        result.total_accepted_tokens += ev.accepted_tokens
+        result.total_rejected_tokens += rejected
+        if ev.draft_tokens > 0:
+            acceptance_rates.append(ev.accepted_tokens / ev.draft_tokens)
+
+    result.tokens_saved = result.total_accepted_tokens
+
+    if acceptance_rates:
+        result.mean_acceptance_rate = float(np.mean(acceptance_rates))
+    if draft_totals:
+        result.mean_draft_batch_size = float(np.mean(draft_totals))
+
+    return result
+
+
+def compute_speculative_aggregate(
+    per_request: list[RequestSpecMetrics],
+) -> dict[str, Any]:
+    """Aggregate speculative decoding metrics across all requests.
+
+    Args:
+        per_request: List of per-request speculative metrics.
+
+    Returns:
+        Dict with aggregate speculative decoding statistics.
+    """
+    if not per_request:
+        return {}
+
+    # Filter out requests with no speculative data
+    with_data = [r for r in per_request if r.events]
+    if not with_data:
+        return {"requests_with_spec_data": 0, "total_requests": len(per_request)}
+
+    total_draft = sum(r.total_draft_tokens for r in with_data)
+    total_accepted = sum(r.total_accepted_tokens for r in with_data)
+    total_rejected = sum(r.total_rejected_tokens for r in with_data)
+    total_saved = sum(r.tokens_saved for r in with_data)
+
+    all_acceptance_rates = [
+        r.mean_acceptance_rate for r in with_data if r.mean_acceptance_rate is not None
+    ]
+    all_batch_sizes = [
+        r.mean_draft_batch_size for r in with_data if r.mean_draft_batch_size is not None
+    ]
+
+    result: dict[str, Any] = {
+        "requests_with_spec_data": len(with_data),
+        "total_requests": len(per_request),
+        "total_draft_tokens": total_draft,
+        "total_accepted_tokens": total_accepted,
+        "total_rejected_tokens": total_rejected,
+        "total_tokens_saved": total_saved,
+        "overall_acceptance_rate": (
+            round(total_accepted / total_draft, 4) if total_draft > 0 else None
+        ),
+    }
+
+    if all_acceptance_rates:
+        arr = np.array(all_acceptance_rates)
+        result["mean_acceptance_rate"] = round(float(np.mean(arr)), 4)
+        result["p50_acceptance_rate"] = round(float(np.percentile(arr, 50)), 4)
+        result["p90_acceptance_rate"] = round(float(np.percentile(arr, 90)), 4)
+
+    if all_batch_sizes:
+        arr = np.array(all_batch_sizes)
+        result["mean_draft_batch_size"] = round(float(np.mean(arr)), 2)
+
+    return result
+
+
+def parse_spec_data_from_chunk(chunk_data: dict[str, Any]) -> SpecTokenEvent | None:
+    """Extract speculative decoding data from an SSE chunk if present.
+
+    Servers that support speculative decoding may include extra fields in
+    their SSE chunks. We look for:
+      - ``x_spec``: dict with ``draft_tokens`` and ``accepted_tokens``
+      - ``speculative``: dict with same fields (alternative key)
+      - Choice-level ``x_spec`` field
+
+    Args:
+        chunk_data: Parsed JSON dict from an SSE ``data:`` line.
+
+    Returns:
+        SpecTokenEvent if speculative data found, None otherwise.
+    """
+    # Check top-level x_spec / speculative
+    spec = chunk_data.get("x_spec") or chunk_data.get("speculative")
+    if spec and isinstance(spec, dict):
+        draft = spec.get("draft_tokens", 0)
+        accepted = spec.get("accepted_tokens", 0)
+        if isinstance(draft, int) and isinstance(accepted, int) and draft > 0:
+            return SpecTokenEvent(
+                draft_tokens=draft,
+                accepted_tokens=accepted,
+                timestamp=0.0,  # caller sets real timestamp
+            )
+
+    # Check choice-level x_spec
+    choices = chunk_data.get("choices", [])
+    if choices and isinstance(choices, list):
+        for choice in choices:
+            if not isinstance(choice, dict):
+                continue
+            choice_spec = choice.get("x_spec") or choice.get("speculative")
+            if choice_spec and isinstance(choice_spec, dict):
+                draft = choice_spec.get("draft_tokens", 0)
+                accepted = choice_spec.get("accepted_tokens", 0)
+                if isinstance(draft, int) and isinstance(accepted, int) and draft > 0:
+                    return SpecTokenEvent(
+                        draft_tokens=draft,
+                        accepted_tokens=accepted,
+                        timestamp=0.0,
+                    )
+
+    return None

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -497,6 +497,15 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Threshold in ms to flag a gap between chunks as a stall (default: 1000).",
     )
 
+    # Speculative decoding metrics (M88)
+    parser.add_argument(
+        "--speculative-metrics",
+        action="store_true",
+        default=False,
+        dest="speculative_metrics",
+        help="Track speculative decoding indicators in streaming SSE responses.",
+    )
+
     # Network latency decomposition (M57)
     parser.add_argument(
         "--latency-breakdown",

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -139,6 +139,7 @@ _KNOWN_KEYS: set[str] = {
     "deduplicate",
     "adaptive_timeout",
     "adaptive_timeout_multiplier",
+    "speculative_metrics",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/src/xpyd_bench/dummy/cli.py
+++ b/src/xpyd_bench/dummy/cli.py
@@ -69,6 +69,20 @@ def dummy_main(argv: list[str] | None = None) -> None:
         default=None,
         help="Include rate-limit headers in responses with this RPM limit.",
     )
+    parser.add_argument(
+        "--speculative-draft-size",
+        type=int,
+        default=0,
+        dest="speculative_draft_size",
+        help="Emit x_spec data in SSE chunks with this draft batch size (0 disables).",
+    )
+    parser.add_argument(
+        "--speculative-acceptance-rate",
+        type=float,
+        default=0.8,
+        dest="speculative_acceptance_rate",
+        help="Simulated draft token acceptance rate (default 0.8).",
+    )
     args = parser.parse_args(argv)
 
     import uvicorn
@@ -85,6 +99,8 @@ def dummy_main(argv: list[str] | None = None) -> None:
         embedding_dim=args.embedding_dim,
         max_rps=args.max_rps,
         ratelimit_rpm=args.ratelimit_rpm,
+        speculative_draft_size=args.speculative_draft_size,
+        speculative_acceptance_rate=args.speculative_acceptance_rate,
     )
     app = create_app(config)
 

--- a/src/xpyd_bench/dummy/server.py
+++ b/src/xpyd_bench/dummy/server.py
@@ -38,6 +38,8 @@ class ServerConfig:
     embedding_dim: int = 1536  # Dimensionality for embedding vectors
     max_rps: float | None = None  # If set, reject requests above this rate (429)
     ratelimit_rpm: int | None = None  # If set, include rate-limit headers in responses
+    speculative_draft_size: int = 0  # If >0, emit x_spec data in SSE chunks
+    speculative_acceptance_rate: float = 0.8  # Simulated draft token acceptance rate
 
 
 # Rate-limit tracking state for dummy server
@@ -57,6 +59,17 @@ def set_config(config: ServerConfig) -> None:
         global _ratelimit_remaining, _ratelimit_window_start  # noqa: PLW0603
         _ratelimit_remaining = config.ratelimit_rpm
         _ratelimit_window_start = time.time()
+
+
+def _maybe_add_spec_data(chunk: dict) -> None:
+    """Add speculative decoding metadata to SSE chunk if configured (M88)."""
+    if _config.speculative_draft_size > 0:
+        import random as _rng
+
+        draft = _config.speculative_draft_size
+        accepted = max(1, int(draft * _config.speculative_acceptance_rate + _rng.uniform(-1, 1)))
+        accepted = min(accepted, draft)
+        chunk["x_spec"] = {"draft_tokens": draft, "accepted_tokens": accepted}
 
 
 def _ratelimit_headers() -> dict[str, str]:
@@ -512,6 +525,7 @@ async def _stream_completions(
             }
             if seed is not None:
                 chunk["system_fingerprint"] = f"fp_seed_{seed}"
+            _maybe_add_spec_data(chunk)
             yield f"data: {json.dumps(chunk)}\n\n"
             await asyncio.sleep(_config.decode_ms / 1000.0)
 
@@ -879,6 +893,7 @@ async def _stream_chat_completions(
             }
             if seed is not None:
                 chunk["system_fingerprint"] = f"fp_seed_{seed}"
+            _maybe_add_spec_data(chunk)
             yield f"data: {json.dumps(chunk)}\n\n"
             await asyncio.sleep(_config.decode_ms / 1000.0)
 

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -1,0 +1,276 @@
+"""Tests for M88: Speculative Decoding Metrics."""
+
+from __future__ import annotations
+
+import argparse
+
+from xpyd_bench.bench.models import BenchmarkResult, RequestResult
+from xpyd_bench.bench.speculative import (
+    SpecTokenEvent,
+    analyze_spec_events,
+    compute_speculative_aggregate,
+    parse_spec_data_from_chunk,
+)
+
+# ---------------------------------------------------------------------------
+# parse_spec_data_from_chunk tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseSpecDataFromChunk:
+    """Test SSE chunk parsing for speculative decoding data."""
+
+    def test_top_level_x_spec(self):
+        """Parse x_spec from top-level chunk field."""
+        chunk = {
+            "id": "cmpl-1",
+            "choices": [{"index": 0, "text": "token"}],
+            "x_spec": {"draft_tokens": 5, "accepted_tokens": 4},
+        }
+        ev = parse_spec_data_from_chunk(chunk)
+        assert ev is not None
+        assert ev.draft_tokens == 5
+        assert ev.accepted_tokens == 4
+
+    def test_top_level_speculative_key(self):
+        """Parse alternative 'speculative' key."""
+        chunk = {
+            "id": "cmpl-1",
+            "choices": [{"index": 0, "text": "token"}],
+            "speculative": {"draft_tokens": 3, "accepted_tokens": 2},
+        }
+        ev = parse_spec_data_from_chunk(chunk)
+        assert ev is not None
+        assert ev.draft_tokens == 3
+        assert ev.accepted_tokens == 2
+
+    def test_choice_level_x_spec(self):
+        """Parse x_spec from choice-level field."""
+        chunk = {
+            "id": "cmpl-1",
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "token",
+                    "x_spec": {"draft_tokens": 4, "accepted_tokens": 3},
+                }
+            ],
+        }
+        ev = parse_spec_data_from_chunk(chunk)
+        assert ev is not None
+        assert ev.draft_tokens == 4
+        assert ev.accepted_tokens == 3
+
+    def test_no_spec_data(self):
+        """Return None when no speculative data present."""
+        chunk = {
+            "id": "cmpl-1",
+            "choices": [{"index": 0, "text": "token"}],
+        }
+        ev = parse_spec_data_from_chunk(chunk)
+        assert ev is None
+
+    def test_zero_draft_tokens_ignored(self):
+        """Ignore x_spec with draft_tokens=0."""
+        chunk = {
+            "id": "cmpl-1",
+            "x_spec": {"draft_tokens": 0, "accepted_tokens": 0},
+        }
+        ev = parse_spec_data_from_chunk(chunk)
+        assert ev is None
+
+    def test_invalid_types_ignored(self):
+        """Ignore x_spec with non-integer values."""
+        chunk = {
+            "id": "cmpl-1",
+            "x_spec": {"draft_tokens": "five", "accepted_tokens": 4},
+        }
+        ev = parse_spec_data_from_chunk(chunk)
+        assert ev is None
+
+
+# ---------------------------------------------------------------------------
+# analyze_spec_events tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeSpecEvents:
+    """Test per-request speculative decoding analysis."""
+
+    def test_basic_analysis(self):
+        """Compute acceptance rate and batch size from events."""
+        events = [
+            SpecTokenEvent(draft_tokens=5, accepted_tokens=4, timestamp=0.1),
+            SpecTokenEvent(draft_tokens=5, accepted_tokens=3, timestamp=0.2),
+            SpecTokenEvent(draft_tokens=5, accepted_tokens=5, timestamp=0.3),
+        ]
+        result = analyze_spec_events(events)
+        assert result.total_draft_tokens == 15
+        assert result.total_accepted_tokens == 12
+        assert result.total_rejected_tokens == 3
+        assert result.tokens_saved == 12
+        assert result.mean_acceptance_rate is not None
+        assert 0.7 < result.mean_acceptance_rate < 0.9
+        assert result.mean_draft_batch_size == 5.0
+
+    def test_empty_events(self):
+        """Handle empty event list."""
+        result = analyze_spec_events([])
+        assert result.total_draft_tokens == 0
+        assert result.mean_acceptance_rate is None
+        assert result.tokens_saved == 0
+
+    def test_single_event(self):
+        """Handle single event."""
+        events = [SpecTokenEvent(draft_tokens=4, accepted_tokens=2, timestamp=0.1)]
+        result = analyze_spec_events(events)
+        assert result.total_draft_tokens == 4
+        assert result.total_accepted_tokens == 2
+        assert result.total_rejected_tokens == 2
+        assert result.mean_acceptance_rate == 0.5
+
+    def test_to_dict(self):
+        """Verify dict serialization."""
+        events = [SpecTokenEvent(draft_tokens=5, accepted_tokens=4, timestamp=0.1)]
+        result = analyze_spec_events(events)
+        d = result.to_dict()
+        assert "event_count" in d
+        assert d["event_count"] == 1
+        assert d["total_draft_tokens"] == 5
+        assert d["tokens_saved"] == 4
+
+
+# ---------------------------------------------------------------------------
+# compute_speculative_aggregate tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSpeculativeAggregate:
+    """Test cross-request speculative decoding aggregation."""
+
+    def test_aggregate_multiple_requests(self):
+        """Aggregate across multiple requests."""
+        r1 = analyze_spec_events([
+            SpecTokenEvent(draft_tokens=5, accepted_tokens=4, timestamp=0.1),
+            SpecTokenEvent(draft_tokens=5, accepted_tokens=5, timestamp=0.2),
+        ])
+        r2 = analyze_spec_events([
+            SpecTokenEvent(draft_tokens=3, accepted_tokens=2, timestamp=0.1),
+        ])
+        agg = compute_speculative_aggregate([r1, r2])
+        assert agg["requests_with_spec_data"] == 2
+        assert agg["total_draft_tokens"] == 13
+        assert agg["total_accepted_tokens"] == 11
+        assert agg["total_rejected_tokens"] == 2
+        assert agg["overall_acceptance_rate"] is not None
+        assert agg["mean_acceptance_rate"] is not None
+
+    def test_empty_list(self):
+        """Handle empty per-request list."""
+        agg = compute_speculative_aggregate([])
+        assert agg == {}
+
+    def test_no_spec_data_requests(self):
+        """Handle requests with no speculative events."""
+        r1 = analyze_spec_events([])
+        agg = compute_speculative_aggregate([r1])
+        assert agg["requests_with_spec_data"] == 0
+
+    def test_mixed_with_and_without(self):
+        """Aggregate correctly when some requests lack spec data."""
+        r1 = analyze_spec_events([
+            SpecTokenEvent(draft_tokens=5, accepted_tokens=4, timestamp=0.1),
+        ])
+        r2 = analyze_spec_events([])
+        agg = compute_speculative_aggregate([r1, r2])
+        assert agg["requests_with_spec_data"] == 1
+        assert agg["total_requests"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Model integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestModelIntegration:
+    """Test that model fields work correctly."""
+
+    def test_request_result_spec_events(self):
+        """RequestResult has spec_events field."""
+        r = RequestResult()
+        assert r.spec_events is None
+        r.spec_events = [SpecTokenEvent(draft_tokens=5, accepted_tokens=4, timestamp=0.1)]
+        assert len(r.spec_events) == 1
+
+    def test_benchmark_result_speculative_summary(self):
+        """BenchmarkResult has speculative_summary field."""
+        r = BenchmarkResult()
+        assert r.speculative_summary is None
+        r.speculative_summary = {"overall_acceptance_rate": 0.8}
+        assert r.speculative_summary["overall_acceptance_rate"] == 0.8
+
+
+# ---------------------------------------------------------------------------
+# CLI integration test
+# ---------------------------------------------------------------------------
+
+
+class TestCLIFlag:
+    """Test CLI argument parsing for speculative metrics."""
+
+    def test_speculative_metrics_flag(self):
+        """--speculative-metrics flag is parsed correctly."""
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--speculative-metrics"])
+        assert args.speculative_metrics is True
+
+    def test_speculative_metrics_default_false(self):
+        """--speculative-metrics defaults to False."""
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        assert args.speculative_metrics is False
+
+
+# ---------------------------------------------------------------------------
+# Config key test
+# ---------------------------------------------------------------------------
+
+
+class TestConfigKey:
+    """Test that speculative_metrics is a known config key."""
+
+    def test_known_key(self):
+        """speculative_metrics is in _KNOWN_KEYS."""
+        from xpyd_bench.config_cmd import _KNOWN_KEYS
+
+        assert "speculative_metrics" in _KNOWN_KEYS
+
+
+# ---------------------------------------------------------------------------
+# Dummy server speculative config test
+# ---------------------------------------------------------------------------
+
+
+class TestDummyServerConfig:
+    """Test dummy server speculative decoding configuration."""
+
+    def test_server_config_fields(self):
+        """ServerConfig has speculative fields."""
+        from xpyd_bench.dummy.server import ServerConfig
+
+        cfg = ServerConfig(speculative_draft_size=5, speculative_acceptance_rate=0.7)
+        assert cfg.speculative_draft_size == 5
+        assert cfg.speculative_acceptance_rate == 0.7
+
+    def test_default_disabled(self):
+        """Speculative decoding is disabled by default."""
+        from xpyd_bench.dummy.server import ServerConfig
+
+        cfg = ServerConfig()
+        assert cfg.speculative_draft_size == 0


### PR DESCRIPTION
## Summary
Add speculative decoding metrics tracking to xPyD-bench (M88).

Closes #237

## Changes
- **New module**: `src/xpyd_bench/bench/speculative.py` — parsing, per-request analysis, cross-request aggregation
- **CLI**: `--speculative-metrics` flag to enable tracking
- **Models**: `RequestResult.spec_events`, `BenchmarkResult.speculative_summary`
- **Runner**: Parse `x_spec`/`speculative` from SSE chunks, aggregate after benchmark, print in terminal summary
- **Dummy server**: `--speculative-draft-size` and `--speculative-acceptance-rate` flags
- **Config**: `speculative_metrics` added to known YAML config keys
- **Tests**: 21 tests covering all components

## Test Results
- All 1584 tests pass (including 21 new)
- Lint clean (`ruff check` + `isort --check`)