### PR TITLE
feat(M94): Model Output Quality Scoring

### DIFF
--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -95,4 +95,5 @@
 | 2 | 2026-04-06 | M90: Request Warm-up Curve Analysis | ✅ merged | Both approved |
 | 3 | 2026-04-06 | M91: Token-Level Streaming Latency CDF | ✅ merged (PR #246) | Both approved |
 | 4 | 2026-04-06 | M92: Prompt Caching Cost Analysis | ✅ merged (PR #248) | Both approved |
-| 5 | 2026-04-06 | M93: Request Pacing Accuracy Report | ⏳ in progress | — |
+| 5 | 2026-04-06 | M93: Request Pacing Accuracy Report | ✅ merged (PR #250) | Both approved |
+| 6 | 2026-04-06 | M94: Model Output Quality Scoring | ⏳ in progress | — |

--- a/src/xpyd_bench/bench/models.py
+++ b/src/xpyd_bench/bench/models.py
@@ -37,6 +37,7 @@ class RequestResult:
     queue_time_ms: float | None = None  # Client-side queuing time in ms (M71)
     response_hash: str | None = None  # SHA-256 hash of response text (M85)
     spec_events: list | None = None  # Speculative decoding events (M88)
+    quality_scores: dict | None = None  # Per-mode quality scores (M94)
 
 
 @dataclass
@@ -182,3 +183,6 @@ class BenchmarkResult:
 
     # Pacing accuracy report (M93)
     pacing_report: dict | None = None
+
+    # Model output quality scoring (M94)
+    quality_summary: dict | None = None

--- a/src/xpyd_bench/bench/quality.py
+++ b/src/xpyd_bench/bench/quality.py
@@ -1,0 +1,154 @@
+"""Model output quality scoring (M94).
+
+Lightweight output quality assessment to detect quality degradation under
+high load.  Three scoring modes are supported:
+
+- ``perplexity-proxy``: response length vs prompt complexity ratio.
+- ``repetition``: n-gram repetition rate (bigram + trigram).
+- ``coherence``: sentence-level token-overlap similarity.
+"""
+
+from __future__ import annotations
+
+import re
+import statistics
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from xpyd_bench.bench.models import RequestResult
+
+
+def _tokenize(text: str) -> list[str]:
+    """Cheap whitespace + punctuation tokenizer."""
+    return re.findall(r"\w+", text.lower())
+
+
+def _sentences(text: str) -> list[str]:
+    """Split text into sentences."""
+    parts = re.split(r"[.!?]+", text.strip())
+    return [s.strip() for s in parts if s.strip()]
+
+
+# ------------------------------------------------------------------
+# Individual scoring functions
+# ------------------------------------------------------------------
+
+def score_perplexity_proxy(prompt_tokens: int, completion_tokens: int) -> float:
+    """Ratio of completion tokens to prompt tokens.
+
+    A very low ratio may indicate the model produced an unusually short
+    (possibly degenerate) response.  Returns 0.0 when *prompt_tokens* is
+    zero to avoid division errors.
+    """
+    if prompt_tokens <= 0:
+        return 0.0
+    return completion_tokens / prompt_tokens
+
+
+def score_repetition(text: str) -> float:
+    """N-gram repetition rate (average of bigram and trigram rates).
+
+    Returns a value in [0, 1] where 0 means no repetition and 1 means
+    every n-gram is repeated at least once.
+    """
+    tokens = _tokenize(text)
+    if len(tokens) < 3:
+        return 0.0
+
+    def _ngram_rep_rate(n: int) -> float:
+        ngrams = [tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1)]
+        if not ngrams:
+            return 0.0
+        unique = len(set(ngrams))
+        total = len(ngrams)
+        return 1.0 - unique / total
+
+    bigram_rate = _ngram_rep_rate(2)
+    trigram_rate = _ngram_rep_rate(3)
+    return (bigram_rate + trigram_rate) / 2.0
+
+
+def score_coherence(text: str) -> float:
+    """Sentence-level token-overlap similarity (Jaccard).
+
+    Computes mean pairwise Jaccard similarity between consecutive
+    sentences.  Returns 0.0 for texts with fewer than two sentences.
+    High values may indicate repetitive sentence structures.
+    """
+    sents = _sentences(text)
+    if len(sents) < 2:
+        return 0.0
+
+    similarities: list[float] = []
+    for i in range(len(sents) - 1):
+        a = set(_tokenize(sents[i]))
+        b = set(_tokenize(sents[i + 1]))
+        if not a and not b:
+            continue
+        union = a | b
+        if not union:
+            continue
+        similarities.append(len(a & b) / len(union))
+
+    return statistics.mean(similarities) if similarities else 0.0
+
+
+# ------------------------------------------------------------------
+# Aggregate helpers
+# ------------------------------------------------------------------
+
+_MODE_FN = {
+    "perplexity-proxy": None,  # handled specially (needs tokens, not text)
+    "repetition": score_repetition,
+    "coherence": score_coherence,
+}
+
+VALID_MODES = frozenset(_MODE_FN.keys())
+
+
+def compute_request_quality(
+    request: RequestResult,
+    modes: list[str],
+) -> dict[str, float]:
+    """Compute quality scores for a single request.
+
+    Returns a dict mapping mode name to score.
+    """
+    scores: dict[str, float] = {}
+    for mode in modes:
+        if mode == "perplexity-proxy":
+            scores[mode] = score_perplexity_proxy(
+                request.prompt_tokens, request.completion_tokens
+            )
+        elif mode in ("repetition", "coherence"):
+            text = request.response_text or ""
+            fn = _MODE_FN[mode]
+            scores[mode] = fn(text) if fn else 0.0
+        # unknown modes silently ignored
+    return scores
+
+
+def compute_quality_summary(
+    all_scores: list[dict[str, float]],
+    modes: list[str],
+) -> dict:
+    """Aggregate per-request quality scores into a summary.
+
+    Returns a dict with per-mode statistics: mean, min, max, stddev.
+    """
+    if not all_scores:
+        return {}
+
+    summary: dict[str, dict] = {}
+    for mode in modes:
+        values = [s[mode] for s in all_scores if mode in s]
+        if not values:
+            continue
+        summary[mode] = {
+            "mean": round(statistics.mean(values), 6),
+            "min": round(min(values), 6),
+            "max": round(max(values), 6),
+            "stddev": round(statistics.stdev(values), 6) if len(values) > 1 else 0.0,
+            "count": len(values),
+        }
+    return summary

--- a/src/xpyd_bench/bench/runner.py
+++ b/src/xpyd_bench/bench/runner.py
@@ -1587,6 +1587,33 @@ async def run_benchmark(args: Namespace, base_url: str) -> tuple[dict, Benchmark
                         f" ({bu['burst_ratio']:.1%})"
                     )
 
+    # Model output quality scoring (M94)
+    _quality_modes = getattr(args, "quality_check", None) or []
+    if _quality_modes and result.requests:
+        from xpyd_bench.bench.quality import (
+            compute_quality_summary,
+            compute_request_quality,
+        )
+
+        _all_qscores: list[dict[str, float]] = []
+        for _rq in result.requests:
+            if _rq.success:
+                qs = compute_request_quality(_rq, _quality_modes)
+                _rq.quality_scores = qs
+                _all_qscores.append(qs)
+        _qsummary = compute_quality_summary(_all_qscores, _quality_modes)
+        if _qsummary:
+            result.quality_summary = _qsummary
+            if not getattr(args, "disable_tqdm", False):
+                print("\n--- Output Quality Scores ---")
+                for _qm, _qs in _qsummary.items():
+                    print(
+                        f"  {_qm}: mean={_qs['mean']:.4f}"
+                        f" min={_qs['min']:.4f}"
+                        f" max={_qs['max']:.4f}"
+                        f" stddev={_qs['stddev']:.4f}"
+                    )
+
     # Structured output validation (M56)
     _tools_path = getattr(args, "tools", None)
     _response_format = getattr(args, "response_format", None)
@@ -1945,4 +1972,6 @@ def _to_dict(r: BenchmarkResult) -> dict:
         d["cache_savings"] = r.cache_savings
     if r.pacing_report:
         d["pacing_report"] = r.pacing_report
+    if r.quality_summary:
+        d["quality_summary"] = r.quality_summary
     return d

--- a/src/xpyd_bench/cli.py
+++ b/src/xpyd_bench/cli.py
@@ -549,6 +549,19 @@ def _add_vllm_compat_args(parser: argparse.ArgumentParser) -> None:
         help="Measure and report request pacing accuracy vs target rate.",
     )
 
+    # Model output quality scoring (M94)
+    parser.add_argument(
+        "--quality-check",
+        action="append",
+        default=None,
+        dest="quality_check",
+        metavar="MODE",
+        help=(
+            "Lightweight output quality assessment mode (repeatable). "
+            "Modes: perplexity-proxy, repetition, coherence."
+        ),
+    )
+
     # Network latency decomposition (M57)
     parser.add_argument(
         "--latency-breakdown",

--- a/src/xpyd_bench/config_cmd.py
+++ b/src/xpyd_bench/config_cmd.py
@@ -145,6 +145,7 @@ _KNOWN_KEYS: set[str] = {
     "analyze_cache_savings",
     "cache_pricing_ratio",
     "pacing_report",
+    "quality_check",
 }
 
 # Deprecated keys (currently none, placeholder for future use)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,190 @@
+"""Tests for model output quality scoring (M94)."""
+
+from __future__ import annotations
+
+from xpyd_bench.bench.quality import (
+    VALID_MODES,
+    compute_quality_summary,
+    compute_request_quality,
+    score_coherence,
+    score_perplexity_proxy,
+    score_repetition,
+)
+
+
+def _make_request(
+    prompt_tokens: int = 100,
+    completion_tokens: int = 50,
+    response_text: str | None = None,
+    success: bool = True,
+):
+    """Create a minimal RequestResult-like object."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class FakeRequest:
+        prompt_tokens: int = 0
+        completion_tokens: int = 0
+        response_text: str | None = None
+        success: bool = True
+        quality_scores: dict | None = None
+
+    return FakeRequest(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        response_text=response_text,
+        success=success,
+    )
+
+
+# --- score_perplexity_proxy ---
+
+
+def test_perplexity_proxy_normal():
+    assert score_perplexity_proxy(100, 50) == 0.5
+
+
+def test_perplexity_proxy_zero_prompt():
+    assert score_perplexity_proxy(0, 50) == 0.0
+
+
+def test_perplexity_proxy_negative_prompt():
+    assert score_perplexity_proxy(-1, 50) == 0.0
+
+
+def test_perplexity_proxy_zero_completion():
+    assert score_perplexity_proxy(100, 0) == 0.0
+
+
+# --- score_repetition ---
+
+
+def test_repetition_no_repeat():
+    text = "the quick brown fox jumps over a lazy dog today"
+    rate = score_repetition(text)
+    assert rate >= 0.0
+
+
+def test_repetition_high_repeat():
+    text = "hello hello hello hello hello hello hello hello"
+    rate = score_repetition(text)
+    assert rate > 0.5
+
+
+def test_repetition_short_text():
+    assert score_repetition("hi") == 0.0
+
+
+def test_repetition_empty():
+    assert score_repetition("") == 0.0
+
+
+# --- score_coherence ---
+
+
+def test_coherence_similar_sentences():
+    text = "The cat sat on the mat. The cat lay on the mat."
+    score = score_coherence(text)
+    assert score > 0.3
+
+
+def test_coherence_different_sentences():
+    text = "The sun is bright. Quantum mechanics is complex."
+    score = score_coherence(text)
+    assert score < 0.5
+
+
+def test_coherence_single_sentence():
+    assert score_coherence("Just one sentence here") == 0.0
+
+
+def test_coherence_empty():
+    assert score_coherence("") == 0.0
+
+
+# --- compute_request_quality ---
+
+
+def test_request_quality_all_modes():
+    req = _make_request(
+        prompt_tokens=100,
+        completion_tokens=50,
+        response_text="The quick brown fox. The lazy dog sleeps.",
+    )
+    scores = compute_request_quality(req, list(VALID_MODES))
+    assert "perplexity-proxy" in scores
+    assert "repetition" in scores
+    assert "coherence" in scores
+    assert scores["perplexity-proxy"] == 0.5
+
+
+def test_request_quality_single_mode():
+    req = _make_request(response_text="hello world test data")
+    scores = compute_request_quality(req, ["repetition"])
+    assert "repetition" in scores
+    assert "perplexity-proxy" not in scores
+
+
+def test_request_quality_no_response_text():
+    req = _make_request(response_text=None)
+    scores = compute_request_quality(req, ["repetition", "coherence"])
+    assert scores["repetition"] == 0.0
+    assert scores["coherence"] == 0.0
+
+
+# --- compute_quality_summary ---
+
+
+def test_quality_summary_basic():
+    all_scores = [
+        {"repetition": 0.1, "coherence": 0.3},
+        {"repetition": 0.2, "coherence": 0.5},
+        {"repetition": 0.3, "coherence": 0.4},
+    ]
+    summary = compute_quality_summary(all_scores, ["repetition", "coherence"])
+    assert "repetition" in summary
+    assert "coherence" in summary
+    assert summary["repetition"]["count"] == 3
+    assert summary["repetition"]["min"] == 0.1
+    assert summary["repetition"]["max"] == 0.3
+
+
+def test_quality_summary_empty():
+    assert compute_quality_summary([], ["repetition"]) == {}
+
+
+def test_quality_summary_single_request():
+    all_scores = [{"repetition": 0.2}]
+    summary = compute_quality_summary(all_scores, ["repetition"])
+    assert summary["repetition"]["stddev"] == 0.0
+    assert summary["repetition"]["count"] == 1
+
+
+# --- VALID_MODES ---
+
+
+def test_valid_modes():
+    assert "perplexity-proxy" in VALID_MODES
+    assert "repetition" in VALID_MODES
+    assert "coherence" in VALID_MODES
+
+
+# --- Edge cases ---
+
+
+def test_repetition_all_same_word():
+    text = "word " * 50
+    rate = score_repetition(text)
+    assert rate > 0.9
+
+
+def test_coherence_identical_sentences():
+    text = "Same sentence here. Same sentence here. Same sentence here."
+    score = score_coherence(text)
+    assert score == 1.0
+
+
+def test_request_quality_unknown_mode_ignored():
+    req = _make_request(response_text="test")
+    scores = compute_request_quality(req, ["unknown_mode"])
+    assert "unknown_mode" not in scores


### PR DESCRIPTION
## Summary

Add `--quality-check <mode>` CLI flag for lightweight output quality assessment to detect quality degradation under high load.

### Three scoring modes:
- **perplexity-proxy**: response/prompt token ratio as adequacy proxy
- **repetition**: bigram+trigram n-gram repetition rate to detect degenerate outputs
- **coherence**: sentence-level Jaccard similarity to detect incoherent responses

### Changes:
- New `src/xpyd_bench/bench/quality.py` module with scoring functions and aggregation
- Per-request `quality_scores` dict in `RequestResult`
- Aggregate `quality_summary` in `BenchmarkResult` (mean/min/max/stddev per mode)
- `--quality-check` CLI flag (repeatable for multiple modes)
- YAML config support (`quality_check`)
- Terminal summary prints quality scores when enabled
- JSON output includes `quality_summary` section
- 22 tests covering all modes, edge cases, and aggregation
- `docs/iterations/current.md` updated

Closes #251