### PR TITLE
feat(M92): Prompt Caching Cost Analysis

### DIFF
--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -93,4 +93,5 @@
 |---|------|------|--------|-------------------|
 | 1 | 2026-04-05 | M89: Multi-LoRA Endpoint Benchmarking | ✅ merged (PR #242) | Both approved — clean code, good test coverage |
 | 2 | 2026-04-06 | M90: Request Warm-up Curve Analysis | ✅ merged | Both approved |
-| 3 | 2026-04-06 | M91: Token-Level Streaming Latency CDF | ⏳ in progress | — |
+| 3 | 2026-04-06 | M91: Token-Level Streaming Latency CDF | ✅ merged (PR #246) | Both approved |
+| 4 | 2026-04-06 | M92: Prompt Caching Cost Analysis | ⏳ in progress | — |

--- a/src/xpyd_bench/bench/cache_savings.py
+++ b/src/xpyd_bench/bench/cache_savings.py
@@ -1,0 +1,115 @@
+"""Prompt Caching Cost Analysis (M92).
+
+Analyze dataset prompts for shared prefix patterns and estimate
+potential cost savings from prompt caching.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _longest_common_prefix(a: str, b: str) -> int:
+    """Return length of longest common prefix between two strings."""
+    limit = min(len(a), len(b))
+    i = 0
+    while i < limit and a[i] == b[i]:
+        i += 1
+    return i
+
+
+def _estimate_token_count(text: str) -> int:
+    """Rough token estimate (word-split heuristic). ~4 chars per token."""
+    return max(1, len(text) // 4)
+
+
+def analyze_cache_savings(
+    prompts: list[str],
+    *,
+    cache_pricing_ratio: float = 0.5,
+    cost_per_1k_input: float | None = None,
+) -> dict[str, Any]:
+    """Analyze prompts for prefix caching savings potential.
+
+    Parameters
+    ----------
+    prompts:
+        List of prompt strings from the dataset.
+    cache_pricing_ratio:
+        Ratio of cached token cost to uncached (0.5 = cached tokens cost 50%).
+    cost_per_1k_input:
+        If provided, compute dollar-amount savings estimate.
+
+    Returns
+    -------
+    dict with cache savings analysis.
+    """
+    n = len(prompts)
+    if n < 2:
+        return {
+            "num_prompts": n,
+            "cacheable_token_ratio": 0.0,
+            "estimated_cache_hit_rate": 0.0,
+            "total_prompt_tokens": _estimate_token_count(prompts[0]) if n == 1 else 0,
+            "cacheable_tokens": 0,
+            "unique_tokens": _estimate_token_count(prompts[0]) if n == 1 else 0,
+            "savings_ratio": 0.0,
+            "cost_savings": None,
+        }
+
+    # Sort prompts to find shared prefixes efficiently
+    sorted_prompts = sorted(prompts)
+
+    # Compute pairwise LCP between adjacent sorted prompts
+    lcp_chars: list[int] = []
+    for i in range(len(sorted_prompts) - 1):
+        lcp = _longest_common_prefix(sorted_prompts[i], sorted_prompts[i + 1])
+        lcp_chars.append(lcp)
+
+    # Estimate total and cacheable tokens
+    total_tokens = sum(_estimate_token_count(p) for p in prompts)
+
+    # For each prompt (except first in sorted order), the prefix shared with
+    # at least one neighbor represents cacheable tokens.
+    # Use max LCP per prompt position as the cacheable portion.
+    cacheable_chars = 0
+    for lcp in lcp_chars:
+        cacheable_chars += lcp
+
+    cacheable_tokens = max(0, cacheable_chars // 4)
+    cacheable_ratio = round(cacheable_tokens / total_tokens, 4) if total_tokens > 0 else 0.0
+
+    # Cache hit rate: fraction of prompt pairs with non-trivial shared prefix (>10 chars)
+    hits = sum(1 for lcp in lcp_chars if lcp > 10)
+    hit_rate = round(hits / len(lcp_chars), 4) if lcp_chars else 0.0
+
+    # Savings: cached tokens cost less
+    # Without cache: total_tokens * full_price
+    # With cache: uncached * full + cached * (full * ratio)
+    # Savings = cacheable_tokens * full_price * (1 - ratio)
+    savings_ratio = round(cacheable_ratio * (1 - cache_pricing_ratio), 4)
+
+    cost_savings: dict[str, Any] | None = None
+    if cost_per_1k_input is not None and cost_per_1k_input > 0:
+        full_cost = total_tokens / 1000 * cost_per_1k_input
+        saved = cacheable_tokens / 1000 * cost_per_1k_input * (1 - cache_pricing_ratio)
+        cost_savings = {
+            "currency": "USD",
+            "full_cost": round(full_cost, 6),
+            "cached_cost": round(full_cost - saved, 6),
+            "saved": round(saved, 6),
+        }
+
+    unique_tokens = total_tokens - cacheable_tokens
+
+    return {
+        "num_prompts": n,
+        "cacheable_token_ratio": cacheable_ratio,
+        "estimated_cache_hit_rate": hit_rate,
+        "total_prompt_tokens": total_tokens,
+        "cacheable_tokens": cacheable_tokens,
+        "unique_tokens": unique_tokens,
+        "savings_ratio": savings_ratio,
+        "cache_pricing_ratio": cache_pricing_ratio,
+        "cost_savings": cost_savings,
+    }

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -176,3 +176,6 @@ class BenchmarkResult:
     speculative_summary: dict | None = None
     warmup_curve: dict | None = None
     token_latency_cdf: dict | None = None
+
+    # Prompt caching cost analysis (M92)
+    cache_savings: dict | None = None

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -718,6 +718,10 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
             prompt_priorities = [None] * args.num_prompts
 
     # Apply template variable substitution (M37)
+
+    # Store prompts text for cache savings analysis (M92)
+    if getattr(args, "analyze_cache_savings", False):
+        args._prompts_text = list(prompts)
     template_vars_path = getattr(args, "template_vars", None)
     if template_vars_path:
         from xpyd_bench.templating import apply_templates, load_template_vars
@@ -1506,6 +1510,36 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
             "stats": noise_injector.stats.to_dict(),
         }
 
+    # Prompt caching cost analysis (M92)
+    cache_savings_enabled = bool(getattr(args, "analyze_cache_savings", False))
+    if cache_savings_enabled and hasattr(args, "_prompts_text") and args._prompts_text:
+        from xpyd_bench.bench.cache_savings import analyze_cache_savings
+
+        _ratio = getattr(args, "cache_pricing_ratio", 0.5)
+        _cost_1k: float | None = None
+        if hasattr(args, "_cost_model") and args._cost_model is not None:
+            _cm = args._cost_model
+            _mp = _cm.models.get(result.model) or _cm.default
+            if _mp:
+                _cost_1k = _mp.get("input")
+        _cs = analyze_cache_savings(
+            args._prompts_text,
+            cache_pricing_ratio=_ratio,
+            cost_per_1k_input=_cost_1k,
+        )
+        result.cache_savings = _cs
+        if not getattr(args, "disable_tqdm", False):
+            print("\n--- Prompt Caching Cost Analysis ---")
+            print(f"  Prompts analyzed: {_cs['num_prompts']}")
+            print(f"  Cacheable token ratio: {_cs['cacheable_token_ratio']:.2%}")
+            print(f"  Estimated cache hit rate: {_cs['estimated_cache_hit_rate']:.2%}")
+            print(f"  Projected savings ratio: {_cs['savings_ratio']:.2%}")
+            if _cs.get("cost_savings"):
+                _csav = _cs["cost_savings"]
+                print(f"  Cost without cache: ${_csav['full_cost']:.4f}")
+                print(f"  Cost with cache:    ${_csav['cached_cost']:.4f}")
+                print(f"  Savings:            ${_csav['saved']:.4f}")
+
     # Structured output validation (M56)
     _tools_path = getattr(args, "tools", None)
     _response_format = getattr(args, "response_format", None)
@@ -1860,4 +1894,6 @@ def _to_dict(r: BenchmarkResult) -> dict:
         d["speculative_summary"] = r.speculative_summary
     if r.token_latency_cdf:
         d["token_latency_cdf"] = r.token_latency_cdf
+    if r.cache_savings:
+        d["cache_savings"] = r.cache_savings
     return d

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -515,6 +515,22 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Compute CDF of inter-token latencies with bimodal detection.",
     )
 
+    # Prompt caching cost analysis (M92)
+    parser.add_argument(
+        "--analyze-cache-savings",
+        action="store_true",
+        default=False,
+        dest="analyze_cache_savings",
+        help="Analyze dataset for shared prefix patterns and estimate caching cost savings.",
+    )
+    parser.add_argument(
+        "--cache-pricing-ratio",
+        type=float,
+        default=0.5,
+        dest="cache_pricing_ratio",
+        help="Ratio of cached token cost to uncached (default: 0.5).",
+    )
+
     # Speculative decoding metrics (M88)
     parser.add_argument(
         "--speculative-metrics",

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -142,6 +142,8 @@ _KNOWN_KEYS: set[str] = {
     "speculative_metrics",
     "warmup_curve",
     "token_cdf",
+    "analyze_cache_savings",
+    "cache_pricing_ratio",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/tests/test_cache_savings.py
+++ b/tests/test_cache_savings.py
@@ -1,0 +1,215 @@
+"""Tests for M92: Prompt Caching Cost Analysis."""
+
+from __future__ import annotations
+
+from xpyd_bench.bench.cache_savings import (
+    _estimate_token_count,
+    _longest_common_prefix,
+    analyze_cache_savings,
+)
+
+# --- Unit tests for helpers ---
+
+
+class TestLongestCommonPrefix:
+    def test_identical(self):
+        assert _longest_common_prefix("hello", "hello") == 5
+
+    def test_no_common(self):
+        assert _longest_common_prefix("abc", "xyz") == 0
+
+    def test_partial(self):
+        assert _longest_common_prefix("abcdef", "abcxyz") == 3
+
+    def test_empty(self):
+        assert _longest_common_prefix("", "abc") == 0
+        assert _longest_common_prefix("abc", "") == 0
+
+    def test_different_lengths(self):
+        assert _longest_common_prefix("ab", "abcdef") == 2
+
+
+class TestEstimateTokenCount:
+    def test_basic(self):
+        assert _estimate_token_count("a" * 20) == 5
+
+    def test_minimum(self):
+        assert _estimate_token_count("a") == 1
+
+    def test_empty(self):
+        assert _estimate_token_count("") == 1
+
+
+# --- Core analysis tests ---
+
+
+class TestAnalyzeCacheSavings:
+    def test_single_prompt(self):
+        result = analyze_cache_savings(["Hello world this is a test prompt"])
+        assert result["num_prompts"] == 1
+        assert result["cacheable_token_ratio"] == 0.0
+        assert result["estimated_cache_hit_rate"] == 0.0
+        assert result["savings_ratio"] == 0.0
+        assert result["cost_savings"] is None
+
+    def test_identical_prompts(self):
+        prompts = ["The quick brown fox jumps over the lazy dog"] * 10
+        result = analyze_cache_savings(prompts)
+        assert result["num_prompts"] == 10
+        assert result["cacheable_token_ratio"] > 0.5
+        assert result["estimated_cache_hit_rate"] == 1.0
+        assert result["savings_ratio"] > 0.0
+
+    def test_no_shared_prefix(self):
+        prompts = [
+            "Alpha bravo charlie delta echo foxtrot golf hotel",
+            "India juliet kilo lima mike november oscar papa",
+            "Quebec romeo sierra tango uniform victor whiskey",
+        ]
+        result = analyze_cache_savings(prompts)
+        assert result["num_prompts"] == 3
+        assert result["cacheable_token_ratio"] < 0.1
+
+    def test_shared_prefix(self):
+        prefix = "You are a helpful AI assistant. Please answer: "
+        prompts = [
+            prefix + "What is Python?",
+            prefix + "What is Java?",
+            prefix + "What is Rust?",
+            prefix + "What is Go?",
+        ]
+        result = analyze_cache_savings(prompts)
+        assert result["cacheable_token_ratio"] > 0.3
+        assert result["estimated_cache_hit_rate"] > 0.5
+
+    def test_custom_pricing_ratio(self):
+        prompts = [
+            "Shared prefix content here: query A",
+            "Shared prefix content here: query B",
+        ]
+        r1 = analyze_cache_savings(prompts, cache_pricing_ratio=0.5)
+        r2 = analyze_cache_savings(prompts, cache_pricing_ratio=0.0)
+        assert r2["savings_ratio"] >= r1["savings_ratio"]
+
+    def test_cost_savings_with_cost_model(self):
+        prompts = [
+            "Reusable system prompt for benchmarking: question alpha",
+            "Reusable system prompt for benchmarking: question beta",
+        ]
+        result = analyze_cache_savings(
+            prompts,
+            cache_pricing_ratio=0.5,
+            cost_per_1k_input=0.03,
+        )
+        assert result["cost_savings"] is not None
+        cs = result["cost_savings"]
+        assert cs["currency"] == "USD"
+        assert cs["full_cost"] > 0
+        assert cs["saved"] >= 0
+        assert cs["cached_cost"] <= cs["full_cost"]
+
+    def test_cost_savings_none_without_cost_model(self):
+        prompts = ["Hello world test prompt", "Hello world other prompt"]
+        result = analyze_cache_savings(prompts)
+        assert result["cost_savings"] is None
+
+    def test_two_prompts(self):
+        result = analyze_cache_savings(["abc def ghi", "abc def xyz"])
+        assert result["num_prompts"] == 2
+        assert result["total_prompt_tokens"] > 0
+        assert result["unique_tokens"] >= 0
+
+    def test_empty_prompts_list_single(self):
+        result = analyze_cache_savings([""])
+        assert result["num_prompts"] == 1
+
+
+# --- BenchmarkResult integration ---
+
+
+class TestBenchmarkResultIntegration:
+    def test_cache_savings_field(self):
+        from xpyd_bench.bench.models import BenchmarkResult
+
+        r = BenchmarkResult()
+        assert r.cache_savings is None
+        r.cache_savings = {"cacheable_token_ratio": 0.5}
+        assert r.cache_savings["cacheable_token_ratio"] == 0.5
+
+    def test_json_serialization(self):
+        from xpyd_bench.bench.models import BenchmarkResult
+        from xpyd_bench.bench.runner import _to_dict as _result_to_dict
+
+        r = BenchmarkResult()
+        r.cache_savings = {
+            "num_prompts": 5,
+            "cacheable_token_ratio": 0.42,
+            "savings_ratio": 0.21,
+        }
+        d = _result_to_dict(r)
+        assert "cache_savings" in d
+        assert d["cache_savings"]["cacheable_token_ratio"] == 0.42
+
+    def test_json_serialization_absent(self):
+        from xpyd_bench.bench.models import BenchmarkResult
+        from xpyd_bench.bench.runner import _to_dict as _result_to_dict
+
+        r = BenchmarkResult()
+        d = _result_to_dict(r)
+        assert "cache_savings" not in d
+
+
+# --- Config key validation ---
+
+
+class TestConfigKey:
+    def test_known_keys(self):
+        from xpyd_bench.config_cmd import _KNOWN_KEYS as KNOWN_KEYS
+
+        assert "analyze_cache_savings" in KNOWN_KEYS
+        assert "cache_pricing_ratio" in KNOWN_KEYS
+
+
+# --- CLI integration ---
+
+
+class TestCLIIntegration:
+    def test_flag_parsing(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--analyze-cache-savings"])
+        assert args.analyze_cache_savings is True
+
+    def test_default_disabled(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        assert args.analyze_cache_savings is False
+
+    def test_pricing_ratio_parsing(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args(["--cache-pricing-ratio", "0.3"])
+        assert args.cache_pricing_ratio == 0.3
+
+    def test_pricing_ratio_default(self):
+        import argparse
+
+        from xpyd_bench.cli import _add_vllm_compat_args
+
+        parser = argparse.ArgumentParser()
+        _add_vllm_compat_args(parser)
+        args = parser.parse_args([])
+        assert args.cache_pricing_ratio == 0.5


### PR DESCRIPTION
## Summary
Add `--analyze-cache-savings` flag that analyzes dataset prompts for shared prefix patterns and estimates potential cost savings from prompt caching.

## Changes
- New module `src/xpyd_bench/bench/cache_savings.py` with prefix analysis logic
- `--analyze-cache-savings` CLI flag enables analysis after benchmark
- `--cache-pricing-ratio` configures cached vs uncached token cost ratio (default 0.5)
- `BenchmarkResult.cache_savings` dict field with analysis results
- Integrates with existing `--cost-model` for dollar-amount savings estimates
- YAML config support (`analyze_cache_savings`, `cache_pricing_ratio`)
- 25 tests covering all logic paths

## Acceptance Criteria
All items from issue #247 are addressed.

Closes #247