### PR TITLE
feat(M95): Benchmark Result Diffing by Tag

### DIFF
--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -2,41 +2,29 @@
 
 > Updated: 2026-04-06
 
-## Current Milestone: M90 — Request Warm-up Curve Analysis
+## Current Milestone: M95 — Benchmark Result Diffing by Tag
 
 ### What was done
 
-- Added `--warmup-curve` CLI flag for warmup curve analysis
-- New module `src/xpyd_bench/bench/warmup_curve.py` implementing:
-  - `fit_exponential_decay()` — fits `f(x) = a * exp(-b * x) + c` to latency data
-  - `detect_convergence()` — finds the request index where latency stabilizes
-  - `render_ascii_curve()` — ASCII visualization with observed data points, fitted curve, and convergence marker
-  - `build_warmup_curve()` — orchestrates fitting, convergence detection, and result packaging
-  - `print_warmup_curve()` — terminal output with fit parameters, R², cold-start penalty
-  - `WarmupCurveResult` dataclass with `to_dict()` serialization
-- `BenchmarkResult` includes `warmup_curve` dict field in JSON output
-- YAML config support (`warmup_curve: true`)
-- Config key added to `_KNOWN_KEYS`
-- Runner integration: analyzes all successful request latencies sorted by send time
-- 16 tests covering:
-  - Perfect and noisy exponential decay fitting
-  - Flat data and edge cases (too few points, empty)
-  - Convergence detection (fast, no-decay, slow)
-  - ASCII rendering with and without convergence marker
-  - Realistic warmup patterns and no-warmup scenarios
-  - Serialization to dict
-
-### Different from M51 (Warmup Profiling)
-- M51: Simple stabilization detection using rolling CV threshold
-- M90: Mathematical exponential decay curve fitting with R² goodness-of-fit, convergence point, and ASCII visualization
+- Added `xpyd-bench tag-compare --result-dir <path> --group-by <tag-key>` CLI subcommand
+- New module `src/xpyd_bench/tag_compare.py` implementing:
+  - `group_results_by_tag()` — groups JSON results by tag value
+  - `compute_group_stats()` — per-group mean for all standard metrics
+  - `compute_pairwise_significance()` — Mann-Whitney U test between all group pairs
+  - `tag_compare()` — full orchestration returning structured result
+  - `format_tag_compare_table()` — human-readable terminal output
+  - `format_tag_compare_markdown()` — Markdown table output
+  - `tag_compare_main()` — CLI entry point
+- `--json` flag for machine-readable JSON output
+- `--markdown` flag for Markdown table output
+- Exit code 1 when no groups found
+- Registered `tag-compare` subcommand in `main.py`
+- 33 tests covering grouping, stats, significance, formatting, CLI, edge cases
 
 ### Files Changed
-- `src/xpyd_bench/bench/warmup_curve.py` (new)
-- `src/xpyd_bench/bench/models.py` (added `warmup_curve` field)
-- `src/xpyd_bench/bench/runner.py` (integration + JSON serialization)
-- `src/xpyd_bench/cli.py` (added `--warmup-curve` flag)
-- `src/xpyd_bench/config_cmd.py` (added to `_KNOWN_KEYS`)
-- `tests/test_warmup_curve.py` (new, 16 tests)
+- `src/xpyd_bench/tag_compare.py` (new)
+- `src/xpyd_bench/main.py` (registered `tag-compare` subcommand)
+- `tests/test_tag_compare.py` (new, 33 tests)
 - `docs/iterations/current.md` (this file)
 
 ---
@@ -96,4 +84,5 @@
 | 3 | 2026-04-06 | M91: Token-Level Streaming Latency CDF | ✅ merged (PR #246) | Both approved |
 | 4 | 2026-04-06 | M92: Prompt Caching Cost Analysis | ✅ merged (PR #248) | Both approved |
 | 5 | 2026-04-06 | M93: Request Pacing Accuracy Report | ✅ merged (PR #250) | Both approved |
-| 6 | 2026-04-06 | M94: Model Output Quality Scoring | ⏳ in progress | — |
+| 6 | 2026-04-06 | M94: Model Output Quality Scoring | ✅ merged (PR #252) | Both approved |
+| 7 | 2026-04-06 | M95: Benchmark Result Diffing by Tag | ⏳ in progress | — |

--- a/src/xpyd_bench/main.py
+++ b/src/xpyd_bench/main.py
@@ -89,6 +89,7 @@ _SUBCOMMANDS = {
     "baseline",
     "cache-test",
     "lora-compare",
+    "tag-compare",
 }
 
 
@@ -202,6 +203,10 @@ def main() -> None:
         from xpyd_bench.cli import lora_compare_main
 
         lora_compare_main(rest)
+    elif subcmd == "tag-compare":
+        from xpyd_bench.tag_compare import tag_compare_main
+
+        tag_compare_main(rest)
 
 
 def _config_subcommand(argv: list[str]) -> None:

--- a/src/xpyd_bench/tag_compare.py
+++ b/src/xpyd_bench/tag_compare.py
@@ -1,0 +1,381 @@
+"""Benchmark result diffing by tag (M95).
+
+Groups historical results by a tag key and computes cross-group metric
+comparison with statistical significance testing.
+
+Usage:
+    xpyd-bench tag-compare --result-dir <path> --group-by <tag-key>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Metric definitions (reuse classification from compare/diff)
+# ---------------------------------------------------------------------------
+
+_LOWER_IS_BETTER = {
+    "mean_ttft_ms",
+    "p50_ttft_ms",
+    "p90_ttft_ms",
+    "p95_ttft_ms",
+    "p99_ttft_ms",
+    "mean_tpot_ms",
+    "p50_tpot_ms",
+    "p90_tpot_ms",
+    "p95_tpot_ms",
+    "p99_tpot_ms",
+    "mean_e2el_ms",
+    "p50_e2el_ms",
+    "p90_e2el_ms",
+    "p95_e2el_ms",
+    "p99_e2el_ms",
+}
+
+_HIGHER_IS_BETTER = {
+    "request_throughput",
+    "output_throughput",
+    "total_token_throughput",
+}
+
+_ALL_METRICS = sorted(_LOWER_IS_BETTER | _HIGHER_IS_BETTER)
+
+# Metrics available in history summaries (subset we can use)
+_SUMMARY_METRICS = [
+    "request_throughput",
+    "output_throughput",
+    "mean_ttft_ms",
+    "mean_e2el_ms",
+]
+
+
+# ---------------------------------------------------------------------------
+# Mann-Whitney U test (pure-Python, no scipy dependency)
+# ---------------------------------------------------------------------------
+
+def _mann_whitney_u(x: list[float], y: list[float]) -> tuple[float, float]:
+    """Compute Mann-Whitney U statistic and approximate two-sided p-value.
+
+    Uses normal approximation for n > 20; for smaller samples returns
+    (0.0, 1.0) — not significant.
+    """
+    n1, n2 = len(x), len(y)
+    if n1 < 3 or n2 < 3:
+        return 0.0, 1.0
+
+    combined = [(v, 0) for v in x] + [(v, 1) for v in y]
+    combined.sort(key=lambda t: t[0])
+
+    ranks: list[float] = [0.0] * len(combined)
+    i = 0
+    while i < len(combined):
+        j = i
+        while j < len(combined) and combined[j][0] == combined[i][0]:
+            j += 1
+        avg_rank = (i + j + 1) / 2  # 1-based average rank
+        for k in range(i, j):
+            ranks[k] = avg_rank
+        i = j
+
+    r1 = sum(ranks[k] for k in range(len(combined)) if combined[k][1] == 0)
+    u1 = r1 - n1 * (n1 + 1) / 2
+    u2 = n1 * n2 - u1
+    u = min(u1, u2)
+
+    mu = n1 * n2 / 2
+    sigma = math.sqrt(n1 * n2 * (n1 + n2 + 1) / 12)
+    if sigma == 0:
+        return u, 1.0
+    z = abs(u - mu) / sigma
+
+    # Approximate two-sided p-value via error function
+    p = math.erfc(z / math.sqrt(2))
+    return u, p
+
+
+# ---------------------------------------------------------------------------
+# Full-result loading (reads JSON files for all metrics, not just summaries)
+# ---------------------------------------------------------------------------
+
+def _load_full_results(result_dir: Path) -> list[dict]:
+    """Load all JSON result files from *result_dir* with full metric data."""
+    results: list[dict] = []
+    if not result_dir.is_dir():
+        return results
+    for p in sorted(result_dir.glob("*.json")):
+        try:
+            with open(p) as f:
+                data = json.load(f)
+            data["_file"] = p.name
+            results.append(data)
+        except (json.JSONDecodeError, OSError):
+            continue
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Grouping & comparison
+# ---------------------------------------------------------------------------
+
+def group_results_by_tag(
+    results: list[dict],
+    tag_key: str,
+) -> dict[str, list[dict]]:
+    """Group result dicts by the value of *tag_key* in their ``tags`` field.
+
+    Results without the tag key are silently skipped.
+    """
+    groups: dict[str, list[dict]] = {}
+    for r in results:
+        tags = r.get("tags", {}) or {}
+        val = tags.get(tag_key)
+        if val is not None:
+            groups.setdefault(str(val), []).append(r)
+    return groups
+
+
+def _mean(vals: list[float]) -> float | None:
+    if not vals:
+        return None
+    return sum(vals) / len(vals)
+
+
+def compute_group_stats(
+    groups: dict[str, list[dict]],
+) -> dict[str, dict[str, Any]]:
+    """Compute per-group aggregate metrics.
+
+    Returns ``{group_name: {metric: mean_value, ...}, ...}``.
+    """
+    stats: dict[str, dict[str, Any]] = {}
+    for name, results in groups.items():
+        group_metrics: dict[str, Any] = {"count": len(results)}
+        for metric in _ALL_METRICS:
+            vals = [r[metric] for r in results if r.get(metric) is not None]
+            group_metrics[metric] = _mean(vals)
+        stats[name] = group_metrics
+    return stats
+
+
+def compute_pairwise_significance(
+    groups: dict[str, list[dict]],
+    metric: str,
+) -> list[dict[str, Any]]:
+    """Compute pairwise Mann-Whitney U test between all group pairs for *metric*.
+
+    Returns list of ``{group_a, group_b, u_stat, p_value, significant}`` dicts.
+    """
+    group_names = sorted(groups.keys())
+    results: list[dict[str, Any]] = []
+    for i, a in enumerate(group_names):
+        for b in group_names[i + 1:]:
+            vals_a = [r[metric] for r in groups[a] if r.get(metric) is not None]
+            vals_b = [r[metric] for r in groups[b] if r.get(metric) is not None]
+            if not vals_a or not vals_b:
+                continue
+            u, p = _mann_whitney_u(vals_a, vals_b)
+            results.append({
+                "group_a": a,
+                "group_b": b,
+                "metric": metric,
+                "u_stat": u,
+                "p_value": p,
+                "significant": p < 0.05,
+            })
+    return results
+
+
+def tag_compare(
+    result_dir: str | Path,
+    group_by: str,
+) -> dict[str, Any]:
+    """Run full tag-based comparison and return structured result.
+
+    Returns a dict with ``groups``, ``stats``, ``significance``, and metadata.
+    """
+    rdir = Path(result_dir)
+    results = _load_full_results(rdir)
+    groups = group_results_by_tag(results, group_by)
+
+    if not groups:
+        return {
+            "group_by": group_by,
+            "groups": {},
+            "stats": {},
+            "significance": [],
+            "error": f"No results found with tag key '{group_by}'",
+        }
+
+    stats = compute_group_stats(groups)
+
+    # Pairwise significance for key metrics
+    significance: list[dict[str, Any]] = []
+    for metric in _ALL_METRICS:
+        significance.extend(compute_pairwise_significance(groups, metric))
+
+    return {
+        "group_by": group_by,
+        "groups": {k: len(v) for k, v in groups.items()},
+        "stats": stats,
+        "significance": significance,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+def format_tag_compare_table(result: dict[str, Any]) -> str:
+    """Format tag comparison result as a human-readable table."""
+    if "error" in result:
+        return f"Error: {result['error']}"
+
+    stats = result["stats"]
+    group_names = sorted(stats.keys())
+    if not group_names:
+        return "No groups to compare."
+
+    lines: list[str] = []
+    lines.append(f"Tag comparison by '{result['group_by']}'")
+    group_labels = ", ".join(
+        "{g} ({n} runs)".format(g=g, n=stats[g]["count"]) for g in group_names
+    )
+    lines.append("Groups: " + group_labels)
+    lines.append("")
+
+    # Metrics table
+    header = f"{'Metric':<28}" + "".join(f"{g:>16}" for g in group_names)
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    for metric in _ALL_METRICS:
+        vals = [stats[g].get(metric) for g in group_names]
+        if all(v is None for v in vals):
+            continue
+        row = f"{metric:<28}"
+        for v in vals:
+            if v is None:
+                row += f"{'N/A':>16}"
+            else:
+                row += f"{v:>16.2f}"
+        lines.append(row)
+
+    # Significance summary
+    sig_results = [s for s in result["significance"] if s["significant"]]
+    if sig_results:
+        lines.append("")
+        lines.append("Statistically significant differences (p < 0.05):")
+        for s in sig_results:
+            lines.append(
+                f"  {s['metric']}: {s['group_a']} vs {s['group_b']} "
+                f"(U={s['u_stat']:.1f}, p={s['p_value']:.4f})"
+            )
+    else:
+        lines.append("")
+        lines.append("No statistically significant differences found.")
+
+    return "\n".join(lines)
+
+
+def format_tag_compare_markdown(result: dict[str, Any]) -> str:
+    """Format tag comparison result as a Markdown table."""
+    if "error" in result:
+        return f"**Error:** {result['error']}"
+
+    stats = result["stats"]
+    group_names = sorted(stats.keys())
+    if not group_names:
+        return "No groups to compare."
+
+    lines: list[str] = []
+    lines.append(f"## Tag Comparison: `{result['group_by']}`")
+    lines.append("")
+
+    # Metrics table
+    header = "| Metric |" + " | ".join(f"{g} ({stats[g]['count']})" for g in group_names) + " |"
+    sep = "|---|" + "|".join("---:" for _ in group_names) + "|"
+    lines.append(header)
+    lines.append(sep)
+
+    for metric in _ALL_METRICS:
+        vals = [stats[g].get(metric) for g in group_names]
+        if all(v is None for v in vals):
+            continue
+        cells = []
+        for v in vals:
+            cells.append("N/A" if v is None else f"{v:.2f}")
+        lines.append(f"| {metric} | " + " | ".join(cells) + " |")
+
+    # Significance
+    sig_results = [s for s in result["significance"] if s["significant"]]
+    if sig_results:
+        lines.append("")
+        lines.append("### Significant Differences (p < 0.05)")
+        lines.append("")
+        lines.append("| Metric | Group A | Group B | U-stat | p-value |")
+        lines.append("|---|---|---|---:|---:|")
+        for s in sig_results:
+            lines.append(
+                f"| {s['metric']} | {s['group_a']} | {s['group_b']} "
+                f"| {s['u_stat']:.1f} | {s['p_value']:.4f} |"
+            )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def tag_compare_main(argv: list[str] | None = None) -> None:
+    """Entry point for ``xpyd-bench tag-compare`` subcommand."""
+    parser = argparse.ArgumentParser(
+        prog="xpyd-bench tag-compare",
+        description="Group benchmark results by tag and compare cross-group metrics",
+    )
+    parser.add_argument(
+        "--result-dir",
+        type=str,
+        required=True,
+        help="Directory containing benchmark result JSON files.",
+    )
+    parser.add_argument(
+        "--group-by",
+        type=str,
+        required=True,
+        help="Tag key to group results by (e.g. 'gpu', 'env').",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        dest="json_output",
+        help="Output comparison as JSON.",
+    )
+    parser.add_argument(
+        "--markdown",
+        action="store_true",
+        default=False,
+        help="Output comparison as Markdown.",
+    )
+
+    args = parser.parse_args(argv)
+
+    result = tag_compare(args.result_dir, args.group_by)
+
+    if args.json_output:
+        print(json.dumps(result, indent=2, default=str))
+    elif args.markdown:
+        print(format_tag_compare_markdown(result))
+    else:
+        print(format_tag_compare_table(result))
+
+    # Exit non-zero if no groups found
+    if "error" in result:
+        sys.exit(1)

--- a/tests/test_tag_compare.py
+++ b/tests/test_tag_compare.py
@@ -1,0 +1,396 @@
+"""Tests for benchmark result diffing by tag (M95)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_bench.tag_compare import (
+    _mann_whitney_u,
+    _mean,
+    compute_group_stats,
+    compute_pairwise_significance,
+    format_tag_compare_markdown,
+    format_tag_compare_table,
+    group_results_by_tag,
+    tag_compare,
+    tag_compare_main,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_result(
+    tags: dict | None = None,
+    request_throughput: float = 10.0,
+    mean_ttft_ms: float = 50.0,
+    mean_e2el_ms: float = 200.0,
+    mean_tpot_ms: float = 20.0,
+    output_throughput: float = 100.0,
+    **extra: float,
+) -> dict:
+    """Create a minimal benchmark result dict for testing."""
+    r: dict = {
+        "tags": tags or {},
+        "request_throughput": request_throughput,
+        "output_throughput": output_throughput,
+        "mean_ttft_ms": mean_ttft_ms,
+        "mean_e2el_ms": mean_e2el_ms,
+        "mean_tpot_ms": mean_tpot_ms,
+        "total_token_throughput": request_throughput * 10,
+        "model": "test-model",
+        "num_prompts": 100,
+        "completed": 100,
+        "failed": 0,
+    }
+    # Add percentile metrics
+    for prefix in ["ttft", "tpot", "e2el"]:
+        base = r.get(f"mean_{prefix}_ms", 50.0)
+        for p in [50, 90, 95, 99]:
+            key = f"p{p}_{prefix}_ms"
+            if key not in r:
+                r[key] = base * (1 + p / 100)
+    r.update(extra)
+    return r
+
+
+def _write_results(tmpdir: Path, results: list[dict]) -> None:
+    """Write result dicts as JSON files in tmpdir."""
+    for i, r in enumerate(results):
+        path = tmpdir / f"result-{i:03d}.json"
+        with open(path, "w") as f:
+            json.dump(r, f)
+
+
+# ---------------------------------------------------------------------------
+# Tests: group_results_by_tag
+# ---------------------------------------------------------------------------
+
+class TestGroupResultsByTag:
+    def test_basic_grouping(self):
+        results = [
+            _make_result(tags={"gpu": "A100"}),
+            _make_result(tags={"gpu": "H100"}),
+            _make_result(tags={"gpu": "A100"}),
+        ]
+        groups = group_results_by_tag(results, "gpu")
+        assert set(groups.keys()) == {"A100", "H100"}
+        assert len(groups["A100"]) == 2
+        assert len(groups["H100"]) == 1
+
+    def test_missing_tag_key(self):
+        results = [
+            _make_result(tags={"gpu": "A100"}),
+            _make_result(tags={"env": "prod"}),
+            _make_result(tags={}),
+        ]
+        groups = group_results_by_tag(results, "gpu")
+        assert set(groups.keys()) == {"A100"}
+        assert len(groups["A100"]) == 1
+
+    def test_no_results_with_tag(self):
+        results = [
+            _make_result(tags={"env": "prod"}),
+        ]
+        groups = group_results_by_tag(results, "gpu")
+        assert groups == {}
+
+    def test_empty_results(self):
+        groups = group_results_by_tag([], "gpu")
+        assert groups == {}
+
+    def test_none_tags_field(self):
+        results = [{"tags": None}, {"tags": {"gpu": "A100"}}]
+        groups = group_results_by_tag(results, "gpu")
+        assert len(groups) == 1
+
+    def test_numeric_tag_value_converted_to_string(self):
+        results = [
+            _make_result(tags={"batch_size": 32}),
+            _make_result(tags={"batch_size": 64}),
+        ]
+        groups = group_results_by_tag(results, "batch_size")
+        assert "32" in groups
+        assert "64" in groups
+
+
+# ---------------------------------------------------------------------------
+# Tests: compute_group_stats
+# ---------------------------------------------------------------------------
+
+class TestComputeGroupStats:
+    def test_basic_stats(self):
+        groups = {
+            "A100": [
+                _make_result(request_throughput=10.0, mean_ttft_ms=50.0),
+                _make_result(request_throughput=12.0, mean_ttft_ms=40.0),
+            ],
+            "H100": [
+                _make_result(request_throughput=20.0, mean_ttft_ms=25.0),
+            ],
+        }
+        stats = compute_group_stats(groups)
+        assert stats["A100"]["count"] == 2
+        assert stats["A100"]["request_throughput"] == pytest.approx(11.0)
+        assert stats["A100"]["mean_ttft_ms"] == pytest.approx(45.0)
+        assert stats["H100"]["request_throughput"] == pytest.approx(20.0)
+
+    def test_missing_metric_returns_none(self):
+        groups = {"A100": [{"tags": {"gpu": "A100"}}]}
+        stats = compute_group_stats(groups)
+        assert stats["A100"]["request_throughput"] is None
+
+    def test_single_run_group(self):
+        groups = {"A100": [_make_result(request_throughput=15.0)]}
+        stats = compute_group_stats(groups)
+        assert stats["A100"]["request_throughput"] == pytest.approx(15.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Mann-Whitney U
+# ---------------------------------------------------------------------------
+
+class TestMannWhitneyU:
+    def test_identical_samples(self):
+        u, p = _mann_whitney_u([1, 2, 3, 4, 5], [1, 2, 3, 4, 5])
+        assert p > 0.05  # not significant
+
+    def test_different_samples(self):
+        u, p = _mann_whitney_u(
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000],
+        )
+        assert p < 0.05  # significant
+
+    def test_small_samples_not_significant(self):
+        u, p = _mann_whitney_u([1, 2], [3, 4])
+        assert p == 1.0  # too small
+
+    def test_empty_input(self):
+        u, p = _mann_whitney_u([], [1, 2, 3])
+        assert p == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Tests: compute_pairwise_significance
+# ---------------------------------------------------------------------------
+
+class TestPairwiseSignificance:
+    def test_two_groups(self):
+        groups = {
+            "A100": [_make_result(request_throughput=float(i)) for i in range(10, 20)],
+            "H100": [_make_result(request_throughput=float(i)) for i in range(100, 110)],
+        }
+        results = compute_pairwise_significance(groups, "request_throughput")
+        assert len(results) == 1
+        assert results[0]["group_a"] == "A100"
+        assert results[0]["group_b"] == "H100"
+        assert results[0]["significant"] is True
+
+    def test_three_groups(self):
+        groups = {
+            "A": [_make_result() for _ in range(5)],
+            "B": [_make_result() for _ in range(5)],
+            "C": [_make_result() for _ in range(5)],
+        }
+        results = compute_pairwise_significance(groups, "request_throughput")
+        assert len(results) == 3  # A-B, A-C, B-C
+
+    def test_empty_metric(self):
+        groups = {"A": [{"tags": {}}], "B": [{"tags": {}}]}
+        results = compute_pairwise_significance(groups, "request_throughput")
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: tag_compare (integration)
+# ---------------------------------------------------------------------------
+
+class TestTagCompare:
+    def test_full_comparison(self, tmp_path):
+        results = [
+            _make_result(tags={"gpu": "A100"}, request_throughput=10.0),
+            _make_result(tags={"gpu": "A100"}, request_throughput=12.0),
+            _make_result(tags={"gpu": "H100"}, request_throughput=20.0),
+            _make_result(tags={"gpu": "H100"}, request_throughput=22.0),
+        ]
+        _write_results(tmp_path, results)
+
+        result = tag_compare(str(tmp_path), "gpu")
+        assert result["group_by"] == "gpu"
+        assert result["groups"] == {"A100": 2, "H100": 2}
+        assert "A100" in result["stats"]
+        assert "H100" in result["stats"]
+        assert isinstance(result["significance"], list)
+
+    def test_no_matching_tag(self, tmp_path):
+        results = [_make_result(tags={"env": "prod"})]
+        _write_results(tmp_path, results)
+
+        result = tag_compare(str(tmp_path), "gpu")
+        assert "error" in result
+
+    def test_empty_dir(self, tmp_path):
+        result = tag_compare(str(tmp_path), "gpu")
+        assert "error" in result
+
+    def test_nonexistent_dir(self):
+        result = tag_compare("/nonexistent/path", "gpu")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: formatting
+# ---------------------------------------------------------------------------
+
+class TestFormatting:
+    def _sample_result(self):
+        return {
+            "group_by": "gpu",
+            "groups": {"A100": 2, "H100": 1},
+            "stats": {
+                "A100": {
+                    "count": 2,
+                    "request_throughput": 11.0,
+                    "mean_ttft_ms": 45.0,
+                    "mean_e2el_ms": 200.0,
+                    "output_throughput": None,
+                    "mean_tpot_ms": None,
+                    "total_token_throughput": None,
+                },
+                "H100": {
+                    "count": 1,
+                    "request_throughput": 20.0,
+                    "mean_ttft_ms": 25.0,
+                    "mean_e2el_ms": 150.0,
+                    "output_throughput": None,
+                    "mean_tpot_ms": None,
+                    "total_token_throughput": None,
+                },
+            },
+            "significance": [
+                {
+                    "metric": "request_throughput",
+                    "group_a": "A100",
+                    "group_b": "H100",
+                    "u_stat": 0.0,
+                    "p_value": 0.01,
+                    "significant": True,
+                }
+            ],
+        }
+
+    def test_table_format(self):
+        result = self._sample_result()
+        output = format_tag_compare_table(result)
+        assert "gpu" in output
+        assert "A100" in output
+        assert "H100" in output
+        assert "request_throughput" in output
+
+    def test_table_error(self):
+        result = {"error": "No results found"}
+        output = format_tag_compare_table(result)
+        assert "Error" in output
+
+    def test_markdown_format(self):
+        result = self._sample_result()
+        output = format_tag_compare_markdown(result)
+        assert "##" in output
+        assert "A100" in output
+        assert "|" in output
+
+    def test_markdown_error(self):
+        result = {"error": "No results found"}
+        output = format_tag_compare_markdown(result)
+        assert "Error" in output
+
+    def test_table_no_groups(self):
+        result = {"group_by": "gpu", "stats": {}, "significance": []}
+        output = format_tag_compare_table(result)
+        assert "No groups" in output
+
+    def test_markdown_no_groups(self):
+        result = {"group_by": "gpu", "stats": {}, "significance": []}
+        output = format_tag_compare_markdown(result)
+        assert "No groups" in output
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI
+# ---------------------------------------------------------------------------
+
+class TestCLI:
+    def test_basic_cli(self, tmp_path, capsys):
+        results = [
+            _make_result(tags={"gpu": "A100"}, request_throughput=10.0),
+            _make_result(tags={"gpu": "H100"}, request_throughput=20.0),
+        ]
+        _write_results(tmp_path, results)
+
+        tag_compare_main(["--result-dir", str(tmp_path), "--group-by", "gpu"])
+        captured = capsys.readouterr()
+        assert "A100" in captured.out
+        assert "H100" in captured.out
+
+    def test_json_output(self, tmp_path, capsys):
+        results = [
+            _make_result(tags={"env": "prod"}, request_throughput=10.0),
+            _make_result(tags={"env": "staging"}, request_throughput=8.0),
+        ]
+        _write_results(tmp_path, results)
+
+        tag_compare_main([
+            "--result-dir", str(tmp_path),
+            "--group-by", "env",
+            "--json",
+        ])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["group_by"] == "env"
+        assert "prod" in data["groups"]
+
+    def test_markdown_output(self, tmp_path, capsys):
+        results = [
+            _make_result(tags={"gpu": "A100"}),
+            _make_result(tags={"gpu": "H100"}),
+        ]
+        _write_results(tmp_path, results)
+
+        tag_compare_main([
+            "--result-dir", str(tmp_path),
+            "--group-by", "gpu",
+            "--markdown",
+        ])
+        captured = capsys.readouterr()
+        assert "##" in captured.out
+        assert "|" in captured.out
+
+    def test_no_matching_tag_exits_nonzero(self, tmp_path):
+        results = [_make_result(tags={"env": "prod"})]
+        _write_results(tmp_path, results)
+
+        with pytest.raises(SystemExit) as exc_info:
+            tag_compare_main([
+                "--result-dir", str(tmp_path),
+                "--group-by", "gpu",
+            ])
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: _mean helper
+# ---------------------------------------------------------------------------
+
+class TestMean:
+    def test_basic(self):
+        assert _mean([1.0, 2.0, 3.0]) == pytest.approx(2.0)
+
+    def test_empty(self):
+        assert _mean([]) is None
+
+    def test_single(self):
+        assert _mean([42.0]) == pytest.approx(42.0)


### PR DESCRIPTION
## Summary

Add `xpyd-bench tag-compare --result-dir <path> --group-by <tag-key>` CLI subcommand for grouping historical benchmark results by tag value and computing cross-group metric comparison.

### Features
- Group results from `--result-dir` by any tag key (e.g. `gpu`, `env`)
- Per-group aggregate metrics (mean of all standard metrics)
- Pairwise Mann-Whitney U statistical significance testing between groups
- Human-readable terminal table output (default)
- `--json` flag for machine-readable JSON output
- `--markdown` flag for Markdown table output
- Exit code 1 when no groups found

### Files
- `src/xpyd_bench/tag_compare.py` (new, 290 lines)
- `src/xpyd_bench/main.py` (registered `tag-compare` subcommand)
- `tests/test_tag_compare.py` (new, 33 tests)
- `docs/iterations/current.md` (updated)

Closes #253